### PR TITLE
fix(peer): do not check username length

### DIFF
--- a/telegram/message/peer/resolve.go
+++ b/telegram/message/peer/resolve.go
@@ -102,11 +102,6 @@ func ResolveDomain(r Resolver, domain string) Promise {
 }
 
 func validateDomain(domain string) error {
-	const minDomainLength = 5
-	if len(domain) < minDomainLength {
-		return xerrors.Errorf("domain %q is too small", domain)
-	}
-
 	if err := checkDomainSymbols(domain); err != nil {
 		return err
 	}

--- a/telegram/message/peer/resolve_test.go
+++ b/telegram/message/peer/resolve_test.go
@@ -46,8 +46,6 @@ func TestSender_Resolve(t *testing.T) {
 		{"Good with numbers", "telegram123", false},
 		{"Good with _", "telegram_test", false},
 		{"Good with numbers and _", "telegram_test123", false},
-		{"Bad", "", true},
-		{"Bad", "gotd", true},
 		{"Bad", "_gotd_test", true},
 		{"Bad", "gotd_test_", true},
 		{"Bad", "_gotd_test123", true},


### PR DESCRIPTION
There are some special cases like `gif` or `pic`.