### PR TITLE
fix(entity): fix MentionName entity formatter

### DIFF
--- a/telegram/message/entity/formatter.go
+++ b/telegram/message/entity/formatter.go
@@ -86,10 +86,10 @@ func TextURL(url string) Formatter {
 }
 
 // MentionName formats message as MentionName message entity.
-// See https://core.telegram.org/constructor/messageEntityMentionName.
-func MentionName(userID int) Formatter {
+// See https://core.telegram.org/constructor/inputMessageEntityMentionName.
+func MentionName(userID tg.InputUserClass) Formatter {
 	return func(offset, limit int) tg.MessageEntityClass {
-		return &tg.MessageEntityMentionName{Offset: offset, Length: limit, UserID: userID}
+		return &tg.InputMessageEntityMentionName{Offset: offset, Length: limit, UserID: userID}
 	}
 }
 

--- a/telegram/message/entity/html_test.go
+++ b/telegram/message/entity/html_test.go
@@ -40,7 +40,9 @@ func TestHTML(t *testing.T) {
 		{`<a href="http://www.example.com/">inline URL</a>`, "inline URL",
 			getEnities(TextURL("http://www.example.com/"))},
 		{`<a href="tg://user?id=123456789">inline mention of a user</a>`, "inline mention of a user",
-			getEnities(MentionName(123456789))},
+			getEnities(MentionName(&tg.InputUser{
+				UserID: 123456789,
+			}))},
 		{`<pre><code class="language-python">python code</code></pre>`, "python code",
 			getEnities(Pre("python"), Code())},
 		{"<b>&lt;</b>", "<", getEnities(Bold())},
@@ -50,7 +52,7 @@ func TestHTML(t *testing.T) {
 		t.Run(strings.Title(test.msg), func(t *testing.T) {
 			a := require.New(t)
 			b := Builder{}
-			a.NoError(HTML(strings.NewReader(test.html), &b))
+			a.NoError(HTML(strings.NewReader(test.html), &b, nil))
 
 			msg, entities := b.Complete()
 			a.Equal(test.msg, msg)

--- a/telegram/message/entity/options.go
+++ b/telegram/message/entity/options.go
@@ -1,5 +1,7 @@
 package entity
 
+import "github.com/gotd/td/tg"
+
 // Plain formats message as plain text.
 func (b *Builder) Plain(s string) *Builder {
 	b.message.WriteString(s)
@@ -73,8 +75,8 @@ func (b *Builder) TextURL(s, url string) *Builder {
 }
 
 // MentionName formats message as MentionName message entity.
-// See https://core.telegram.org/constructor/messageEntityMentionName.
-func (b *Builder) MentionName(s string, userID int) *Builder {
+// See https://core.telegram.org/constructor/inputMessageEntityMentionName.
+func (b *Builder) MentionName(s string, userID tg.InputUserClass) *Builder {
 	return b.Format(s, MentionName(userID))
 }
 

--- a/telegram/message/entity/options_test.go
+++ b/telegram/message/entity/options_test.go
@@ -109,12 +109,16 @@ func TestBuilder(t *testing.T) {
 		}, r)
 	})
 	t.Run("MentionName", func(t *testing.T) {
-		_, ent := b.MentionName("abc", 1).Complete()
+		user := &tg.InputUser{
+			UserID:     10,
+			AccessHash: 10,
+		}
+		_, ent := b.MentionName("abc", user).Complete()
 		r := ent[0]
-		require.Equal(t, &tg.MessageEntityMentionName{
+		require.Equal(t, &tg.InputMessageEntityMentionName{
 			Offset: 0,
 			Length: len("abc"),
-			UserID: 1,
+			UserID: user,
 		}, r)
 	})
 	t.Run("Phone", func(t *testing.T) {

--- a/telegram/message/html/html.go
+++ b/telegram/message/html/html.go
@@ -9,37 +9,38 @@ import (
 
 	"github.com/gotd/td/telegram/message/entity"
 	"github.com/gotd/td/telegram/message/styling"
+	"github.com/gotd/td/tg"
 )
 
 // Bytes reads HTML from given byte slice and returns styling option
 // to build styled text block.
-func Bytes(b []byte) styling.StyledTextOption {
-	return Reader(bytes.NewReader(b))
+func Bytes(resolver func(id int) (tg.InputUserClass, error), b []byte) styling.StyledTextOption {
+	return Reader(resolver, bytes.NewReader(b))
 }
 
 // String reads HTML from given string and returns styling option
 // to build styled text block.
-func String(s string) styling.StyledTextOption {
-	return Reader(strings.NewReader(s))
+func String(resolver func(id int) (tg.InputUserClass, error), s string) styling.StyledTextOption {
+	return Reader(resolver, strings.NewReader(s))
 }
 
 // Format formats string using fmt, parses HTML from formatted string and returns styling option
 // to build styled text block.
-func Format(format string, args ...interface{}) styling.StyledTextOption {
+func Format(resolver func(id int) (tg.InputUserClass, error), format string, args ...interface{}) styling.StyledTextOption {
 	return styling.Custom(func(eb *entity.Builder) error {
 		var buf bytes.Buffer
 		_, err := fmt.Fprintf(&buf, format, args...)
 		if err != nil {
 			return err
 		}
-		return entity.HTML(&buf, eb)
+		return entity.HTML(&buf, eb, resolver)
 	})
 }
 
 // Reader reads HTML from given reader and returns styling option
 // to build styled text block.
-func Reader(r io.Reader) styling.StyledTextOption {
+func Reader(resolver func(id int) (tg.InputUserClass, error), r io.Reader) styling.StyledTextOption {
 	return styling.Custom(func(eb *entity.Builder) error {
-		return entity.HTML(r, eb)
+		return entity.HTML(r, eb, resolver)
 	})
 }

--- a/telegram/message/html/html_example_test.go
+++ b/telegram/message/html/html_example_test.go
@@ -23,7 +23,7 @@ func sendHTML(ctx context.Context) error {
 	// See https://core.telegram.org/bots/api#html-style.
 	return client.Run(ctx, func(ctx context.Context) error {
 		_, err := message.NewSender(tg.NewClient(client)).
-			Self().StyledText(ctx, html.String(`<b>bold</b>, <strong>bold</strong>
+			Self().StyledText(ctx, html.String(nil, `<b>bold</b>, <strong>bold</strong>
 <i>italic</i>, <em>italic</em>
 <u>underline</u>, <ins>underline</ins>
 <s>strikethrough</s>, <strike>strikethrough</strike>, <del>strikethrough</del>

--- a/telegram/message/html_test.go
+++ b/telegram/message/html_test.go
@@ -28,7 +28,7 @@ func TestHTMLBuilder_String(t *testing.T) {
 		}, req.Entities[0])
 	}).ThenResult(&tg.Updates{})
 
-	_, err := sender.Self().StyledText(ctx, html.Format("<b>%s</b>", msg))
+	_, err := sender.Self().StyledText(ctx, html.Format(nil, "<b>%s</b>", msg))
 	mock.NoError(err)
 
 	mock.ExpectFunc(func(b bin.Encoder) {
@@ -43,6 +43,6 @@ func TestHTMLBuilder_String(t *testing.T) {
 		}, req.Entities[0])
 	}).ThenRPCErr(testRPCError())
 
-	_, err = sender.Self().StyledText(ctx, html.Bytes([]byte(send)))
+	_, err = sender.Self().StyledText(ctx, html.Bytes(nil, []byte(send)))
 	mock.Error(err)
 }

--- a/telegram/message/styling/option.go
+++ b/telegram/message/styling/option.go
@@ -2,6 +2,7 @@ package styling
 
 import (
 	"github.com/gotd/td/telegram/message/entity"
+	"github.com/gotd/td/tg"
 )
 
 // StyledTextOption is a option for styling text.
@@ -140,7 +141,7 @@ func TextURL(s, url string) StyledTextOption {
 
 // MentionName formats text as MentionName entity.
 // See https://core.telegram.org/constructor/messageEntityMentionName.
-func MentionName(s string, userID int) StyledTextOption {
+func MentionName(s string, userID tg.InputUserClass) StyledTextOption {
 	return styledTextOption(s, func(b *textBuilder) error {
 		b.MentionName(s, userID)
 		return nil


### PR DESCRIPTION
Use `InputMessageEntityMentionName` instead of `MessageEntityMentionName`.