### PR TITLE
feat(crypto): use minio/sha256-simd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/gotd/xor v0.1.1
 	github.com/k0kubun/pp/v3 v3.0.7
 	github.com/klauspost/compress v1.13.1
+	github.com/minio/sha256-simd v1.0.0
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/quasilyte/go-ruleguard/dsl v0.3.6
 	github.com/rogpeppe/go-internal v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -59,6 +59,8 @@ github.com/k0kubun/pp/v3 v3.0.7/go.mod h1:2ol0zQBSPTermAo8igHVJ4d5vTiNmBkCrUdu7w
 github.com/klauspost/compress v1.10.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.13.1 h1:wXr2uRxZTJXHLly6qhJabee5JqIhTRoLBhDOA74hDEQ=
 github.com/klauspost/compress v1.13.1/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
+github.com/klauspost/cpuid/v2 v2.0.4 h1:g0I61F2K2DjRHz1cnxlkNSBIaePVoJIjjnHui8QHbiw=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
@@ -70,6 +72,8 @@ github.com/mattn/go-colorable v0.1.7 h1:bQGKb3vps/j0E9GfJQ03JyhRuxsvdAanXlT9BTw3
 github.com/mattn/go-colorable v0.1.7/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+github.com/minio/sha256-simd v1.0.0 h1:v1ta+49hkWZyvaKwrQB8elexRqm6Y0aMLjCNsrYxo6g=
+github.com/minio/sha256-simd v1.0.0/go.mod h1:OuYzVNI5vcoYIAmbIvHPl3N3jUzVedXbKy5RFepssQM=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=

--- a/internal/crypto/cipher_decrypt.go
+++ b/internal/crypto/cipher_decrypt.go
@@ -30,8 +30,12 @@ func (c Cipher) Decrypt(k AuthKey, encrypted *EncryptedMessage) (*EncryptedMessa
 	}
 
 	side := c.encryptSide.DecryptSide()
-	// Checking SHA256 hash value of msg_key
-	msgKey := MessageKey(k.Value, plaintext, side)
+	var msgKey bin.Int128
+	if len(plaintext) < 512*1024 {
+		msgKey = MessageKey(k.Value, plaintext, side)
+	} else {
+		msgKey = MessageKeySIMD(k.Value, plaintext, side)
+	}
 	if msgKey != encrypted.MsgKey {
 		return nil, xerrors.Errorf("msg_key is invalid")
 	}

--- a/internal/crypto/keys_test.go
+++ b/internal/crypto/keys_test.go
@@ -56,6 +56,21 @@ func BenchmarkMessageKey(b *testing.B) {
 	}
 }
 
+func BenchmarkMessageKeySIMD(b *testing.B) {
+	k, _ := genMessageAndAuthKeys()
+	payload := make([]byte, 1024*512)
+	if _, err := io.ReadFull(rand.Reader, payload); err != nil {
+		b.Error(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_ = MessageKeySIMD(k, payload, Client)
+	}
+}
+
 func TestMessageKey(t *testing.T) {
 	k, _ := genMessageAndAuthKeys()
 	payload := make([]byte, 1024)


### PR DESCRIPTION
```
name             old time/op    new time/op    delta
Read/16b-16         749ns ± 0%     659ns ± 2%  -11.91%
Read/128b-16        830ns ± 1%     740ns ± 4%  -10.92%
Read/1024b-16      1.43µs ± 1%    1.34µs ± 8%   -5.96%
Read/8192b-16      5.26µs ± 9%    5.53µs ±16%   +4.99%
Read/65536b-16     26.9µs ± 2%    33.0µs ±14%  +22.49%
Read/524288b-16     139µs ± 3%      89µs ± 1%  -36.00%

name             old speed      new speed      delta
Read/16b-16      21.4MB/s ± 0%  24.3MB/s ± 2%  +13.53%
Read/128b-16      154MB/s ± 1%   173MB/s ± 4%  +12.33%
Read/1024b-16     717MB/s ± 1%   766MB/s ± 8%   +6.80%
Read/8192b-16    1.57GB/s ± 8%  1.51GB/s ±18%   -3.98%
Read/65536b-16   2.43GB/s ± 2%  2.01GB/s ±15%  -17.46%
Read/524288b-16  3.78GB/s ± 3%  5.90GB/s ± 1%  +56.16%

name             old alloc/op   new alloc/op   delta
Read/16b-16        1.37kB ± 0%    1.37kB ± 0%    0.00%
Read/128b-16       1.59kB ± 0%    1.59kB ± 0%    0.00%
Read/1024b-16      3.48kB ± 0%    3.48kB ± 0%    0.00%
Read/8192b-16      20.1kB ± 0%    20.1kB ± 0%   -0.00%
Read/65536b-16      148kB ± 0%     148kB ± 1%   +0.03%
Read/524288b-16    1.07MB ± 0%    1.07MB ± 0%   +0.10%

name             old allocs/op  new allocs/op  delta
Read/16b-16          16.0 ± 0%      15.7 ± 4%   -2.08%
Read/128b-16         16.0 ± 0%      16.0 ± 0%    0.00%
Read/1024b-16        16.0 ± 0%      16.0 ± 0%    0.00%
Read/8192b-16        16.0 ± 0%      16.0 ± 0%    0.00%
Read/65536b-16       15.5 ± 3%      15.7 ± 4%   +1.08%
Read/524288b-16      16.0 ± 0%      18.3 ± 4%  +14.58%
```

New benchmark is too noisy, should investigate before merge.