### PR TITLE
feat(telegram, mtproto): improve idle memory consumption

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,7 +65,6 @@ linters:
     - unused
     - varcheck
     - whitespace
-    - gochecknoglobals
 
   # Do not enable:
   # - wsl       (too opinionated about newlines)
@@ -74,6 +73,7 @@ linters:
   # - prealloc  (not worth it in scope of this project)
   # - maligned  (same as prealloc)
   # - funlen    (gocyclo is enough)
+  # - gochecknoglobals (we know when it is ok to use globals)
 
 issues:
   exclude-use-default: false
@@ -87,20 +87,9 @@ issues:
     - path: tlstypes
       linters: [gochecknoglobals, gosec, golint]
 
-    # default transport protocols are stateless const-like vars.
-    - path: transport
-      linters: [gochecknoglobals]
-
     - linters: [gocritic]
       text: "commentedOutCode"
       source: "SHA1"
-
-    - path: codec
-      linters: [gochecknoglobals]
-
-    # Allow embed globals
-    - source: "embed\\.FS"
-      linters: [gochecknoglobals]
 
     # Exclude go:generate from lll
     - source: "//go:generate"
@@ -118,13 +107,12 @@ issues:
         - gocognit
         - scopelint
         - lll
-        - gochecknoglobals
     # Ignore shadowing of err.
     - linters: [govet]
       text: 'declaration of "(err|ctx|log)"'
     # Ignore linters in main packages.
     - path: main\.go
-      linters: [gochecknoglobals, goconst, funlen, gocognit, gocyclo]
+      linters: [goconst, funlen, gocognit, gocyclo]
     - linters: [goconst]
       text: 'string `bool`'
 

--- a/clock/system.go
+++ b/clock/system.go
@@ -47,4 +47,4 @@ func (systemClock) Timer(d time.Duration) Timer {
 func (systemClock) Now() time.Time { return time.Now() }
 
 // System Clock.
-var System Clock = systemClock{} // nolint:gochecknoglobals
+var System Clock = systemClock{}

--- a/internal/crypto/sha256.go
+++ b/internal/crypto/sha256.go
@@ -16,7 +16,6 @@ func SHA256(from ...[]byte) []byte {
 	return h.Sum(nil)
 }
 
-// nolint:gochecknoglobals // optimization for sha256-hash reuse
 var sha256Pool = &sync.Pool{
 	New: func() interface{} {
 		return sha256.New()

--- a/internal/gen/names.go
+++ b/internal/gen/names.go
@@ -32,7 +32,6 @@ func pascalWords(words []string) string {
 	return strings.Join(words, "")
 }
 
-// nolint:gochecknoglobals
 var (
 	rules    = ruleset()
 	acronyms = make(map[string]struct{})

--- a/internal/mtproto/conn.go
+++ b/internal/mtproto/conn.go
@@ -3,7 +3,6 @@ package mtproto
 import (
 	"context"
 	"crypto/rsa"
-	"fmt"
 	"io"
 	"sync"
 	"time"
@@ -200,7 +199,7 @@ func (c *Conn) Run(ctx context.Context, f func(ctx context.Context) error) error
 		g.Go("ackLoop", c.ackLoop)
 		g.Go("saltsLoop", c.saltLoop)
 		g.Go("userCallback", f)
-		g.Go(fmt.Sprintf("readLoop"), c.readLoop)
+		g.Go("readLoop", c.readLoop)
 
 		if err := g.Wait(); err != nil {
 			return xerrors.Errorf("group: %w", err)

--- a/internal/mtproto/read_test.go
+++ b/internal/mtproto/read_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"io"
-	"runtime"
 	"testing"
 	"time"
 
@@ -53,7 +52,6 @@ func TestCheckMessageID(t *testing.T) {
 func benchRead(payloadSize int) func(b *testing.B) {
 	return func(b *testing.B) {
 		a := require.New(b)
-		procs := runtime.GOMAXPROCS(0)
 		logger := zap.NewNop()
 		random := rand.Reader
 		c := neo.NewTime(time.Now())
@@ -107,9 +105,7 @@ func benchRead(payloadSize int) func(b *testing.B) {
 		b.ReportAllocs()
 		b.SetBytes(int64(payloadSize))
 
-		for i := 0; i < procs; i++ {
-			grp.Go(conn.readLoop)
-		}
+		grp.Go(conn.readLoop)
 		a.ErrorIs(grp.Wait(), context.Canceled)
 	}
 }

--- a/internal/mtproto/read_test.go
+++ b/internal/mtproto/read_test.go
@@ -99,7 +99,6 @@ func benchRead(payloadSize int) func(b *testing.B) {
 			log:               logger,
 			messageIDBuf:      noopBuf{},
 			authKey:           authKey,
-			readConcurrency:   procs,
 			compressThreshold: -1,
 		}
 		grp := tdsync.NewCancellableGroup(ctx)

--- a/internal/mtproto/vendored_keys.go
+++ b/internal/mtproto/vendored_keys.go
@@ -11,7 +11,7 @@ import (
 )
 
 //go:embed _data/public_keys.pem
-var publicKeys []byte // nolint:gochecknoglobals
+var publicKeys []byte
 
 // vendoredKeys parses vendored file _data/public_keys.pem as list of
 // PEM-encoded public RSA keys.

--- a/internal/mtproto/write.go
+++ b/internal/mtproto/write.go
@@ -15,7 +15,7 @@ func (c *Conn) writeServiceMessage(ctx context.Context, message bin.Encoder) err
 	return c.write(ctx, msgID, seqNo, message)
 }
 
-var bufPool = bin.NewPool(0) //nolint:gochecknoglobals
+var bufPool = bin.NewPool(0)
 
 func (c *Conn) write(ctx context.Context, msgID int64, seqNo int32, message bin.Encoder) error {
 	b := bufPool.Get()

--- a/internal/mtproxy/faketls/tls.go
+++ b/internal/mtproxy/faketls/tls.go
@@ -26,7 +26,7 @@ const (
 	HandshakeTypeServer HandshakeType = 0x02
 )
 
-// nolint:gochecknoglobals
+// Possible versions.
 var (
 	Version10Bytes = [2]byte{0x03, 0x01}
 	Version11Bytes = [2]byte{0x03, 0x02}

--- a/internal/proto/gzip.go
+++ b/internal/proto/gzip.go
@@ -72,7 +72,6 @@ type GZIP struct {
 // GZIPTypeID is TL type id of GZIP.
 const GZIPTypeID = 0x3072cfa1
 
-// nolint:gochecknoglobals
 var (
 	gzipRWPool  = newGzipPool()
 	gzipBufPool = sync.Pool{New: func() interface{} {

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -213,17 +213,15 @@ func NewClient(appID int, appHash string, opt Options) *Client {
 	}
 
 	client.opts = mtproto.Options{
-		PublicKeys:      opt.PublicKeys,
-		Random:          opt.Random,
-		Logger:          opt.Logger,
-		AckBatchSize:    opt.AckBatchSize,
-		AckInterval:     opt.AckInterval,
-		RetryInterval:   opt.RetryInterval,
-		MaxRetries:      opt.MaxRetries,
-		ReadConcurrency: opt.ReadConcurrency,
-		NoBufferReuse:   opt.NoBufferReuse,
-		MessageID:       opt.MessageID,
-		Clock:           opt.Clock,
+		PublicKeys:    opt.PublicKeys,
+		Random:        opt.Random,
+		Logger:        opt.Logger,
+		AckBatchSize:  opt.AckBatchSize,
+		AckInterval:   opt.AckInterval,
+		RetryInterval: opt.RetryInterval,
+		MaxRetries:    opt.MaxRetries,
+		MessageID:     opt.MessageID,
+		Clock:         opt.Clock,
 
 		Types: getTypesMapping(),
 	}

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -152,6 +152,22 @@ func getVersion() string {
 // Port is default port used by telegram.
 const Port = 443
 
+var (
+	typesMap  *tmap.Map
+	typesOnce sync.Once
+)
+
+func getTypesMapping() *tmap.Map {
+	typesOnce.Do(func() {
+		typesMap = tmap.New(
+			tg.TypesMap(),
+			mt.TypesMap(),
+			proto.TypesMap(),
+		)
+	})
+	return typesMap
+}
+
 // NewClient creates new unstarted client.
 func NewClient(appID int, appHash string, opt Options) *Client {
 	opt.setDefaults()
@@ -209,11 +225,7 @@ func NewClient(appID int, appHash string, opt Options) *Client {
 		MessageID:       opt.MessageID,
 		Clock:           opt.Clock,
 
-		Types: tmap.New(
-			tg.TypesMap(),
-			mt.TypesMap(),
-			proto.TypesMap(),
-		),
+		Types: getTypesMapping(),
 	}
 	client.conn = client.createPrimaryConn(nil)
 

--- a/telegram/flood_wait.go
+++ b/telegram/flood_wait.go
@@ -12,4 +12,4 @@ const ErrFloodWait = tgerr.ErrFloodWait
 //
 // Client should wait for that duration before issuing new requests with
 // same method.
-var AsFloodWait = tgerr.AsFloodWait // nolint:gochecknoglobals
+var AsFloodWait = tgerr.AsFloodWait

--- a/telegram/options.go
+++ b/telegram/options.go
@@ -65,6 +65,8 @@ type Options struct {
 	MaxRetries    int
 	// ReadConcurrency is a count of workers to decrypt and decode incoming messages.
 	// Should be more than 2 to make effect. Otherwise ignored.
+	//
+	// Deprecated: no longer used.
 	ReadConcurrency int
 	// NoBufferReuse disables buffer reuse for workers that decrypt and decode
 	// incoming messages. Each worker adds around 0.5 MiB to the total used
@@ -72,6 +74,8 @@ type Options struct {
 	// programs that maintain many connections this quickly adds up to hundreds
 	// of megabytes (buffer size multiplied by the number of connections and read
 	// concurrency).
+	//
+	// Deprecated: no longer used.
 	NoBufferReuse bool
 
 	// Device is device config.


### PR DESCRIPTION
Initialize type mappings only once to decrease memory
consumption for multiple concurrent clients.

Also decrease goroutine count (remove worker model).