### PR TITLE
feat(mtproto): use buffer pool in read loop

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -66,7 +66,6 @@ linters:
     - varcheck
     - whitespace
     - gochecknoglobals
-    - gocognit
 
   # Do not enable:
   # - wsl       (too opinionated about newlines)

--- a/internal/mtproto/conn.go
+++ b/internal/mtproto/conn.go
@@ -94,7 +94,6 @@ type Conn struct {
 	pingInterval time.Duration
 
 	readConcurrency int
-	noBufferReuse   bool
 	gotSession      *tdsync.Ready
 
 	// compressThreshold is a threshold in bytes to determine that message
@@ -137,7 +136,6 @@ func New(dialer Dialer, opt Options) *Conn {
 		pingInterval: opt.PingInterval,
 
 		readConcurrency: opt.ReadConcurrency,
-		noBufferReuse:   opt.NoBufferReuse,
 		gotSession:      tdsync.NewReady(),
 
 		rpc:               opt.engine,

--- a/internal/mtproto/conn.go
+++ b/internal/mtproto/conn.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rsa"
 	"io"
-	"strconv"
 	"sync"
 	"time"
 
@@ -204,10 +203,8 @@ func (c *Conn) Run(ctx context.Context, f func(ctx context.Context) error) error
 		g.Go("ackLoop", c.ackLoop)
 		g.Go("saltsLoop", c.saltLoop)
 		g.Go("userCallback", f)
+		g.Go("readLoop", c.readLoop)
 
-		for i := 0; i < c.readConcurrency; i++ {
-			g.Go("readLoop-"+strconv.Itoa(i), c.readLoop)
-		}
 		if err := g.Wait(); err != nil {
 			return xerrors.Errorf("group: %w", err)
 		}

--- a/internal/mtproto/options.go
+++ b/internal/mtproto/options.go
@@ -72,6 +72,8 @@ type Options struct {
 	// programs that maintain many connections this quickly adds up to hundreds
 	// of megabytes (buffer size multiplied by the number of connections and read
 	// concurrency).
+	//
+	// Deprecated: no longer needed, will be removed in v0.48.
 	NoBufferReuse bool
 	// Cipher defines message crypto.
 	Cipher Cipher

--- a/internal/mtproto/read.go
+++ b/internal/mtproto/read.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"golang.org/x/sync/errgroup"
 	"golang.org/x/xerrors"
 
 	"github.com/gotd/td/bin"
@@ -69,7 +70,9 @@ func (c *Conn) decryptMessage(b *bin.Buffer) (*crypto.EncryptedMessageData, erro
 	return msg, nil
 }
 
-func (c *Conn) consumeMessage(ctx context.Context, buf *bin.Buffer) error {
+func (c *Conn) consumeMessageAndPut(ctx context.Context, buf *bin.Buffer) error {
+	defer bufPool.Put(buf)
+
 	msg, err := c.decryptMessage(buf)
 	if errors.Is(err, errRejected) {
 		c.log.Warn("Ignoring rejected message", zap.Error(err))
@@ -130,8 +133,6 @@ func (c *Conn) handleAuthKeyNotFound(ctx context.Context) error {
 }
 
 func (c *Conn) readLoop(ctx context.Context) (err error) {
-	b := new(bin.Buffer)
-
 	log := c.log.Named("read")
 	log.Debug("Read loop started")
 	defer func() {
@@ -142,44 +143,56 @@ func (c *Conn) readLoop(ctx context.Context) (err error) {
 		l.Debug("Read loop done")
 	}()
 
-	for {
-		if !c.noBufferReuse {
-			b.Reset()
-		} else {
-			b.ResetTo(nil)
-		}
+	incoming := make(chan *bin.Buffer, c.readConcurrency)
 
-		err = c.conn.Recv(ctx, b)
-		if err == nil {
-			if err := c.consumeMessage(ctx, b); err != nil {
-				return err
+	g, ctx := errgroup.WithContext(ctx)
+	for i := 0; i < c.readConcurrency; i++ {
+		g.Go(func() error {
+			for {
+				select {
+				case b, ok := <-incoming:
+					if !ok {
+						return nil
+					}
+					if err := c.consumeMessageAndPut(ctx, b); err != nil {
+						return xerrors.Errorf("consume: %w", err)
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
 			}
-
-			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			return ctx.Err()
-		default:
-			if c.noUpdates(err) {
-				continue
-			}
-		}
-
-		var protoErr *codec.ProtocolErr
-		if errors.As(err, &protoErr) && protoErr.Code == codec.CodeAuthKeyNotFound {
-			if err := c.handleAuthKeyNotFound(ctx); err != nil {
-				return xerrors.Errorf("auth key not found: %w", err)
-			}
-			continue
-		}
-
-		select {
-		case <-ctx.Done():
-			return xerrors.Errorf("read loop: %w", ctx.Err())
-		default:
-			return xerrors.Errorf("read: %w", err)
-		}
+		})
 	}
+
+	g.Go(func() error {
+		defer close(incoming)
+
+		for {
+			buf := bufPool.Get()
+			if err := c.conn.Recv(ctx, buf); err != nil {
+				var protoErr *codec.ProtocolErr
+				if errors.As(err, &protoErr) && protoErr.Code == codec.CodeAuthKeyNotFound {
+					if err := c.handleAuthKeyNotFound(ctx); err != nil {
+						return xerrors.Errorf("auth key not found: %w", err)
+					}
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					return xerrors.Errorf("read loop: %w", ctx.Err())
+				default:
+					return xerrors.Errorf("read: %w", err)
+				}
+			}
+
+			select {
+			case incoming <- buf:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+
+	return g.Wait()
 }


### PR DESCRIPTION
Rework read loop to reduce idle memory consumption and deprecate "NoRese" option.

Delta for 16 threads:
```
name             old time/op    new time/op    delta
Read/16b-16         533ns ± 1%     518ns ± 2%   -2.72%
Read/128b-16        550ns ± 1%     548ns ± 1%   -0.35%
Read/1024b-16       795ns ± 1%    1006ns ± 2%  +26.49%
Read/8192b-16      3.59µs ± 1%    3.49µs ± 1%   -2.85%
Read/65536b-16     30.9µs ± 1%    15.8µs ± 2%  -48.67%
Read/524288b-16     173µs ± 1%     121µs ± 2%  -29.91%

name             old speed      new speed      delta
Read/16b-16      30.0MB/s ± 1%  30.9MB/s ± 2%   +2.80%
Read/128b-16      233MB/s ± 1%   234MB/s ± 1%   +0.35%
Read/1024b-16    1.29GB/s ± 1%  1.02GB/s ± 2%  -20.92%
Read/8192b-16    2.28GB/s ± 1%  2.35GB/s ± 1%   +2.94%
Read/65536b-16   2.12GB/s ± 1%  4.14GB/s ± 2%  +94.84%
Read/524288b-16  3.03GB/s ± 1%  4.33GB/s ± 2%  +42.69%

name             old alloc/op   new alloc/op   delta
Read/16b-16        1.22kB ± 0%    1.23kB ± 0%   +0.74%
Read/128b-16       1.33kB ± 0%    1.34kB ± 0%   +0.98%
Read/1024b-16      2.35kB ± 0%    2.39kB ± 0%   +1.72%
Read/8192b-16      10.7kB ± 0%    11.0kB ± 0%   +3.21%
Read/65536b-16     74.9kB ± 0%    77.1kB ± 0%   +2.88%
Read/524288b-16     536kB ± 0%     553kB ± 1%   +3.19%

name             old allocs/op  new allocs/op  delta
Read/16b-16          13.0 ± 0%      13.0 ± 0%    0.00%
Read/128b-16         13.0 ± 0%      13.0 ± 0%    0.00%
Read/1024b-16        13.0 ± 0%      13.0 ± 0%    0.00%
Read/8192b-16        13.0 ± 0%      13.0 ± 0%    0.00%
Read/65536b-16       13.0 ± 0%      13.0 ± 0%    0.00%
Read/524288b-16      13.0 ± 0%      13.0 ± 0%    0.00%
```

Delta for 32 threads:
```
name             old time/op    new time/op    delta
Read/16b-32         627ns ± 2%    1242ns ± 2%  +98.08%
Read/128b-32        668ns ± 0%    1265ns ± 1%  +89.23%
Read/1024b-32      1.15µs ± 1%    1.72µs ± 2%  +49.33%
Read/8192b-32      5.31µs ± 2%    2.91µs ± 5%  -45.17%
Read/65536b-32     22.0µs ± 1%    12.8µs ± 0%  -42.06%
Read/524288b-32     135µs ± 1%      99µs ± 1%  -26.54%

name             old speed      new speed      delta
Read/16b-32      25.5MB/s ± 2%  12.9MB/s ± 2%  -49.52%
Read/128b-32      191MB/s ± 0%   101MB/s ± 1%  -47.15%
Read/1024b-32     890MB/s ± 1%   596MB/s ± 2%  -33.03%
Read/8192b-32    1.54GB/s ± 2%  2.82GB/s ± 5%  +82.60%
Read/65536b-32   2.98GB/s ± 1%  5.14GB/s ± 0%  +72.59%
Read/524288b-32  3.88GB/s ± 1%  5.28GB/s ± 1%  +36.13%

name             old alloc/op   new alloc/op   delta
Read/16b-32        1.22kB ± 0%    1.23kB ± 0%   +1.21%
Read/128b-32       1.33kB ± 0%    1.35kB ± 0%   +1.53%
Read/1024b-32      2.35kB ± 0%    2.40kB ± 0%   +2.43%
Read/8192b-32      10.7kB ± 0%    10.9kB ± 0%   +2.32%
Read/65536b-32     75.0kB ± 0%    76.5kB ± 0%   +2.04%
Read/524288b-32     535kB ± 0%     567kB ± 2%   +5.96%

name             old allocs/op  new allocs/op  delta
Read/16b-32          13.0 ± 0%      13.0 ± 0%    0.00%
Read/128b-32         13.0 ± 0%      13.0 ± 0%    0.00%
Read/1024b-32        13.0 ± 0%      13.0 ± 0%    0.00%
Read/8192b-32        13.0 ± 0%      13.0 ± 0%    0.00%
Read/65536b-32       13.0 ± 0%      13.0 ± 0%    0.00%
Read/524288b-32      13.0 ± 0%      13.0 ± 0%    0.00%

```