### PR TITLE
fix: don’t initialize config on error

### DIFF
--- a/telegram/internal/manager/conn.go
+++ b/telegram/internal/manager/conn.go
@@ -176,7 +176,6 @@ func (c *Conn) wrapRequest(req bin.Object) bin.Object {
 }
 
 func (c *Conn) init(ctx context.Context) error {
-	defer c.gotConfig.Signal()
 	c.log.Debug("Initializing")
 
 	q := c.wrapRequest(&tg.InitConnectionRequest{
@@ -210,5 +209,6 @@ func (c *Conn) init(ctx context.Context) error {
 	c.cfg = cfg
 	c.mux.Unlock()
 
+	c.gotConfig.Signal()
 	return nil
 }


### PR DESCRIPTION
This change should fix a bug where session data is overwritten with empty config
without current DC ID thus rendering client that uses session storage completely
unusable since it would indefinitely retry connection to non-existent DC ID 0.

For reference, the symptom of the bug is a “Got error on self” log message spam
and of course corrupted data in session storage.
