### PR TITLE
feat(proto): add GZIP pooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gotd/tl v0.4.0
 	github.com/gotd/xor v0.1.1
 	github.com/k0kubun/pp/v3 v3.0.7
+	github.com/klauspost/compress v1.10.3
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.3
 	github.com/rogpeppe/go-internal v1.8.0

--- a/internal/proto/gzip.go
+++ b/internal/proto/gzip.go
@@ -2,10 +2,10 @@ package proto
 
 import (
 	"bytes"
-	"compress/gzip"
 	"io"
 	"sync"
 
+	"github.com/klauspost/compress/gzip"
 	"go.uber.org/multierr"
 	"golang.org/x/xerrors"
 

--- a/internal/proto/gzip.go
+++ b/internal/proto/gzip.go
@@ -70,6 +70,7 @@ type GZIP struct {
 // GZIPTypeID is TL type id of GZIP.
 const GZIPTypeID = 0x3072cfa1
 
+// nolint:gochecknoglobals
 var (
 	gzipRWPool  = newGzipPool()
 	gzipBufPool = sync.Pool{New: func() interface{} {

--- a/internal/proto/gzip.go
+++ b/internal/proto/gzip.go
@@ -4,11 +4,60 @@ import (
 	"bytes"
 	"compress/gzip"
 	"io"
+	"sync"
 
+	"go.uber.org/multierr"
 	"golang.org/x/xerrors"
 
 	"github.com/gotd/td/bin"
 )
+
+type gzipPool struct {
+	writers sync.Pool
+	readers sync.Pool
+}
+
+func newGzipPool() *gzipPool {
+	return &gzipPool{
+		writers: sync.Pool{
+			New: func() interface{} {
+				return gzip.NewWriter(nil)
+			},
+		},
+		readers: sync.Pool{},
+	}
+}
+
+func (g *gzipPool) GetWriter(w io.Writer) *gzip.Writer {
+	writer := g.writers.Get().(*gzip.Writer)
+	writer.Reset(w)
+	return writer
+}
+
+func (g *gzipPool) PutWriter(w *gzip.Writer) {
+	g.writers.Put(w)
+}
+
+func (g *gzipPool) GetReader(r io.Reader) (*gzip.Reader, error) {
+	reader, ok := g.readers.Get().(*gzip.Reader)
+	if !ok {
+		r, err := gzip.NewReader(r)
+		if err != nil {
+			return nil, err
+		}
+		return r, nil
+	}
+
+	if err := reader.Reset(r); err != nil {
+		g.readers.Put(reader)
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (g *gzipPool) PutReader(w *gzip.Reader) {
+	g.readers.Put(w)
+}
 
 // GZIP represents a Packed Object.
 //
@@ -21,14 +70,36 @@ type GZIP struct {
 // GZIPTypeID is TL type id of GZIP.
 const GZIPTypeID = 0x3072cfa1
 
+var (
+	gzipRWPool  = newGzipPool()
+	gzipBufPool = sync.Pool{New: func() interface{} {
+		return bytes.NewBuffer(nil)
+	}}
+	copyBufPool = bin.NewPool(0)
+)
+
 // Encode implements bin.Encoder.
-func (g GZIP) Encode(b *bin.Buffer) error {
+func (g GZIP) Encode(b *bin.Buffer) (rErr error) {
 	b.PutID(GZIPTypeID)
 
 	// Writing compressed data to buf.
-	buf := new(bytes.Buffer)
-	w := gzip.NewWriter(buf)
-	if _, err := io.Copy(w, bytes.NewReader(g.Data)); err != nil {
+	buf := gzipBufPool.Get().(*bytes.Buffer)
+	buf.Reset()
+	defer gzipBufPool.Put(buf)
+
+	// Copy buffer.
+	copyBuf := copyBufPool.GetSize(b.Len())
+	defer copyBufPool.Put(copyBuf)
+
+	w := gzipRWPool.GetWriter(buf)
+	defer func() {
+		if closeErr := w.Close(); closeErr != nil {
+			closeErr = xerrors.Errorf("close: %w", closeErr)
+			multierr.AppendInto(&rErr, closeErr)
+		}
+		gzipRWPool.PutWriter(w)
+	}()
+	if _, err := io.CopyBuffer(w, bytes.NewReader(g.Data), copyBuf.Buf); err != nil {
 		return xerrors.Errorf("compress: %w", err)
 	}
 	if err := w.Close(); err != nil {
@@ -42,7 +113,7 @@ func (g GZIP) Encode(b *bin.Buffer) error {
 }
 
 // Decode implements bin.Decoder.
-func (g *GZIP) Decode(b *bin.Buffer) error {
+func (g *GZIP) Decode(b *bin.Buffer) (rErr error) {
 	if err := b.ConsumeID(GZIPTypeID); err != nil {
 		return err
 	}
@@ -51,11 +122,17 @@ func (g *GZIP) Decode(b *bin.Buffer) error {
 		return err
 	}
 
-	r, err := gzip.NewReader(bytes.NewReader(buf))
+	r, err := gzipRWPool.GetReader(bytes.NewReader(buf))
 	if err != nil {
 		return xerrors.Errorf("gzip error: %w", err)
 	}
-	defer func() { _ = r.Close() }()
+	defer func() {
+		if closeErr := r.Close(); closeErr != nil {
+			closeErr = xerrors.Errorf("close: %w", closeErr)
+			multierr.AppendInto(&rErr, closeErr)
+		}
+		gzipRWPool.PutReader(r)
+	}()
 
 	// Apply mitigation for reading too much data which can result in OOM.
 	const maxUncompressedSize = 1024 * 1024 * 10 // 10 mb

--- a/internal/proto/gzip_test.go
+++ b/internal/proto/gzip_test.go
@@ -2,11 +2,15 @@ package proto
 
 import (
 	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/gotd/td/bin"
+	"github.com/gotd/td/internal/testutil"
 )
 
 func TestGZIP_Encode(t *testing.T) {
@@ -34,4 +38,52 @@ func TestGZIP_Decode(t *testing.T) {
 	// TODO(ernado): fail explicitly if limit is reached
 	require.NoError(t, b.Decode(&decoded))
 	require.Less(t, len(decoded.Data), len(g.Data))
+}
+
+func benchmarkGZIPEncode(payloadSize int) func(b *testing.B) {
+	return func(b *testing.B) {
+		g := &GZIP{Data: make([]byte, payloadSize)}
+		_, err := io.ReadFull(rand.Reader, g.Data)
+		require.NoError(b, err)
+
+		var buf bin.Buffer
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			buf.Reset()
+			_ = g.Encode(&buf)
+		}
+	}
+}
+
+func BenchmarkGZIP_Encode(b *testing.B) {
+	for _, size := range testutil.Payloads() {
+		b.Run(fmt.Sprintf("%db", size), benchmarkGZIPEncode(size))
+	}
+}
+
+func benchmarkGZIPDecode(payloadSize int) func(b *testing.B) {
+	return func(b *testing.B) {
+		g := &GZIP{Data: make([]byte, payloadSize)}
+		_, err := io.ReadFull(rand.Reader, g.Data)
+		require.NoError(b, err)
+
+		var buf bin.Buffer
+		require.NoError(b, g.Encode(&buf))
+		b.ReportAllocs()
+		b.SetBytes(int64(payloadSize))
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			_ = g.Decode(&bin.Buffer{Buf: buf.Buf})
+		}
+	}
+}
+
+func BenchmarkGZIP_Decode(b *testing.B) {
+	for _, size := range testutil.Payloads() {
+		b.Run(fmt.Sprintf("%db", size), benchmarkGZIPDecode(size))
+	}
 }


### PR DESCRIPTION
Benchstat results:
```
name                    old time/op    new time/op     delta
GZIP_Encode/16b-12         102µs ± 4%       19µs ± 1%   -81.77%  (p=0.008 n=5+5)
GZIP_Encode/128b-12        120µs ± 2%       32µs ± 3%   -72.87%  (p=0.008 n=5+5)
GZIP_Encode/1024b-12       170µs ± 6%       74µs ± 5%   -56.42%  (p=0.008 n=5+5)
GZIP_Encode/8192b-12       237µs ± 1%      140µs ± 1%   -40.81%  (p=0.008 n=5+5)
GZIP_Encode/65536b-12     1.28ms ± 1%     1.04ms ± 1%   -18.86%  (p=0.008 n=5+5)
GZIP_Encode/524288b-12    9.65ms ± 0%     8.83ms ± 1%    -8.49%  (p=0.008 n=5+5)
GZIP_Decode/16b-12        5.62µs ± 2%     0.79µs ± 2%   -85.85%  (p=0.008 n=5+5)
GZIP_Decode/128b-12       5.43µs ± 0%     0.66µs ± 1%   -87.78%  (p=0.016 n=4+5)
GZIP_Decode/1024b-12      5.69µs ± 1%     1.00µs ± 0%   -82.43%  (p=0.008 n=5+5)
GZIP_Decode/8192b-12      11.3µs ± 1%      6.5µs ± 0%   -42.47%  (p=0.008 n=5+5)
GZIP_Decode/65536b-12     47.4µs ± 2%     42.0µs ± 1%   -11.35%  (p=0.008 n=5+5)
GZIP_Decode/524288b-12     373µs ± 1%      369µs ± 1%      ~     (p=0.056 n=5+5)

name                    old speed      new speed       delta
GZIP_Encode/16b-12       160kB/s ± 0%    858kB/s ± 1%  +436.25%  (p=0.016 n=4+5)
GZIP_Encode/128b-12     1.07MB/s ± 2%   3.94MB/s ± 3%  +268.60%  (p=0.008 n=5+5)
GZIP_Encode/1024b-12    6.04MB/s ± 5%  13.84MB/s ± 5%  +129.28%  (p=0.008 n=5+5)
GZIP_Encode/8192b-12    34.6MB/s ± 1%   58.4MB/s ± 1%   +68.94%  (p=0.008 n=5+5)
GZIP_Encode/65536b-12   51.1MB/s ± 1%   63.0MB/s ± 1%   +23.25%  (p=0.008 n=5+5)
GZIP_Encode/524288b-12  54.3MB/s ± 0%   59.4MB/s ± 1%    +9.28%  (p=0.008 n=5+5)
GZIP_Decode/16b-12      2.85MB/s ± 2%  20.14MB/s ± 2%  +607.02%  (p=0.008 n=5+5)
GZIP_Decode/128b-12     23.6MB/s ± 0%  192.9MB/s ± 1%  +718.37%  (p=0.016 n=4+5)
GZIP_Decode/1024b-12     180MB/s ± 1%   1025MB/s ± 0%  +469.32%  (p=0.008 n=5+5)
GZIP_Decode/8192b-12     725MB/s ± 1%   1260MB/s ± 0%   +73.84%  (p=0.008 n=5+5)
GZIP_Decode/65536b-12   1.38GB/s ± 2%   1.56GB/s ± 1%   +12.80%  (p=0.008 n=5+5)
GZIP_Decode/524288b-12  1.40GB/s ± 1%   1.42GB/s ± 1%      ~     (p=0.056 n=5+5)

name                    old alloc/op   new alloc/op    delta
GZIP_Encode/16b-12         814kB ± 0%        0kB ± 5%  -100.00%  (p=0.008 n=5+5)
GZIP_Encode/128b-12        814kB ± 0%        0kB ± 7%  -100.00%  (p=0.008 n=5+5)
GZIP_Encode/1024b-12       815kB ± 0%        0kB ± 4%   -99.99%  (p=0.029 n=4+4)
GZIP_Encode/8192b-12       824kB ± 0%        0kB ±98%   -99.99%  (p=0.008 n=5+5)
GZIP_Encode/65536b-12     1.01MB ± 0%     0.00MB ±89%   -99.94%  (p=0.008 n=5+5)
GZIP_Encode/524288b-12    2.83MB ± 0%     0.03MB ± 1%   -99.11%  (p=0.016 n=5+4)
GZIP_Decode/16b-12        41.8kB ± 0%      0.6kB ± 0%   -98.60%  (p=0.000 n=5+4)
GZIP_Decode/128b-12       41.8kB ± 0%      0.6kB ± 0%   -98.60%  (p=0.000 n=5+4)
GZIP_Decode/1024b-12      42.8kB ± 0%      1.6kB ± 0%   -96.23%  (p=0.008 n=5+5)
GZIP_Decode/8192b-12      77.0kB ± 0%     35.8kB ± 0%   -53.43%  (p=0.008 n=5+5)
GZIP_Decode/65536b-12      325kB ± 0%      285kB ± 0%   -12.48%  (p=0.008 n=5+5)
GZIP_Decode/524288b-12    2.96MB ± 0%     2.92MB ± 0%    -1.20%  (p=0.008 n=5+5)

name                    old allocs/op  new allocs/op   delta
GZIP_Encode/16b-12          20.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Encode/128b-12         21.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Encode/1024b-12        21.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Encode/8192b-12        21.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Encode/65536b-12       23.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Encode/524288b-12      26.0 ± 0%        0.0       -100.00%  (p=0.008 n=5+5)
GZIP_Decode/16b-12          8.00 ± 0%       3.00 ± 0%   -62.50%  (p=0.008 n=5+5)
GZIP_Decode/128b-12         8.00 ± 0%       3.00 ± 0%   -62.50%  (p=0.008 n=5+5)
GZIP_Decode/1024b-12        9.00 ± 0%       4.00 ± 0%   -55.56%  (p=0.008 n=5+5)
GZIP_Decode/8192b-12        17.0 ± 0%       12.0 ± 0%   -29.41%  (p=0.008 n=5+5)
GZIP_Decode/65536b-12       24.0 ± 0%       19.0 ± 0%   -20.83%  (p=0.008 n=5+5)
GZIP_Decode/524288b-12      33.0 ± 0%       30.0 ± 0%    -9.09%  (p=0.008 n=5+5)
```