### PR TITLE
fix(telegram): don't client.AuthAcceptTOS

### DIFF
--- a/telegram/auth_flow.go
+++ b/telegram/auth_flow.go
@@ -65,9 +65,6 @@ func (f AuthFlow) Run(ctx context.Context, client AuthFlowClient) error {
 		if err := f.Auth.AcceptTermsOfService(ctx, signUpRequired.TermsOfService); err != nil {
 			return xerrors.Errorf("confirm TOS: %w", err)
 		}
-		if err := client.AuthAcceptTOS(ctx, signUpRequired.TermsOfService.ID); err != nil {
-			return xerrors.Errorf("accept TOS: %w", err)
-		}
 		info, err := f.Auth.SignUp(ctx)
 		if err != nil {
 			return xerrors.Errorf("sign up info not provided: %w", err)


### PR DESCRIPTION
This method seems to be to accept TOS updates for existing users. It looks like by signing up you automatically accept the TOS.
> By signing up for Telegram, you agree not to: ...

This method is not in the [list of methods](https://core.telegram.org/api/auth#we-are-authorized) available to unauthorized users.