### PR TITLE
feat(telegram): implement sign up flow

### DIFF
--- a/telegram/auth.go
+++ b/telegram/auth.go
@@ -6,12 +6,32 @@ import (
 	"github.com/gotd/td/tg"
 )
 
+// SignUpRequired means that log in failed because corresponding account
+// does not exist, so sign up is required.
+type SignUpRequired struct {
+	TermsOfService tg.HelpTermsOfService
+}
+
+// Is returns true if err is SignUpRequired.
+func (s *SignUpRequired) Is(err error) bool {
+	_, ok := err.(*SignUpRequired)
+	return ok
+}
+
+func (s *SignUpRequired) Error() string {
+	return "account with provided number does not exist (sign up required)"
+}
+
 // checkAuthResult checks that a is *tg.AuthAuthorization.
 func (c *Client) checkAuthResult(a tg.AuthAuthorizationClass) error {
-	switch a.(type) {
+	switch v := a.(type) {
 	case *tg.AuthAuthorization:
 		// Ok.
 		return nil
+	case *tg.AuthAuthorizationSignUpRequired:
+		return &SignUpRequired{
+			TermsOfService: v.TermsOfService,
+		}
 	default:
 		return xerrors.Errorf("got unexpected response %T", a)
 	}

--- a/telegram/auth_user.go
+++ b/telegram/auth_user.go
@@ -115,3 +115,37 @@ func (c *Client) AuthSignIn(ctx context.Context, phone, code, codeHash string) e
 
 	return nil
 }
+
+// AuthAcceptTOS accepts version of Terms Of Service.
+func (c *Client) AuthAcceptTOS(ctx context.Context, id tg.DataJSON) error {
+	_, err := c.tg.HelpAcceptTermsOfService(ctx, id)
+	return err
+}
+
+// SignUp wraps parameters for AuthSignUp.
+type SignUp struct {
+	PhoneNumber   string
+	PhoneCodeHash string
+	FirstName     string
+	LastName      string
+}
+
+// AuthSignUp registers a validated phone number in the system.
+//
+// To obtain codeHash, use AuthSendCode.
+// Use AuthFlow helper to handle authentication flow.
+func (c *Client) AuthSignUp(ctx context.Context, s SignUp) error {
+	auth, err := c.tg.AuthSignUp(ctx, &tg.AuthSignUpRequest{
+		LastName:      s.LastName,
+		PhoneCodeHash: s.PhoneCodeHash,
+		PhoneNumber:   s.PhoneNumber,
+		FirstName:     s.FirstName,
+	})
+	if err != nil {
+		return xerrors.Errorf("request: %w", err)
+	}
+	if err := c.checkAuthResult(auth); err != nil {
+		return xerrors.Errorf("check: %w", err)
+	}
+	return nil
+}


### PR DESCRIPTION
Handle sign up and term of service in AuthFlow.
This is required for end-to-end tests.