### PR TITLE
chore(updates): reduce warn log to debug

### DIFF
--- a/telegram/updates/engine.go
+++ b/telegram/updates/engine.go
@@ -225,7 +225,7 @@ func (e *Engine) handleChannelTooLong(date int, long *tg.UpdateChannelTooLong) {
 	if !ok {
 		pts, havePts := long.GetPts()
 		if !havePts {
-			log.Warn("Got UpdateChannelTooLong without pts field")
+			log.Info("Got UpdateChannelTooLong without pts field")
 			return
 		}
 

--- a/telegram/updates/engine.go
+++ b/telegram/updates/engine.go
@@ -225,7 +225,7 @@ func (e *Engine) handleChannelTooLong(date int, long *tg.UpdateChannelTooLong) {
 	if !ok {
 		pts, havePts := long.GetPts()
 		if !havePts {
-			log.Info("Got UpdateChannelTooLong without pts field")
+			log.Debug("Got UpdateChannelTooLong without pts field")
 			return
 		}
 


### PR DESCRIPTION
>Got UpdateChannelTooLong without pts field

Seems to be a pretty common warning and doesn’t require human intervention, so should probably be Info instead of Warn.