### PR TITLE
chore(mtproto): slightly rework ping-pong logic

### DIFF
--- a/internal/tdsync/reset_ready_test.go
+++ b/internal/tdsync/reset_ready_test.go
@@ -101,6 +101,7 @@ func TestResetReady(t *testing.T) {
 				<-wait
 			}()
 
+			wg.Wait()
 			r.Reset()
 			checkNoSignal(t, r)
 		})

--- a/mtproto/conn.go
+++ b/mtproto/conn.go
@@ -76,7 +76,7 @@ type Conn struct {
 
 	// callbacks for ping results.
 	// Key is ping id.
-	ping    map[int64]func()
+	ping    map[int64]chan struct{}
 	pingMux sync.Mutex
 
 	readConcurrency int
@@ -99,7 +99,7 @@ func New(addr string, opt Options) *Conn {
 		rand:         opt.Random,
 		cipher:       opt.Cipher,
 		log:          opt.Logger,
-		ping:         map[int64]func(){},
+		ping:         map[int64]chan struct{}{},
 		messageID:    opt.MessageID,
 		messageIDBuf: proto.NewMessageIDBuf(100),
 

--- a/mtproto/ping.go
+++ b/mtproto/ping.go
@@ -45,10 +45,12 @@ func (c *Conn) handlePong(b *bin.Buffer) error {
 
 	c.pingMux.Lock()
 	ch, ok := c.ping[pong.PingID]
-	c.pingMux.Unlock()
 	if ok {
 		close(ch)
+		delete(c.ping, pong.PingID)
 	}
+	c.pingMux.Unlock()
+
 	return nil
 }
 


### PR DESCRIPTION
In the current implementation pong callback was setting after ping request.
This may cause a problem when:
1. Client sent ping request
2. Server responded with pong
3. Client received pong, but callback for that pong not found
4. Client sets pong callback, but it will never be called because we already received pong before
5. Client disconnects because pong was 'missed'.

This PR should fix that.