### PR TITLE
refactor: ensure groups naming consistency

### DIFF
--- a/internal/exchange/client_flow_test.go
+++ b/internal/exchange/client_flow_test.go
@@ -29,18 +29,18 @@ func TestExchangeTimeout(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	grp := tdsync.NewCancellableGroup(ctx)
-	grp.Go(func(groupCtx context.Context) error {
+	g := tdsync.NewCancellableGroup(ctx)
+	g.Go(func(ctx context.Context) error {
 		_, err := NewExchanger(client).
 			WithLogger(log.Named("client")).
 			WithRand(reader).
 			WithTimeout(1 * time.Second).
 			Client([]*rsa.PublicKey{&key.PublicKey}).
-			Run(groupCtx)
+			Run(ctx)
 		return err
 	})
 
-	err = grp.Wait()
+	err = g.Wait()
 	if err, ok := err.(net.Error); !ok || !err.Timeout() {
 		require.NoError(t, err)
 	}

--- a/internal/exchange/flow_test.go
+++ b/internal/exchange/flow_test.go
@@ -31,25 +31,25 @@ func TestExchange(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
 	defer cancel()
 
-	grp := tdsync.NewCancellableGroup(ctx)
-	grp.Go(func(groupCtx context.Context) error {
+	g := tdsync.NewCancellableGroup(ctx)
+	g.Go(func(ctx context.Context) error {
 		_, err := NewExchanger(client).
 			WithLogger(log.Named("client")).
 			WithRand(reader).
 			Client([]*rsa.PublicKey{&key.PublicKey}).
-			Run(groupCtx)
+			Run(ctx)
 		return err
 	})
-	grp.Go(func(groupCtx context.Context) error {
+	g.Go(func(ctx context.Context) error {
 		_, err := NewExchanger(server).
 			WithLogger(log.Named("server")).
 			WithRand(reader).
 			Server(key).
-			Run(groupCtx)
+			Run(ctx)
 		return err
 	})
 
-	require.NoError(t, grp.Wait())
+	require.NoError(t, g.Wait())
 }
 
 func TestExchangeCorpus(t *testing.T) {

--- a/internal/tdsync/cancel_group_test.go
+++ b/internal/tdsync/cancel_group_test.go
@@ -7,15 +7,15 @@ import (
 )
 
 func TestCancellableGroup(t *testing.T) {
-	grp := NewCancellableGroup(context.Background())
+	g := NewCancellableGroup(context.Background())
 
-	grp.Go(func(groupCtx context.Context) error {
-		<-groupCtx.Done()
-		return groupCtx.Err()
+	g.Go(func(ctx context.Context) error {
+		<-ctx.Done()
+		return ctx.Err()
 	})
 
-	grp.Cancel()
-	if err := grp.Wait(); !errors.Is(err, context.Canceled) {
+	g.Cancel()
+	if err := g.Wait(); !errors.Is(err, context.Canceled) {
 		t.Error(err)
 	}
 }

--- a/telegram/client_mtproxy_test.go
+++ b/telegram/client_mtproxy_test.go
@@ -84,14 +84,14 @@ func testMTProxy(secretType string, m mtg, storage session.Storage) func(t *test
 			}
 		})
 
-		grp := tdsync.NewCancellableGroup(ctx)
+		g := tdsync.NewCancellableGroup(ctx)
 		ready := tdsync.NewReady()
-		grp.Go(func(groupCtx context.Context) error {
-			_ = m.run(groupCtx, hex.EncodeToString(secret), w, w, ready)
+		g.Go(func(ctx context.Context) error {
+			_ = m.run(ctx, hex.EncodeToString(secret), w, w, ready)
 			return nil
 		})
-		grp.Go(func(groupCtx context.Context) error {
-			defer grp.Cancel()
+		g.Go(func(ctx context.Context) error {
+			defer g.Cancel()
 			<-ready.Ready()
 
 			trp, err := transport.MTProxy(nil, m.addr, secret)
@@ -113,7 +113,7 @@ func testMTProxy(secretType string, m mtg, storage session.Storage) func(t *test
 			})
 		})
 
-		a.NoError(grp.Wait())
+		a.NoError(g.Wait())
 	}
 }
 


### PR DESCRIPTION
* Use `g` for group variable name
* Use fooMux for mutex names
* Use `ctx` for context parameter name