### PR TITLE
fix(gen): bare vectors don’t imply bare encoders

### DIFF
--- a/internal/gen/_template/main.tmpl
+++ b/internal/gen/_template/main.tmpl
@@ -116,8 +116,8 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) EncodeBare({{ $s.BufArg }} *bin.Buffer) 
             return fmt.Errorf("unable to encode {{ $s.RawType }}: field {{ $f.RawName }} element with index %d is nil", idx)
             }
         {{- end}}
-        if err := v.Encode{{ if $f.BareVector }}Bare{{ end }}({{ $s.BufArg }}); err != nil {
-            return fmt.Errorf("unable to encode{{ if $f.BareVector }} bare{{ end }} {{ $s.RawType }}: field {{ $f.RawName }} element with index %d: %w", idx, err)
+        if err := v.Encode{{ if and $f.BareEncoder $f.BareVector }}Bare{{ end }}({{ $s.BufArg }}); err != nil {
+            return fmt.Errorf("unable to encode{{ if and $f.BareEncoder $f.BareVector }} bare{{ end }} {{ $s.RawType }}: field {{ $f.RawName }} element with index %d: %w", idx, err)
         }
     {{- else }}
         {{ $s.BufArg }}.Put{{ $f.Func }}(v)
@@ -280,8 +280,8 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) DecodeBare({{ $s.BufArg }} *bin.Buffer) 
                 }
             {{- else if $f.Encoder }}
                 var value {{ $f.Type }}
-                if err := value.Decode{{ if $f.BareVector }}Bare{{ end }}({{ $s.BufArg }}); err != nil {
-                    return fmt.Errorf("unable to decode{{ if $f.BareVector }} bare{{ end }} {{ $s.RawType }}: field {{ $f.RawName }}: %w", err)
+                if err := value.Decode{{ if and $f.BareEncoder $f.BareVector }}Bare{{ end }}({{ $s.BufArg }}); err != nil {
+                    return fmt.Errorf("unable to decode{{ if and $f.BareEncoder $f.BareVector }} bare{{ end }} {{ $s.RawType }}: field {{ $f.RawName }}: %w", err)
                 }
             {{- else}}
                 value, err := {{ $s.BufArg }}.{{ $f.Func }}()

--- a/internal/gen/example/tl_send_multiple_sms_gen.go
+++ b/internal/gen/example/tl_send_multiple_sms_gen.go
@@ -114,8 +114,8 @@ func (s *SendMultipleSMSRequest) EncodeBare(b *bin.Buffer) error {
 	}
 	b.PutInt(len(s.Messages))
 	for idx, v := range s.Messages {
-		if err := v.EncodeBare(b); err != nil {
-			return fmt.Errorf("unable to encode bare sendMultipleSMS#df18e5ca: field messages element with index %d: %w", idx, err)
+		if err := v.Encode(b); err != nil {
+			return fmt.Errorf("unable to encode sendMultipleSMS#df18e5ca: field messages element with index %d: %w", idx, err)
 		}
 	}
 	return nil
@@ -149,8 +149,8 @@ func (s *SendMultipleSMSRequest) DecodeBare(b *bin.Buffer) error {
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SMS
-			if err := value.DecodeBare(b); err != nil {
-				return fmt.Errorf("unable to decode bare sendMultipleSMS#df18e5ca: field messages: %w", err)
+			if err := value.Decode(b); err != nil {
+				return fmt.Errorf("unable to decode sendMultipleSMS#df18e5ca: field messages: %w", err)
 			}
 			s.Messages = append(s.Messages, value)
 		}

--- a/internal/gen/make_field.go
+++ b/internal/gen/make_field.go
@@ -37,6 +37,8 @@ type fieldDef struct {
 	Slice bool
 	// DoubleSlice denotes whether double slicing should be used, e.g. [][]bytes.
 	DoubleSlice bool
+	// BareEncoder denotes whether field type should use bare encoder.
+	BareEncoder bool
 	// Interface is name of interface type if field type is constructor.
 	Interface string
 	// InterfaceFunc is encoding func postfix if Interface is set.
@@ -163,6 +165,8 @@ func (g *Generator) makeField(param tl.Parameter, annotations []tl.Annotation) (
 		f.Slice = true
 	default:
 		f.Encoder = true
+		f.BareEncoder = f.BareVector
+
 		if param.Flags {
 			f.Type = flagsType
 			break
@@ -188,6 +192,9 @@ func (g *Generator) makeField(param tl.Parameter, annotations []tl.Annotation) (
 				return fieldDef{}, xerrors.Errorf("classes[%s] not found", baseType)
 			}
 			f.Type = t.Name
+			if !baseType.Percent && t.Singular && !param.Type.GenericRef {
+				f.BareEncoder = false
+			}
 			if !t.Singular && !param.Type.GenericRef {
 				f.Interface = t.Name
 				f.InterfaceFunc = t.Func

--- a/tg/tl_help_config_simple_gen.go
+++ b/tg/tl_help_config_simple_gen.go
@@ -138,8 +138,8 @@ func (c *HelpConfigSimple) EncodeBare(b *bin.Buffer) error {
 	b.PutInt(c.Expires)
 	b.PutInt(len(c.Rules))
 	for idx, v := range c.Rules {
-		if err := v.EncodeBare(b); err != nil {
-			return fmt.Errorf("unable to encode bare help.configSimple#5a592a6c: field rules element with index %d: %w", idx, err)
+		if err := v.Encode(b); err != nil {
+			return fmt.Errorf("unable to encode help.configSimple#5a592a6c: field rules element with index %d: %w", idx, err)
 		}
 	}
 	return nil
@@ -197,8 +197,8 @@ func (c *HelpConfigSimple) DecodeBare(b *bin.Buffer) error {
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value AccessPointRule
-			if err := value.DecodeBare(b); err != nil {
-				return fmt.Errorf("unable to decode bare help.configSimple#5a592a6c: field rules: %w", err)
+			if err := value.Decode(b); err != nil {
+				return fmt.Errorf("unable to decode help.configSimple#5a592a6c: field rules: %w", err)
 			}
 			c.Rules = append(c.Rules, value)
 		}


### PR DESCRIPTION
This PR fixes an edge case where _bare vectors of singular types_ (classes with one constructor) were decoded as _bare vectors of __bare__ types_.
