### PR TITLE
feat(gen): preallocate slice for vector fields

### DIFF
--- a/bin/const.go
+++ b/bin/const.go
@@ -1,0 +1,4 @@
+package bin
+
+// PreallocateLimit is a vector pre-allocation limit.
+const PreallocateLimit = 1024

--- a/bin/encode_bench_test.go
+++ b/bin/encode_bench_test.go
@@ -1,0 +1,56 @@
+package bin_test
+
+import (
+	"testing"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/telegram/message/entity"
+	"github.com/gotd/td/telegram/message/styling"
+	"github.com/gotd/td/tg"
+)
+
+func BenchmarkDecodeSlice(b *testing.B) {
+	builder := entity.Builder{}
+	if err := styling.Perform(&builder,
+		styling.Plain("plaintext"), styling.Plain("\n\n"),
+		styling.Mention("@durov"), styling.Plain("\n\n"),
+		styling.Hashtag("#hashtag"), styling.Plain("\n\n"),
+		styling.BotCommand("/command"), styling.Plain("\n\n"),
+		styling.URL("https://google.org"), styling.Plain("\n\n"),
+		styling.Email("example@example.org"), styling.Plain("\n\n"),
+		styling.Bold("bold"), styling.Plain("\n\n"),
+		styling.Italic("italic"), styling.Plain("\n\n"),
+		styling.Underline("underline"), styling.Plain("\n\n"),
+		styling.Strike("strike"), styling.Plain("\n\n"),
+		styling.Code("fmt.Println(`Hello, World!`)"), styling.Plain("\n\n"),
+		styling.PreLang("fmt.Println(`Hello, World!`)", "Go"), styling.Plain("\n\n"),
+		styling.TextURL("clickme", "https://google.com"), styling.Plain("\n\n"),
+		styling.Phone("+71234567891"), styling.Plain("\n\n"),
+		styling.Cashtag("$CASHTAG"), styling.Plain("\n\n"),
+		styling.Blockquote("blockquote"), styling.Plain("\n\n"),
+		styling.BankCard("5550111111111111"), styling.Plain("\n\n"),
+	); err != nil {
+		b.Fatal(err)
+	}
+	message, entities := builder.Complete()
+
+	var buf bin.Buffer
+	if err := buf.Encode(&tg.Message{
+		PeerID:   &tg.PeerUser{},
+		Message:  message,
+		Entities: entities,
+	}); err != nil {
+		b.Fatal(err)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		var msg tg.Message
+
+		if err := msg.Decode(&bin.Buffer{Buf: buf.Buf}); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/internal/gen/_template/main.tmpl
+++ b/internal/gen/_template/main.tmpl
@@ -262,8 +262,8 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) DecodeBare({{ $s.BufArg }} *bin.Buffer) 
                 return fmt.Errorf("unable to decode {{ $s.RawType }}: field {{ $f.RawName }}: %w", err)
             }
 
-            if headerLen != 0 {
-                {{ $s.Receiver }}.{{ $f.Name }} = make({{ template "print_type" $f }}, 0, headerLen)
+            if headerLen > 0 {
+                {{ $s.Receiver }}.{{ $f.Name }} = make({{ template "print_type" $f }}, 0, headerLen % bin.PreallocateLimit)
             }
             for idx := 0; idx < headerLen; idx++ {
 
@@ -274,8 +274,8 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) DecodeBare({{ $s.BufArg }} *bin.Buffer) 
                 }
 
                 var row []{{ $f.Type }}
-                if innerLen != 0 {
-                    row = make([]{{ $f.Type }}, 0, innerLen)
+                if innerLen > 0 {
+                    row = make([]{{ $f.Type }}, 0, innerLen % bin.PreallocateLimit)
                 }
                 for innerIndex := 0; innerIndex < innerLen; innerLen++ {
             {{- end }}

--- a/internal/gen/_template/main.tmpl
+++ b/internal/gen/_template/main.tmpl
@@ -261,6 +261,10 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) DecodeBare({{ $s.BufArg }} *bin.Buffer) 
             if err != nil {
                 return fmt.Errorf("unable to decode {{ $s.RawType }}: field {{ $f.RawName }}: %w", err)
             }
+
+            if headerLen != 0 {
+                {{ $s.Receiver }}.{{ $f.Name }} = make({{ template "print_type" $f }}, 0, headerLen)
+            }
             for idx := 0; idx < headerLen; idx++ {
 
             {{- if $f.DoubleVector }}
@@ -268,7 +272,11 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) DecodeBare({{ $s.BufArg }} *bin.Buffer) 
                 if err != nil {
                     return fmt.Errorf("unable to decode {{ $s.RawType }}: field {{ $f.RawName }}: %w", err)
                 }
+
                 var row []{{ $f.Type }}
+                if innerLen != 0 {
+                    row = make([]{{ $f.Type }}, 0, innerLen)
+                }
                 for innerIndex := 0; innerIndex < innerLen; innerLen++ {
             {{- end }}
             {{- if $f.Interface }}

--- a/internal/gen/example/tl_abstract_message_gen.go
+++ b/internal/gen/example/tl_abstract_message_gen.go
@@ -474,8 +474,8 @@ func (t *TargetsMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode targetsMessage#cc6136f1: field targets: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Targets = make([]int32, 0, headerLen)
+		if headerLen > 0 {
+			t.Targets = make([]int32, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int32()

--- a/internal/gen/example/tl_abstract_message_gen.go
+++ b/internal/gen/example/tl_abstract_message_gen.go
@@ -473,6 +473,10 @@ func (t *TargetsMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode targetsMessage#cc6136f1: field targets: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Targets = make([]int32, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int32()
 			if err != nil {

--- a/internal/gen/example/tl_account_themes_gen.go
+++ b/internal/gen/example/tl_account_themes_gen.go
@@ -272,6 +272,10 @@ func (t *AccountThemes) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.themes#7f676421: field themes: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Themes = make([]Theme, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Theme
 			if err := value.Decode(b); err != nil {

--- a/internal/gen/example/tl_account_themes_gen.go
+++ b/internal/gen/example/tl_account_themes_gen.go
@@ -273,8 +273,8 @@ func (t *AccountThemes) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.themes#7f676421: field themes: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Themes = make([]Theme, 0, headerLen)
+		if headerLen > 0 {
+			t.Themes = make([]Theme, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Theme

--- a/internal/gen/example/tl_config_gen.go
+++ b/internal/gen/example/tl_config_gen.go
@@ -1332,6 +1332,10 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption
 			if err := value.Decode(b); err != nil {

--- a/internal/gen/example/tl_config_gen.go
+++ b/internal/gen/example/tl_config_gen.go
@@ -1333,8 +1333,8 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.DCOptions = make([]DCOption, 0, headerLen)
+		if headerLen > 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption

--- a/internal/gen/example/tl_echo_vector_gen.go
+++ b/internal/gen/example/tl_echo_vector_gen.go
@@ -146,8 +146,8 @@ func (e *EchoVectorRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode echoVector#d4785939: field ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.IDs = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			e.IDs = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/internal/gen/example/tl_echo_vector_gen.go
+++ b/internal/gen/example/tl_echo_vector_gen.go
@@ -145,6 +145,10 @@ func (e *EchoVectorRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode echoVector#d4785939: field ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.IDs = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/internal/gen/example/tl_get_updates_resp_gen.go
+++ b/internal/gen/example/tl_get_updates_resp_gen.go
@@ -156,8 +156,8 @@ func (g *GetUpdatesResp) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode getUpdatesResp#300bb5e1: field updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Updates = make([]AbstractMessageClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Updates = make([]AbstractMessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeAbstractMessage(b)

--- a/internal/gen/example/tl_get_updates_resp_gen.go
+++ b/internal/gen/example/tl_get_updates_resp_gen.go
@@ -155,6 +155,10 @@ func (g *GetUpdatesResp) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode getUpdatesResp#300bb5e1: field updates: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Updates = make([]AbstractMessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeAbstractMessage(b)
 			if err != nil {

--- a/internal/gen/example/tl_int_vector_gen.go
+++ b/internal/gen/example/tl_int_vector_gen.go
@@ -142,8 +142,8 @@ func (vec *IntVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<int>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/internal/gen/example/tl_int_vector_gen.go
+++ b/internal/gen/example/tl_int_vector_gen.go
@@ -141,6 +141,10 @@ func (vec *IntVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<int>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/internal/gen/example/tl_send_multiple_sms_gen.go
+++ b/internal/gen/example/tl_send_multiple_sms_gen.go
@@ -148,8 +148,8 @@ func (s *SendMultipleSMSRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode sendMultipleSMS#df18e5ca: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Messages = make([]SMS, 0, headerLen)
+		if headerLen > 0 {
+			s.Messages = make([]SMS, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SMS

--- a/internal/gen/example/tl_send_multiple_sms_gen.go
+++ b/internal/gen/example/tl_send_multiple_sms_gen.go
@@ -147,6 +147,10 @@ func (s *SendMultipleSMSRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode sendMultipleSMS#df18e5ca: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Messages = make([]SMS, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SMS
 			if err := value.Decode(b); err != nil {

--- a/internal/gen/example/tl_test_vector_bytes_gen.go
+++ b/internal/gen/example/tl_test_vector_bytes_gen.go
@@ -145,6 +145,10 @@ func (t *TestVectorBytes) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorBytes#a590fb25: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {

--- a/internal/gen/example/tl_test_vector_bytes_gen.go
+++ b/internal/gen/example/tl_test_vector_bytes_gen.go
@@ -146,8 +146,8 @@ func (t *TestVectorBytes) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorBytes#a590fb25: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()

--- a/internal/gen/example/tl_test_vector_int_gen.go
+++ b/internal/gen/example/tl_test_vector_int_gen.go
@@ -145,6 +145,10 @@ func (t *TestVectorInt) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorInt#df9eb113: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([]int32, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int32()
 			if err != nil {

--- a/internal/gen/example/tl_test_vector_int_gen.go
+++ b/internal/gen/example/tl_test_vector_int_gen.go
@@ -146,8 +146,8 @@ func (t *TestVectorInt) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorInt#df9eb113: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([]int32, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([]int32, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int32()

--- a/internal/gen/example/tl_test_vector_int_object_gen.go
+++ b/internal/gen/example/tl_test_vector_int_object_gen.go
@@ -147,6 +147,10 @@ func (t *TestVectorIntObject) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorIntObject#f152999b: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([]TestInt, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TestInt
 			if err := value.DecodeBare(b); err != nil {

--- a/internal/gen/example/tl_test_vector_int_object_gen.go
+++ b/internal/gen/example/tl_test_vector_int_object_gen.go
@@ -148,8 +148,8 @@ func (t *TestVectorIntObject) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorIntObject#f152999b: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([]TestInt, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([]TestInt, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TestInt

--- a/internal/gen/example/tl_test_vector_string_gen.go
+++ b/internal/gen/example/tl_test_vector_string_gen.go
@@ -145,6 +145,10 @@ func (t *TestVectorString) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorString#5d6f85bc: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {

--- a/internal/gen/example/tl_test_vector_string_gen.go
+++ b/internal/gen/example/tl_test_vector_string_gen.go
@@ -146,8 +146,8 @@ func (t *TestVectorString) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorString#5d6f85bc: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/internal/gen/example/tl_test_vector_string_object_gen.go
+++ b/internal/gen/example/tl_test_vector_string_object_gen.go
@@ -147,6 +147,10 @@ func (t *TestVectorStringObject) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorStringObject#e5ecc0d: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([]TestString, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TestString
 			if err := value.DecodeBare(b); err != nil {

--- a/internal/gen/example/tl_test_vector_string_object_gen.go
+++ b/internal/gen/example/tl_test_vector_string_object_gen.go
@@ -148,8 +148,8 @@ func (t *TestVectorStringObject) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorStringObject#e5ecc0d: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([]TestString, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([]TestString, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TestString

--- a/internal/gen/example/tl_test_vector_vector_gen.go
+++ b/internal/gen/example/tl_test_vector_vector_gen.go
@@ -149,8 +149,8 @@ func (t *TestVectorVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode testVectorVector#69e8846c: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Value = make([][]string, 0, headerLen)
+		if headerLen > 0 {
+			t.Value = make([][]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			innerLen, err := b.VectorHeader()
@@ -159,8 +159,8 @@ func (t *TestVectorVector) DecodeBare(b *bin.Buffer) error {
 			}
 
 			var row []string
-			if innerLen != 0 {
-				row = make([]string, 0, innerLen)
+			if innerLen > 0 {
+				row = make([]string, 0, innerLen%bin.PreallocateLimit)
 			}
 			for innerIndex := 0; innerIndex < innerLen; innerLen++ {
 				value, err := b.String()

--- a/internal/gen/example/tl_test_vector_vector_gen.go
+++ b/internal/gen/example/tl_test_vector_vector_gen.go
@@ -148,12 +148,20 @@ func (t *TestVectorVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode testVectorVector#69e8846c: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Value = make([][]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			innerLen, err := b.VectorHeader()
 			if err != nil {
 				return fmt.Errorf("unable to decode testVectorVector#69e8846c: field value: %w", err)
 			}
+
 			var row []string
+			if innerLen != 0 {
+				row = make([]string, 0, innerLen)
+			}
 			for innerIndex := 0; innerIndex < innerLen; innerLen++ {
 				value, err := b.String()
 				if err != nil {

--- a/internal/gen/example/tl_text_entities_gen.go
+++ b/internal/gen/example/tl_text_entities_gen.go
@@ -148,8 +148,8 @@ func (t *TextEntities) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode textEntities#cf89c258: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Entities = make([]TextEntity, 0, headerLen)
+		if headerLen > 0 {
+			t.Entities = make([]TextEntity, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TextEntity

--- a/internal/gen/example/tl_text_entities_gen.go
+++ b/internal/gen/example/tl_text_entities_gen.go
@@ -147,6 +147,10 @@ func (t *TextEntities) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode textEntities#cf89c258: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Entities = make([]TextEntity, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TextEntity
 			if err := value.DecodeBare(b); err != nil {

--- a/internal/mt/tl_future_salts_gen.go
+++ b/internal/mt/tl_future_salts_gen.go
@@ -193,6 +193,10 @@ func (f *FutureSalts) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode future_salts#ae500895: field salts: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.Salts = make([]FutureSalt, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FutureSalt
 			if err := value.DecodeBare(b); err != nil {

--- a/internal/mt/tl_future_salts_gen.go
+++ b/internal/mt/tl_future_salts_gen.go
@@ -194,8 +194,8 @@ func (f *FutureSalts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode future_salts#ae500895: field salts: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Salts = make([]FutureSalt, 0, headerLen)
+		if headerLen > 0 {
+			f.Salts = make([]FutureSalt, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FutureSalt

--- a/internal/mt/tl_msg_container_gen.go
+++ b/internal/mt/tl_msg_container_gen.go
@@ -146,8 +146,8 @@ func (m *MsgContainer) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode msg_container#73f1f8dc: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Messages = make([]Message, 0, headerLen)
+		if headerLen > 0 {
+			m.Messages = make([]Message, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Message

--- a/internal/mt/tl_msg_container_gen.go
+++ b/internal/mt/tl_msg_container_gen.go
@@ -145,6 +145,10 @@ func (m *MsgContainer) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode msg_container#73f1f8dc: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Messages = make([]Message, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Message
 			if err := value.DecodeBare(b); err != nil {

--- a/internal/mt/tl_msg_resend_req_gen.go
+++ b/internal/mt/tl_msg_resend_req_gen.go
@@ -144,8 +144,8 @@ func (m *MsgResendReq) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode msg_resend_req#7d861a08: field msg_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.MsgIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			m.MsgIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/internal/mt/tl_msg_resend_req_gen.go
+++ b/internal/mt/tl_msg_resend_req_gen.go
@@ -143,6 +143,10 @@ func (m *MsgResendReq) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode msg_resend_req#7d861a08: field msg_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.MsgIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/internal/mt/tl_msgs_ack_gen.go
+++ b/internal/mt/tl_msgs_ack_gen.go
@@ -143,6 +143,10 @@ func (m *MsgsAck) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode msgs_ack#62d6b459: field msg_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.MsgIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/internal/mt/tl_msgs_ack_gen.go
+++ b/internal/mt/tl_msgs_ack_gen.go
@@ -144,8 +144,8 @@ func (m *MsgsAck) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode msgs_ack#62d6b459: field msg_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.MsgIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			m.MsgIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/internal/mt/tl_msgs_all_info_gen.go
+++ b/internal/mt/tl_msgs_all_info_gen.go
@@ -161,8 +161,8 @@ func (m *MsgsAllInfo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode msgs_all_info#8cc0d131: field msg_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.MsgIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			m.MsgIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/internal/mt/tl_msgs_all_info_gen.go
+++ b/internal/mt/tl_msgs_all_info_gen.go
@@ -160,6 +160,10 @@ func (m *MsgsAllInfo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode msgs_all_info#8cc0d131: field msg_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.MsgIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/internal/mt/tl_msgs_state_req_gen.go
+++ b/internal/mt/tl_msgs_state_req_gen.go
@@ -144,8 +144,8 @@ func (m *MsgsStateReq) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode msgs_state_req#da69fb52: field msg_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.MsgIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			m.MsgIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/internal/mt/tl_msgs_state_req_gen.go
+++ b/internal/mt/tl_msgs_state_req_gen.go
@@ -143,6 +143,10 @@ func (m *MsgsStateReq) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode msgs_state_req#da69fb52: field msg_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.MsgIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/internal/mt/tl_res_p_q_gen.go
+++ b/internal/mt/tl_res_p_q_gen.go
@@ -215,6 +215,10 @@ func (r *ResPQ) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode resPQ#5162463: field server_public_key_fingerprints: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ServerPublicKeyFingerprints = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/internal/mt/tl_res_p_q_gen.go
+++ b/internal/mt/tl_res_p_q_gen.go
@@ -216,8 +216,8 @@ func (r *ResPQ) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode resPQ#5162463: field server_public_key_fingerprints: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ServerPublicKeyFingerprints = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			r.ServerPublicKeyFingerprints = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/internal/mtproto/handle_message_test.go
+++ b/internal/mtproto/handle_message_test.go
@@ -93,6 +93,10 @@ func TestConnHandleMessage(t *testing.T) {
 }
 
 func TestConnHandleMessageCorpus(t *testing.T) {
+	if testutil.Race {
+		t.Skip("Skipped")
+	}
+
 	c := &Conn{
 		handler:    newTestHandler(),
 		rpc:        rpc.New(rpc.NopSend, rpc.Options{}),
@@ -102,11 +106,12 @@ func TestConnHandleMessageCorpus(t *testing.T) {
 		gotSession: tdsync.NewReady(),
 	}
 
-	corpusDir := filepath.Join("..", "_fuzz", "handle_message", "corpus")
+	corpusDir := filepath.Join("..", "..", "_fuzz", "handle_message", "corpus")
 	corpus, err := os.ReadDir(corpusDir)
-	if os.IsNotExist(err) || testutil.Race {
-		t.Skip("Skipped")
+	if err != nil {
+		t.Fatal(err)
 	}
+
 	b := &bin.Buffer{}
 	types := tmap.New(
 		tg.TypesMap(),

--- a/internal/mtproto/handle_message_test.go
+++ b/internal/mtproto/handle_message_test.go
@@ -5,14 +5,17 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	"golang.org/x/xerrors"
 
+	"github.com/gotd/neo"
 	"github.com/gotd/td/bin"
 	"github.com/gotd/td/internal/mt"
 	"github.com/gotd/td/internal/rpc"
+	"github.com/gotd/td/internal/tdsync"
 	"github.com/gotd/td/internal/testutil"
 	"github.com/gotd/td/internal/tmap"
 	"github.com/gotd/td/tg"
@@ -91,10 +94,12 @@ func TestConnHandleMessage(t *testing.T) {
 
 func TestConnHandleMessageCorpus(t *testing.T) {
 	c := &Conn{
-		rand:    Zero{},
-		log:     zap.NewNop(),
-		rpc:     rpc.New(rpc.NopSend, rpc.Options{}),
-		handler: newTestHandler(),
+		handler:    newTestHandler(),
+		rpc:        rpc.New(rpc.NopSend, rpc.Options{}),
+		clock:      neo.NewTime(time.Now()),
+		rand:       Zero{},
+		log:        zap.NewNop(),
+		gotSession: tdsync.NewReady(),
 	}
 
 	corpusDir := filepath.Join("..", "_fuzz", "handle_message", "corpus")
@@ -135,7 +140,8 @@ func TestConnHandleMessageCorpus(t *testing.T) {
 					tg.TextMarkedTypeID,
 					tg.MessageTypeID,
 					tg.PageBlockCoverTypeID,
-					tg.InputMediaUploadedDocumentTypeID:
+					tg.InputMediaUploadedDocumentTypeID,
+					tg.SecureRequiredTypeOneOfTypeID:
 					allocThreshold = 256
 				}
 			}

--- a/tdp/internal/schema/tl_config_gen.go
+++ b/tdp/internal/schema/tl_config_gen.go
@@ -1331,8 +1331,8 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.DCOptions = make([]DCOption, 0, headerLen)
+		if headerLen > 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption

--- a/tdp/internal/schema/tl_config_gen.go
+++ b/tdp/internal/schema/tl_config_gen.go
@@ -1330,6 +1330,10 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption
 			if err := value.Decode(b); err != nil {

--- a/tg/e2e/tl_decrypted_message_action_gen.go
+++ b/tg/e2e/tl_decrypted_message_action_gen.go
@@ -276,6 +276,10 @@ func (d *DecryptedMessageActionReadMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessageActionReadMessages#c4f40be: field random_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.RandomIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {
@@ -416,6 +420,10 @@ func (d *DecryptedMessageActionDeleteMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessageActionDeleteMessages#65614304: field random_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.RandomIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {
@@ -555,6 +563,10 @@ func (d *DecryptedMessageActionScreenshotMessages) DecodeBare(b *bin.Buffer) err
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessageActionScreenshotMessages#8ac1f475: field random_ids: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.RandomIDs = make([]int64, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/e2e/tl_decrypted_message_action_gen.go
+++ b/tg/e2e/tl_decrypted_message_action_gen.go
@@ -277,8 +277,8 @@ func (d *DecryptedMessageActionReadMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode decryptedMessageActionReadMessages#c4f40be: field random_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.RandomIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			d.RandomIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
@@ -421,8 +421,8 @@ func (d *DecryptedMessageActionDeleteMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode decryptedMessageActionDeleteMessages#65614304: field random_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.RandomIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			d.RandomIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
@@ -565,8 +565,8 @@ func (d *DecryptedMessageActionScreenshotMessages) DecodeBare(b *bin.Buffer) err
 			return fmt.Errorf("unable to decode decryptedMessageActionScreenshotMessages#8ac1f475: field random_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.RandomIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			d.RandomIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/e2e/tl_decrypted_message_gen.go
+++ b/tg/e2e/tl_decrypted_message_gen.go
@@ -1151,8 +1151,8 @@ func (d *DecryptedMessage46) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode decryptedMessage46#36b091de: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -1624,8 +1624,8 @@ func (d *DecryptedMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode decryptedMessage#91cc4674: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/e2e/tl_decrypted_message_gen.go
+++ b/tg/e2e/tl_decrypted_message_gen.go
@@ -1150,6 +1150,10 @@ func (d *DecryptedMessage46) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessage46#36b091de: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -1618,6 +1622,10 @@ func (d *DecryptedMessage) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessage#91cc4674: field entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/e2e/tl_decrypted_message_media_gen.go
+++ b/tg/e2e/tl_decrypted_message_media_gen.go
@@ -2485,6 +2485,10 @@ func (d *DecryptedMessageMediaExternalDocument) DecodeBare(b *bin.Buffer) error 
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessageMediaExternalDocument#fa95b0dd: field attributes: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
 			if err != nil {
@@ -3513,6 +3517,10 @@ func (d *DecryptedMessageMediaDocument) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode decryptedMessageMediaDocument#7afe8ae2: field attributes: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/e2e/tl_decrypted_message_media_gen.go
+++ b/tg/e2e/tl_decrypted_message_media_gen.go
@@ -2486,8 +2486,8 @@ func (d *DecryptedMessageMediaExternalDocument) DecodeBare(b *bin.Buffer) error 
 			return fmt.Errorf("unable to decode decryptedMessageMediaExternalDocument#fa95b0dd: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
@@ -3519,8 +3519,8 @@ func (d *DecryptedMessageMediaDocument) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode decryptedMessageMediaDocument#7afe8ae2: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_access_point_rule_gen.go
+++ b/tg/tl_access_point_rule_gen.go
@@ -203,6 +203,10 @@ func (a *AccessPointRule) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode accessPointRule#4679b65f: field ips: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.IPs = make([]IPPortClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeIPPort(b)
 			if err != nil {

--- a/tg/tl_access_point_rule_gen.go
+++ b/tg/tl_access_point_rule_gen.go
@@ -204,8 +204,8 @@ func (a *AccessPointRule) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode accessPointRule#4679b65f: field ips: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.IPs = make([]IPPortClass, 0, headerLen)
+		if headerLen > 0 {
+			a.IPs = make([]IPPortClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeIPPort(b)

--- a/tg/tl_account_accept_authorization_gen.go
+++ b/tg/tl_account_accept_authorization_gen.go
@@ -241,8 +241,8 @@ func (a *AccountAcceptAuthorizationRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.acceptAuthorization#e7027c94: field value_hashes: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.ValueHashes = make([]SecureValueHash, 0, headerLen)
+		if headerLen > 0 {
+			a.ValueHashes = make([]SecureValueHash, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValueHash

--- a/tg/tl_account_accept_authorization_gen.go
+++ b/tg/tl_account_accept_authorization_gen.go
@@ -240,6 +240,10 @@ func (a *AccountAcceptAuthorizationRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.acceptAuthorization#e7027c94: field value_hashes: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.ValueHashes = make([]SecureValueHash, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValueHash
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_account_authorization_form_gen.go
+++ b/tg/tl_account_authorization_form_gen.go
@@ -304,6 +304,10 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field required_types: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.RequiredTypes = make([]SecureRequiredTypeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureRequiredType(b)
 			if err != nil {
@@ -316,6 +320,10 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field values: %w", err)
+		}
+
+		if headerLen != 0 {
+			a.Values = make([]SecureValue, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue
@@ -330,6 +338,10 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field errors: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Errors = make([]SecureValueErrorClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueError(b)
 			if err != nil {
@@ -342,6 +354,10 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			a.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_account_authorization_form_gen.go
+++ b/tg/tl_account_authorization_form_gen.go
@@ -305,8 +305,8 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field required_types: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.RequiredTypes = make([]SecureRequiredTypeClass, 0, headerLen)
+		if headerLen > 0 {
+			a.RequiredTypes = make([]SecureRequiredTypeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureRequiredType(b)
@@ -322,8 +322,8 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field values: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Values = make([]SecureValue, 0, headerLen)
+		if headerLen > 0 {
+			a.Values = make([]SecureValue, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue
@@ -339,8 +339,8 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field errors: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Errors = make([]SecureValueErrorClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Errors = make([]SecureValueErrorClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueError(b)
@@ -356,8 +356,8 @@ func (a *AccountAuthorizationForm) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.authorizationForm#ad2e1cd8: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_account_authorizations_gen.go
+++ b/tg/tl_account_authorizations_gen.go
@@ -149,8 +149,8 @@ func (a *AccountAuthorizations) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.authorizations#1250abde: field authorizations: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Authorizations = make([]Authorization, 0, headerLen)
+		if headerLen > 0 {
+			a.Authorizations = make([]Authorization, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Authorization

--- a/tg/tl_account_authorizations_gen.go
+++ b/tg/tl_account_authorizations_gen.go
@@ -148,6 +148,10 @@ func (a *AccountAuthorizations) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.authorizations#1250abde: field authorizations: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Authorizations = make([]Authorization, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Authorization
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_account_delete_secure_value_gen.go
+++ b/tg/tl_account_delete_secure_value_gen.go
@@ -160,6 +160,10 @@ func (d *AccountDeleteSecureValueRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.deleteSecureValue#b880bc4b: field types: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Types = make([]SecureValueTypeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)
 			if err != nil {

--- a/tg/tl_account_delete_secure_value_gen.go
+++ b/tg/tl_account_delete_secure_value_gen.go
@@ -161,8 +161,8 @@ func (d *AccountDeleteSecureValueRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.deleteSecureValue#b880bc4b: field types: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Types = make([]SecureValueTypeClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Types = make([]SecureValueTypeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)

--- a/tg/tl_account_get_multi_wall_papers_gen.go
+++ b/tg/tl_account_get_multi_wall_papers_gen.go
@@ -157,8 +157,8 @@ func (g *AccountGetMultiWallPapersRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.getMultiWallPapers#65ad71dc: field wallpapers: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Wallpapers = make([]InputWallPaperClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Wallpapers = make([]InputWallPaperClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputWallPaper(b)

--- a/tg/tl_account_get_multi_wall_papers_gen.go
+++ b/tg/tl_account_get_multi_wall_papers_gen.go
@@ -156,6 +156,10 @@ func (g *AccountGetMultiWallPapersRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.getMultiWallPapers#65ad71dc: field wallpapers: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Wallpapers = make([]InputWallPaperClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputWallPaper(b)
 			if err != nil {

--- a/tg/tl_account_get_secure_value_gen.go
+++ b/tg/tl_account_get_secure_value_gen.go
@@ -161,8 +161,8 @@ func (g *AccountGetSecureValueRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.getSecureValue#73665bc2: field types: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Types = make([]SecureValueTypeClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Types = make([]SecureValueTypeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)

--- a/tg/tl_account_get_secure_value_gen.go
+++ b/tg/tl_account_get_secure_value_gen.go
@@ -160,6 +160,10 @@ func (g *AccountGetSecureValueRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.getSecureValue#73665bc2: field types: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Types = make([]SecureValueTypeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)
 			if err != nil {

--- a/tg/tl_account_privacy_rules_gen.go
+++ b/tg/tl_account_privacy_rules_gen.go
@@ -217,8 +217,8 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field rules: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Rules = make([]PrivacyRuleClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Rules = make([]PrivacyRuleClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePrivacyRule(b)
@@ -234,8 +234,8 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -251,8 +251,8 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_account_privacy_rules_gen.go
+++ b/tg/tl_account_privacy_rules_gen.go
@@ -216,6 +216,10 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field rules: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Rules = make([]PrivacyRuleClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePrivacyRule(b)
 			if err != nil {
@@ -229,6 +233,10 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -241,6 +249,10 @@ func (p *AccountPrivacyRules) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode account.privacyRules#50a04e45: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_account_register_device_gen.go
+++ b/tg/tl_account_register_device_gen.go
@@ -306,6 +306,10 @@ func (r *AccountRegisterDeviceRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.registerDevice#68976c6f: field other_uids: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.OtherUIDs = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_account_register_device_gen.go
+++ b/tg/tl_account_register_device_gen.go
@@ -307,8 +307,8 @@ func (r *AccountRegisterDeviceRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.registerDevice#68976c6f: field other_uids: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.OtherUIDs = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.OtherUIDs = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_account_set_privacy_gen.go
+++ b/tg/tl_account_set_privacy_gen.go
@@ -185,6 +185,10 @@ func (s *AccountSetPrivacyRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.setPrivacy#c9f81ce8: field rules: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Rules = make([]InputPrivacyRuleClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPrivacyRule(b)
 			if err != nil {

--- a/tg/tl_account_set_privacy_gen.go
+++ b/tg/tl_account_set_privacy_gen.go
@@ -186,8 +186,8 @@ func (s *AccountSetPrivacyRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.setPrivacy#c9f81ce8: field rules: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Rules = make([]InputPrivacyRuleClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Rules = make([]InputPrivacyRuleClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPrivacyRule(b)

--- a/tg/tl_account_themes_gen.go
+++ b/tg/tl_account_themes_gen.go
@@ -278,8 +278,8 @@ func (t *AccountThemes) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.themes#7f676421: field themes: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Themes = make([]Theme, 0, headerLen)
+		if headerLen > 0 {
+			t.Themes = make([]Theme, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Theme

--- a/tg/tl_account_themes_gen.go
+++ b/tg/tl_account_themes_gen.go
@@ -277,6 +277,10 @@ func (t *AccountThemes) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.themes#7f676421: field themes: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Themes = make([]Theme, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Theme
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_account_unregister_device_gen.go
+++ b/tg/tl_account_unregister_device_gen.go
@@ -204,8 +204,8 @@ func (u *AccountUnregisterDeviceRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.unregisterDevice#3076c4bf: field other_uids: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.OtherUIDs = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.OtherUIDs = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_account_unregister_device_gen.go
+++ b/tg/tl_account_unregister_device_gen.go
@@ -203,6 +203,10 @@ func (u *AccountUnregisterDeviceRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.unregisterDevice#3076c4bf: field other_uids: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.OtherUIDs = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_account_wall_papers_gen.go
+++ b/tg/tl_account_wall_papers_gen.go
@@ -285,6 +285,10 @@ func (w *AccountWallPapers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.wallPapers#702b65a9: field wallpapers: %w", err)
 		}
+
+		if headerLen != 0 {
+			w.Wallpapers = make([]WallPaperClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeWallPaper(b)
 			if err != nil {

--- a/tg/tl_account_wall_papers_gen.go
+++ b/tg/tl_account_wall_papers_gen.go
@@ -286,8 +286,8 @@ func (w *AccountWallPapers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.wallPapers#702b65a9: field wallpapers: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Wallpapers = make([]WallPaperClass, 0, headerLen)
+		if headerLen > 0 {
+			w.Wallpapers = make([]WallPaperClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeWallPaper(b)

--- a/tg/tl_account_web_authorizations_gen.go
+++ b/tg/tl_account_web_authorizations_gen.go
@@ -178,6 +178,10 @@ func (w *AccountWebAuthorizations) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode account.webAuthorizations#ed56c9fc: field authorizations: %w", err)
 		}
+
+		if headerLen != 0 {
+			w.Authorizations = make([]WebAuthorization, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value WebAuthorization
 			if err := value.Decode(b); err != nil {
@@ -190,6 +194,10 @@ func (w *AccountWebAuthorizations) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode account.webAuthorizations#ed56c9fc: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			w.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_account_web_authorizations_gen.go
+++ b/tg/tl_account_web_authorizations_gen.go
@@ -179,8 +179,8 @@ func (w *AccountWebAuthorizations) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.webAuthorizations#ed56c9fc: field authorizations: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Authorizations = make([]WebAuthorization, 0, headerLen)
+		if headerLen > 0 {
+			w.Authorizations = make([]WebAuthorization, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value WebAuthorization
@@ -196,8 +196,8 @@ func (w *AccountWebAuthorizations) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode account.webAuthorizations#ed56c9fc: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			w.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_auth_drop_temp_auth_keys_gen.go
+++ b/tg/tl_auth_drop_temp_auth_keys_gen.go
@@ -146,6 +146,10 @@ func (d *AuthDropTempAuthKeysRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode auth.dropTempAuthKeys#8e48a188: field except_auth_keys: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ExceptAuthKeys = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_auth_drop_temp_auth_keys_gen.go
+++ b/tg/tl_auth_drop_temp_auth_keys_gen.go
@@ -147,8 +147,8 @@ func (d *AuthDropTempAuthKeysRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode auth.dropTempAuthKeys#8e48a188: field except_auth_keys: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ExceptAuthKeys = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			d.ExceptAuthKeys = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_auth_export_login_token_gen.go
+++ b/tg/tl_auth_export_login_token_gen.go
@@ -207,6 +207,10 @@ func (e *AuthExportLoginTokenRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode auth.exportLoginToken#b1b41517: field except_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.ExceptIDs = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_auth_export_login_token_gen.go
+++ b/tg/tl_auth_export_login_token_gen.go
@@ -208,8 +208,8 @@ func (e *AuthExportLoginTokenRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode auth.exportLoginToken#b1b41517: field except_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.ExceptIDs = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			e.ExceptIDs = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_bot_command_vector_gen.go
+++ b/tg/tl_bot_command_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *BotCommandVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<BotCommand>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]BotCommand, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_bot_command_vector_gen.go
+++ b/tg/tl_bot_command_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *BotCommandVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<BotCommand>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]BotCommand, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]BotCommand, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand

--- a/tg/tl_bot_info_gen.go
+++ b/tg/tl_bot_info_gen.go
@@ -197,8 +197,8 @@ func (b *BotInfo) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode botInfo#98e81d3a: field commands: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Commands = make([]BotCommand, 0, headerLen)
+		if headerLen > 0 {
+			b.Commands = make([]BotCommand, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand

--- a/tg/tl_bot_info_gen.go
+++ b/tg/tl_bot_info_gen.go
@@ -196,6 +196,10 @@ func (b *BotInfo) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode botInfo#98e81d3a: field commands: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Commands = make([]BotCommand, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand
 			if err := value.Decode(buf); err != nil {

--- a/tg/tl_bot_inline_message_gen.go
+++ b/tg/tl_bot_inline_message_gen.go
@@ -269,6 +269,10 @@ func (b *BotInlineMessageMediaAuto) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode botInlineMessageMediaAuto#764cf810: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(buf)
 			if err != nil {
@@ -568,6 +572,10 @@ func (b *BotInlineMessageText) DecodeBare(buf *bin.Buffer) error {
 		headerLen, err := buf.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode botInlineMessageText#8c7f65e2: field entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			b.Entities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(buf)

--- a/tg/tl_bot_inline_message_gen.go
+++ b/tg/tl_bot_inline_message_gen.go
@@ -270,8 +270,8 @@ func (b *BotInlineMessageMediaAuto) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode botInlineMessageMediaAuto#764cf810: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(buf)
@@ -574,8 +574,8 @@ func (b *BotInlineMessageText) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode botInlineMessageText#8c7f65e2: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(buf)

--- a/tg/tl_bots_set_bot_commands_gen.go
+++ b/tg/tl_bots_set_bot_commands_gen.go
@@ -202,8 +202,8 @@ func (s *BotsSetBotCommandsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode bots.setBotCommands#517165a: field commands: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Commands = make([]BotCommand, 0, headerLen)
+		if headerLen > 0 {
+			s.Commands = make([]BotCommand, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand

--- a/tg/tl_bots_set_bot_commands_gen.go
+++ b/tg/tl_bots_set_bot_commands_gen.go
@@ -201,6 +201,10 @@ func (s *BotsSetBotCommandsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode bots.setBotCommands#517165a: field commands: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Commands = make([]BotCommand, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_cdn_config_gen.go
+++ b/tg/tl_cdn_config_gen.go
@@ -155,8 +155,8 @@ func (c *CDNConfig) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode cdnConfig#5725e40a: field public_keys: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.PublicKeys = make([]CDNPublicKey, 0, headerLen)
+		if headerLen > 0 {
+			c.PublicKeys = make([]CDNPublicKey, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value CDNPublicKey

--- a/tg/tl_cdn_config_gen.go
+++ b/tg/tl_cdn_config_gen.go
@@ -154,6 +154,10 @@ func (c *CDNConfig) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode cdnConfig#5725e40a: field public_keys: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.PublicKeys = make([]CDNPublicKey, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value CDNPublicKey
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_channel_messages_filter_gen.go
+++ b/tg/tl_channel_messages_filter_gen.go
@@ -298,6 +298,10 @@ func (c *ChannelMessagesFilter) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channelMessagesFilter#cd77d957: field ranges: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Ranges = make([]MessageRange, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageRange
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_channel_messages_filter_gen.go
+++ b/tg/tl_channel_messages_filter_gen.go
@@ -299,8 +299,8 @@ func (c *ChannelMessagesFilter) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channelMessagesFilter#cd77d957: field ranges: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Ranges = make([]MessageRange, 0, headerLen)
+		if headerLen > 0 {
+			c.Ranges = make([]MessageRange, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageRange

--- a/tg/tl_channels_admin_log_results_gen.go
+++ b/tg/tl_channels_admin_log_results_gen.go
@@ -208,6 +208,10 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field events: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Events = make([]ChannelAdminLogEvent, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChannelAdminLogEvent
 			if err := value.Decode(b); err != nil {
@@ -221,6 +225,10 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -233,6 +241,10 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			a.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_admin_log_results_gen.go
+++ b/tg/tl_channels_admin_log_results_gen.go
@@ -209,8 +209,8 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field events: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Events = make([]ChannelAdminLogEvent, 0, headerLen)
+		if headerLen > 0 {
+			a.Events = make([]ChannelAdminLogEvent, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChannelAdminLogEvent
@@ -226,8 +226,8 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -243,8 +243,8 @@ func (a *ChannelsAdminLogResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.adminLogResults#ed8af74d: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_channel_participant_gen.go
+++ b/tg/tl_channels_channel_participant_gen.go
@@ -216,8 +216,8 @@ func (c *ChannelsChannelParticipant) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.channelParticipant#dfb80317: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -233,8 +233,8 @@ func (c *ChannelsChannelParticipant) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.channelParticipant#dfb80317: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_channel_participant_gen.go
+++ b/tg/tl_channels_channel_participant_gen.go
@@ -215,6 +215,10 @@ func (c *ChannelsChannelParticipant) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.channelParticipant#dfb80317: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -227,6 +231,10 @@ func (c *ChannelsChannelParticipant) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.channelParticipant#dfb80317: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_channel_participants_gen.go
+++ b/tg/tl_channels_channel_participants_gen.go
@@ -241,8 +241,8 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Participants = make([]ChannelParticipantClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Participants = make([]ChannelParticipantClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChannelParticipant(b)
@@ -258,8 +258,8 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -275,8 +275,8 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_channel_participants_gen.go
+++ b/tg/tl_channels_channel_participants_gen.go
@@ -240,6 +240,10 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field participants: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Participants = make([]ChannelParticipantClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChannelParticipant(b)
 			if err != nil {
@@ -253,6 +257,10 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -265,6 +273,10 @@ func (c *ChannelsChannelParticipants) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.channelParticipants#9ab0feaf: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_channels_delete_messages_gen.go
+++ b/tg/tl_channels_delete_messages_gen.go
@@ -187,8 +187,8 @@ func (d *ChannelsDeleteMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.deleteMessages#84c1fd4e: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			d.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_channels_delete_messages_gen.go
+++ b/tg/tl_channels_delete_messages_gen.go
@@ -186,6 +186,10 @@ func (d *ChannelsDeleteMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.deleteMessages#84c1fd4e: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_channels_get_admin_log_gen.go
+++ b/tg/tl_channels_get_admin_log_gen.go
@@ -363,8 +363,8 @@ func (g *ChannelsGetAdminLogRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.getAdminLog#33ddf480: field admins: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Admins = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Admins = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_channels_get_admin_log_gen.go
+++ b/tg/tl_channels_get_admin_log_gen.go
@@ -362,6 +362,10 @@ func (g *ChannelsGetAdminLogRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.getAdminLog#33ddf480: field admins: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Admins = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_channels_get_channels_gen.go
+++ b/tg/tl_channels_get_channels_gen.go
@@ -159,6 +159,10 @@ func (g *ChannelsGetChannelsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.getChannels#a7f6bbb: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]InputChannelClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputChannel(b)
 			if err != nil {

--- a/tg/tl_channels_get_channels_gen.go
+++ b/tg/tl_channels_get_channels_gen.go
@@ -160,8 +160,8 @@ func (g *ChannelsGetChannelsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.getChannels#a7f6bbb: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]InputChannelClass, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]InputChannelClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputChannel(b)

--- a/tg/tl_channels_get_messages_gen.go
+++ b/tg/tl_channels_get_messages_gen.go
@@ -193,6 +193,10 @@ func (g *ChannelsGetMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.getMessages#ad8c9a23: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]InputMessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputMessage(b)
 			if err != nil {

--- a/tg/tl_channels_get_messages_gen.go
+++ b/tg/tl_channels_get_messages_gen.go
@@ -194,8 +194,8 @@ func (g *ChannelsGetMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.getMessages#ad8c9a23: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]InputMessageClass, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]InputMessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputMessage(b)

--- a/tg/tl_channels_invite_to_channel_gen.go
+++ b/tg/tl_channels_invite_to_channel_gen.go
@@ -190,6 +190,10 @@ func (i *ChannelsInviteToChannelRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.inviteToChannel#199f3a6c: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Users = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_channels_invite_to_channel_gen.go
+++ b/tg/tl_channels_invite_to_channel_gen.go
@@ -191,8 +191,8 @@ func (i *ChannelsInviteToChannelRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.inviteToChannel#199f3a6c: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_channels_read_message_contents_gen.go
+++ b/tg/tl_channels_read_message_contents_gen.go
@@ -186,6 +186,10 @@ func (r *ChannelsReadMessageContentsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.readMessageContents#eab5dc38: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_channels_read_message_contents_gen.go
+++ b/tg/tl_channels_read_message_contents_gen.go
@@ -187,8 +187,8 @@ func (r *ChannelsReadMessageContentsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.readMessageContents#eab5dc38: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_channels_report_spam_gen.go
+++ b/tg/tl_channels_report_spam_gen.go
@@ -210,6 +210,10 @@ func (r *ChannelsReportSpamRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channels.reportSpam#fe087810: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_channels_report_spam_gen.go
+++ b/tg/tl_channels_report_spam_gen.go
@@ -211,8 +211,8 @@ func (r *ChannelsReportSpamRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channels.reportSpam#fe087810: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_chat_full_gen.go
+++ b/tg/tl_chat_full_gen.go
@@ -651,6 +651,10 @@ func (c *ChatFull) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode chatFull#8a1e2983: field bot_info: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.BotInfo = make([]BotInfo, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotInfo
 			if err := value.Decode(b); err != nil {
@@ -2185,6 +2189,10 @@ func (c *ChannelFull) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channelFull#548c3f93: field bot_info: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.BotInfo = make([]BotInfo, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotInfo
 			if err := value.Decode(b); err != nil {
@@ -2291,6 +2299,10 @@ func (c *ChannelFull) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode channelFull#548c3f93: field pending_suggestions: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.PendingSuggestions = make([]string, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_chat_full_gen.go
+++ b/tg/tl_chat_full_gen.go
@@ -652,8 +652,8 @@ func (c *ChatFull) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode chatFull#8a1e2983: field bot_info: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.BotInfo = make([]BotInfo, 0, headerLen)
+		if headerLen > 0 {
+			c.BotInfo = make([]BotInfo, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotInfo
@@ -2190,8 +2190,8 @@ func (c *ChannelFull) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channelFull#548c3f93: field bot_info: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.BotInfo = make([]BotInfo, 0, headerLen)
+		if headerLen > 0 {
+			c.BotInfo = make([]BotInfo, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotInfo
@@ -2301,8 +2301,8 @@ func (c *ChannelFull) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channelFull#548c3f93: field pending_suggestions: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.PendingSuggestions = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			c.PendingSuggestions = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_chat_gen.go
+++ b/tg/tl_chat_gen.go
@@ -1990,8 +1990,8 @@ func (c *Channel) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode channel#d31a961e: field restriction_reason: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.RestrictionReason = make([]RestrictionReason, 0, headerLen)
+		if headerLen > 0 {
+			c.RestrictionReason = make([]RestrictionReason, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason

--- a/tg/tl_chat_gen.go
+++ b/tg/tl_chat_gen.go
@@ -1989,6 +1989,10 @@ func (c *Channel) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode channel#d31a961e: field restriction_reason: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.RestrictionReason = make([]RestrictionReason, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_chat_invite_gen.go
+++ b/tg/tl_chat_invite_gen.go
@@ -551,6 +551,10 @@ func (c *ChatInvite) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode chatInvite#dfc2f58e: field participants: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Participants = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_chat_invite_gen.go
+++ b/tg/tl_chat_invite_gen.go
@@ -552,8 +552,8 @@ func (c *ChatInvite) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode chatInvite#dfc2f58e: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Participants = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Participants = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_chat_participants_gen.go
+++ b/tg/tl_chat_participants_gen.go
@@ -396,8 +396,8 @@ func (c *ChatParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode chatParticipants#3f460fed: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Participants = make([]ChatParticipantClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Participants = make([]ChatParticipantClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChatParticipant(b)

--- a/tg/tl_chat_participants_gen.go
+++ b/tg/tl_chat_participants_gen.go
@@ -395,6 +395,10 @@ func (c *ChatParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode chatParticipants#3f460fed: field participants: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Participants = make([]ChatParticipantClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChatParticipant(b)
 			if err != nil {

--- a/tg/tl_config_gen.go
+++ b/tg/tl_config_gen.go
@@ -1381,8 +1381,8 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.DCOptions = make([]DCOption, 0, headerLen)
+		if headerLen > 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption

--- a/tg/tl_config_gen.go
+++ b/tg/tl_config_gen.go
@@ -1380,6 +1380,10 @@ func (c *Config) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode config#330b4067: field dc_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.DCOptions = make([]DCOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_contact_status_vector_gen.go
+++ b/tg/tl_contact_status_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *ContactStatusVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<ContactStatus>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]ContactStatus, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ContactStatus
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_contact_status_vector_gen.go
+++ b/tg/tl_contact_status_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *ContactStatusVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<ContactStatus>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]ContactStatus, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]ContactStatus, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ContactStatus

--- a/tg/tl_contacts_blocked_gen.go
+++ b/tg/tl_contacts_blocked_gen.go
@@ -208,6 +208,10 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field blocked: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Blocked = make([]PeerBlocked, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PeerBlocked
 			if err := value.Decode(buf); err != nil {
@@ -221,6 +225,10 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(buf)
 			if err != nil {
@@ -233,6 +241,10 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 		headerLen, err := buf.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			b.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)
@@ -461,6 +473,10 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field blocked: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Blocked = make([]PeerBlocked, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PeerBlocked
 			if err := value.Decode(buf); err != nil {
@@ -474,6 +490,10 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(buf)
 			if err != nil {
@@ -486,6 +506,10 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 		headerLen, err := buf.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			b.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)

--- a/tg/tl_contacts_blocked_gen.go
+++ b/tg/tl_contacts_blocked_gen.go
@@ -209,8 +209,8 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field blocked: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Blocked = make([]PeerBlocked, 0, headerLen)
+		if headerLen > 0 {
+			b.Blocked = make([]PeerBlocked, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PeerBlocked
@@ -226,8 +226,8 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(buf)
@@ -243,8 +243,8 @@ func (b *ContactsBlocked) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blocked#ade1591: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)
@@ -474,8 +474,8 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field blocked: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Blocked = make([]PeerBlocked, 0, headerLen)
+		if headerLen > 0 {
+			b.Blocked = make([]PeerBlocked, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PeerBlocked
@@ -491,8 +491,8 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(buf)
@@ -508,8 +508,8 @@ func (b *ContactsBlockedSlice) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.blockedSlice#e1664194: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)

--- a/tg/tl_contacts_contacts_gen.go
+++ b/tg/tl_contacts_contacts_gen.go
@@ -298,8 +298,8 @@ func (c *ContactsContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.contacts#eae87e42: field contacts: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Contacts = make([]Contact, 0, headerLen)
+		if headerLen > 0 {
+			c.Contacts = make([]Contact, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Contact
@@ -322,8 +322,8 @@ func (c *ContactsContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.contacts#eae87e42: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_contacts_gen.go
+++ b/tg/tl_contacts_contacts_gen.go
@@ -297,6 +297,10 @@ func (c *ContactsContacts) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.contacts#eae87e42: field contacts: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Contacts = make([]Contact, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value Contact
 			if err := value.Decode(b); err != nil {
@@ -316,6 +320,10 @@ func (c *ContactsContacts) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.contacts#eae87e42: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_delete_by_phones_gen.go
+++ b/tg/tl_contacts_delete_by_phones_gen.go
@@ -146,6 +146,10 @@ func (d *ContactsDeleteByPhonesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.deleteByPhones#1013fd9e: field phones: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Phones = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {

--- a/tg/tl_contacts_delete_by_phones_gen.go
+++ b/tg/tl_contacts_delete_by_phones_gen.go
@@ -147,8 +147,8 @@ func (d *ContactsDeleteByPhonesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.deleteByPhones#1013fd9e: field phones: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Phones = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			d.Phones = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_contacts_delete_contacts_gen.go
+++ b/tg/tl_contacts_delete_contacts_gen.go
@@ -156,6 +156,10 @@ func (d *ContactsDeleteContactsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.deleteContacts#96a0e00: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ID = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_contacts_delete_contacts_gen.go
+++ b/tg/tl_contacts_delete_contacts_gen.go
@@ -157,8 +157,8 @@ func (d *ContactsDeleteContactsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.deleteContacts#96a0e00: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ID = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.ID = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_contacts_found_gen.go
+++ b/tg/tl_contacts_found_gen.go
@@ -247,8 +247,8 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field my_results: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.MyResults = make([]PeerClass, 0, headerLen)
+		if headerLen > 0 {
+			f.MyResults = make([]PeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
@@ -264,8 +264,8 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field results: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Results = make([]PeerClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Results = make([]PeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
@@ -281,8 +281,8 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -298,8 +298,8 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_found_gen.go
+++ b/tg/tl_contacts_found_gen.go
@@ -246,6 +246,10 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field my_results: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.MyResults = make([]PeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
 			if err != nil {
@@ -258,6 +262,10 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field results: %w", err)
+		}
+
+		if headerLen != 0 {
+			f.Results = make([]PeerClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
@@ -272,6 +280,10 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -284,6 +296,10 @@ func (f *ContactsFound) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.found#b3134d9d: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			f.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_import_contacts_gen.go
+++ b/tg/tl_contacts_import_contacts_gen.go
@@ -154,6 +154,10 @@ func (i *ContactsImportContactsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.importContacts#2c800be5: field contacts: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Contacts = make([]InputPhoneContact, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputPhoneContact
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_contacts_import_contacts_gen.go
+++ b/tg/tl_contacts_import_contacts_gen.go
@@ -155,8 +155,8 @@ func (i *ContactsImportContactsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.importContacts#2c800be5: field contacts: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Contacts = make([]InputPhoneContact, 0, headerLen)
+		if headerLen > 0 {
+			i.Contacts = make([]InputPhoneContact, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputPhoneContact

--- a/tg/tl_contacts_imported_contacts_gen.go
+++ b/tg/tl_contacts_imported_contacts_gen.go
@@ -224,6 +224,10 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field imported: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Imported = make([]ImportedContact, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ImportedContact
 			if err := value.Decode(b); err != nil {
@@ -236,6 +240,10 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field popular_invites: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.PopularInvites = make([]PopularContact, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PopularContact
@@ -250,6 +258,10 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field retry_contacts: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.RetryContacts = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {
@@ -262,6 +274,10 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_imported_contacts_gen.go
+++ b/tg/tl_contacts_imported_contacts_gen.go
@@ -225,8 +225,8 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field imported: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Imported = make([]ImportedContact, 0, headerLen)
+		if headerLen > 0 {
+			i.Imported = make([]ImportedContact, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ImportedContact
@@ -242,8 +242,8 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field popular_invites: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.PopularInvites = make([]PopularContact, 0, headerLen)
+		if headerLen > 0 {
+			i.PopularInvites = make([]PopularContact, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PopularContact
@@ -259,8 +259,8 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field retry_contacts: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.RetryContacts = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			i.RetryContacts = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
@@ -276,8 +276,8 @@ func (i *ContactsImportedContacts) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.importedContacts#77d01c3b: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_resolved_peer_gen.go
+++ b/tg/tl_contacts_resolved_peer_gen.go
@@ -216,8 +216,8 @@ func (r *ContactsResolvedPeer) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.resolvedPeer#7f077ad9: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -233,8 +233,8 @@ func (r *ContactsResolvedPeer) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.resolvedPeer#7f077ad9: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_resolved_peer_gen.go
+++ b/tg/tl_contacts_resolved_peer_gen.go
@@ -215,6 +215,10 @@ func (r *ContactsResolvedPeer) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.resolvedPeer#7f077ad9: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -227,6 +231,10 @@ func (r *ContactsResolvedPeer) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.resolvedPeer#7f077ad9: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			r.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_top_peers_gen.go
+++ b/tg/tl_contacts_top_peers_gen.go
@@ -310,6 +310,10 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field categories: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Categories = make([]TopPeerCategoryPeers, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TopPeerCategoryPeers
 			if err := value.Decode(b); err != nil {
@@ -323,6 +327,10 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -335,6 +343,10 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			t.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_contacts_top_peers_gen.go
+++ b/tg/tl_contacts_top_peers_gen.go
@@ -311,8 +311,8 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field categories: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Categories = make([]TopPeerCategoryPeers, 0, headerLen)
+		if headerLen > 0 {
+			t.Categories = make([]TopPeerCategoryPeers, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TopPeerCategoryPeers
@@ -328,8 +328,8 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			t.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -345,8 +345,8 @@ func (t *ContactsTopPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode contacts.topPeers#70b772a8: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			t.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_dialog_filter_gen.go
+++ b/tg/tl_dialog_filter_gen.go
@@ -627,8 +627,8 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field pinned_peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.PinnedPeers = make([]InputPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			d.PinnedPeers = make([]InputPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
@@ -644,8 +644,8 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field include_peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.IncludePeers = make([]InputPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			d.IncludePeers = make([]InputPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
@@ -661,8 +661,8 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field exclude_peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ExcludePeers = make([]InputPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			d.ExcludePeers = make([]InputPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)

--- a/tg/tl_dialog_filter_gen.go
+++ b/tg/tl_dialog_filter_gen.go
@@ -626,6 +626,10 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field pinned_peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.PinnedPeers = make([]InputPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
 			if err != nil {
@@ -639,6 +643,10 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field include_peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.IncludePeers = make([]InputPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
 			if err != nil {
@@ -651,6 +659,10 @@ func (d *DialogFilter) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode dialogFilter#7438f7e8: field exclude_peers: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.ExcludePeers = make([]InputPeerClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)

--- a/tg/tl_dialog_filter_suggested_vector_gen.go
+++ b/tg/tl_dialog_filter_suggested_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *DialogFilterSuggestedVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<DialogFilterSuggested>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]DialogFilterSuggested, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]DialogFilterSuggested, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DialogFilterSuggested

--- a/tg/tl_dialog_filter_suggested_vector_gen.go
+++ b/tg/tl_dialog_filter_suggested_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *DialogFilterSuggestedVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<DialogFilterSuggested>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]DialogFilterSuggested, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DialogFilterSuggested
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_dialog_filter_vector_gen.go
+++ b/tg/tl_dialog_filter_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *DialogFilterVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<DialogFilter>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]DialogFilter, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]DialogFilter, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DialogFilter

--- a/tg/tl_dialog_filter_vector_gen.go
+++ b/tg/tl_dialog_filter_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *DialogFilterVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<DialogFilter>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]DialogFilter, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DialogFilter
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_dialog_peer_class_vector_gen.go
+++ b/tg/tl_dialog_peer_class_vector_gen.go
@@ -151,6 +151,10 @@ func (vec *DialogPeerClassVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<DialogPeer>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]DialogPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialogPeer(b)
 			if err != nil {

--- a/tg/tl_dialog_peer_class_vector_gen.go
+++ b/tg/tl_dialog_peer_class_vector_gen.go
@@ -152,8 +152,8 @@ func (vec *DialogPeerClassVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<DialogPeer>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]DialogPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]DialogPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialogPeer(b)

--- a/tg/tl_document_gen.go
+++ b/tg/tl_document_gen.go
@@ -565,6 +565,10 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode document#1e87342b: field thumbs: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Thumbs = make([]PhotoSizeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)
 			if err != nil {
@@ -577,6 +581,10 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode document#1e87342b: field video_thumbs: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.VideoThumbs = make([]VideoSize, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value VideoSize
@@ -597,6 +605,10 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode document#1e87342b: field attributes: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_document_gen.go
+++ b/tg/tl_document_gen.go
@@ -566,8 +566,8 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode document#1e87342b: field thumbs: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Thumbs = make([]PhotoSizeClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Thumbs = make([]PhotoSizeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)
@@ -583,8 +583,8 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode document#1e87342b: field video_thumbs: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.VideoThumbs = make([]VideoSize, 0, headerLen)
+		if headerLen > 0 {
+			d.VideoThumbs = make([]VideoSize, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value VideoSize
@@ -607,8 +607,8 @@ func (d *Document) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode document#1e87342b: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_draft_message_gen.go
+++ b/tg/tl_draft_message_gen.go
@@ -490,8 +490,8 @@ func (d *DraftMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode draftMessage#fd8e711f: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_draft_message_gen.go
+++ b/tg/tl_draft_message_gen.go
@@ -489,6 +489,10 @@ func (d *DraftMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode draftMessage#fd8e711f: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_emoji_keyword_gen.go
+++ b/tg/tl_emoji_keyword_gen.go
@@ -171,8 +171,8 @@ func (e *EmojiKeyword) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode emojiKeyword#d5b3b9f9: field emoticons: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Emoticons = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			e.Emoticons = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
@@ -340,8 +340,8 @@ func (e *EmojiKeywordDeleted) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode emojiKeywordDeleted#236df622: field emoticons: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Emoticons = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			e.Emoticons = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_emoji_keyword_gen.go
+++ b/tg/tl_emoji_keyword_gen.go
@@ -170,6 +170,10 @@ func (e *EmojiKeyword) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode emojiKeyword#d5b3b9f9: field emoticons: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Emoticons = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {
@@ -334,6 +338,10 @@ func (e *EmojiKeywordDeleted) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode emojiKeywordDeleted#236df622: field emoticons: %w", err)
+		}
+
+		if headerLen != 0 {
+			e.Emoticons = make([]string, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_emoji_keywords_difference_gen.go
+++ b/tg/tl_emoji_keywords_difference_gen.go
@@ -229,8 +229,8 @@ func (e *EmojiKeywordsDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode emojiKeywordsDifference#5cc761bd: field keywords: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Keywords = make([]EmojiKeywordClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Keywords = make([]EmojiKeywordClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEmojiKeyword(b)

--- a/tg/tl_emoji_keywords_difference_gen.go
+++ b/tg/tl_emoji_keywords_difference_gen.go
@@ -228,6 +228,10 @@ func (e *EmojiKeywordsDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode emojiKeywordsDifference#5cc761bd: field keywords: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Keywords = make([]EmojiKeywordClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEmojiKeyword(b)
 			if err != nil {

--- a/tg/tl_emoji_language_vector_gen.go
+++ b/tg/tl_emoji_language_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *EmojiLanguageVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<EmojiLanguage>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]EmojiLanguage, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value EmojiLanguage
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_emoji_language_vector_gen.go
+++ b/tg/tl_emoji_language_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *EmojiLanguageVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<EmojiLanguage>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]EmojiLanguage, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]EmojiLanguage, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value EmojiLanguage

--- a/tg/tl_file_hash_vector_gen.go
+++ b/tg/tl_file_hash_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *FileHashVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<FileHash>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]FileHash, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FileHash
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_file_hash_vector_gen.go
+++ b/tg/tl_file_hash_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *FileHashVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<FileHash>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]FileHash, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]FileHash, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FileHash

--- a/tg/tl_folders_edit_peer_folders_gen.go
+++ b/tg/tl_folders_edit_peer_folders_gen.go
@@ -151,6 +151,10 @@ func (e *FoldersEditPeerFoldersRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode folders.editPeerFolders#6847d0ab: field folder_peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.FolderPeers = make([]InputFolderPeer, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputFolderPeer
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_folders_edit_peer_folders_gen.go
+++ b/tg/tl_folders_edit_peer_folders_gen.go
@@ -152,8 +152,8 @@ func (e *FoldersEditPeerFoldersRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode folders.editPeerFolders#6847d0ab: field folder_peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.FolderPeers = make([]InputFolderPeer, 0, headerLen)
+		if headerLen > 0 {
+			e.FolderPeers = make([]InputFolderPeer, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputFolderPeer

--- a/tg/tl_group_call_participant_video_gen.go
+++ b/tg/tl_group_call_participant_video_gen.go
@@ -255,8 +255,8 @@ func (g *GroupCallParticipantVideo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode groupCallParticipantVideo#67753ac8: field source_groups: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.SourceGroups = make([]GroupCallParticipantVideoSourceGroup, 0, headerLen)
+		if headerLen > 0 {
+			g.SourceGroups = make([]GroupCallParticipantVideoSourceGroup, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipantVideoSourceGroup

--- a/tg/tl_group_call_participant_video_gen.go
+++ b/tg/tl_group_call_participant_video_gen.go
@@ -254,6 +254,10 @@ func (g *GroupCallParticipantVideo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode groupCallParticipantVideo#67753ac8: field source_groups: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.SourceGroups = make([]GroupCallParticipantVideoSourceGroup, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipantVideoSourceGroup
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_group_call_participant_video_source_group_gen.go
+++ b/tg/tl_group_call_participant_video_source_group_gen.go
@@ -169,6 +169,10 @@ func (g *GroupCallParticipantVideoSourceGroup) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode groupCallParticipantVideoSourceGroup#dcb118b7: field sources: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Sources = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_group_call_participant_video_source_group_gen.go
+++ b/tg/tl_group_call_participant_video_source_group_gen.go
@@ -170,8 +170,8 @@ func (g *GroupCallParticipantVideoSourceGroup) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode groupCallParticipantVideoSourceGroup#dcb118b7: field sources: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Sources = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.Sources = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_help_app_update_gen.go
+++ b/tg/tl_help_app_update_gen.go
@@ -403,6 +403,10 @@ func (a *HelpAppUpdate) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.appUpdate#ccbbce30: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_help_app_update_gen.go
+++ b/tg/tl_help_app_update_gen.go
@@ -404,8 +404,8 @@ func (a *HelpAppUpdate) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.appUpdate#ccbbce30: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_help_config_simple_gen.go
+++ b/tg/tl_help_config_simple_gen.go
@@ -196,8 +196,8 @@ func (c *HelpConfigSimple) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.configSimple#5a592a6c: field rules: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Rules = make([]AccessPointRule, 0, headerLen)
+		if headerLen > 0 {
+			c.Rules = make([]AccessPointRule, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value AccessPointRule

--- a/tg/tl_help_config_simple_gen.go
+++ b/tg/tl_help_config_simple_gen.go
@@ -195,6 +195,10 @@ func (c *HelpConfigSimple) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.configSimple#5a592a6c: field rules: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Rules = make([]AccessPointRule, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value AccessPointRule
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_help_countries_list_gen.go
+++ b/tg/tl_help_countries_list_gen.go
@@ -271,8 +271,8 @@ func (c *HelpCountriesList) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.countriesList#87d0759e: field countries: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Countries = make([]HelpCountry, 0, headerLen)
+		if headerLen > 0 {
+			c.Countries = make([]HelpCountry, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HelpCountry

--- a/tg/tl_help_countries_list_gen.go
+++ b/tg/tl_help_countries_list_gen.go
@@ -270,6 +270,10 @@ func (c *HelpCountriesList) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.countriesList#87d0759e: field countries: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Countries = make([]HelpCountry, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HelpCountry
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_help_country_code_gen.go
+++ b/tg/tl_help_country_code_gen.go
@@ -248,6 +248,10 @@ func (c *HelpCountryCode) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.countryCode#4203c5ef: field prefixes: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Prefixes = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {
@@ -260,6 +264,10 @@ func (c *HelpCountryCode) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode help.countryCode#4203c5ef: field patterns: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Patterns = make([]string, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_help_country_code_gen.go
+++ b/tg/tl_help_country_code_gen.go
@@ -249,8 +249,8 @@ func (c *HelpCountryCode) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.countryCode#4203c5ef: field prefixes: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Prefixes = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			c.Prefixes = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
@@ -266,8 +266,8 @@ func (c *HelpCountryCode) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.countryCode#4203c5ef: field patterns: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Patterns = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			c.Patterns = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_help_country_gen.go
+++ b/tg/tl_help_country_gen.go
@@ -289,6 +289,10 @@ func (c *HelpCountry) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.country#c3878e23: field country_codes: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.CountryCodes = make([]HelpCountryCode, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HelpCountryCode
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_help_country_gen.go
+++ b/tg/tl_help_country_gen.go
@@ -290,8 +290,8 @@ func (c *HelpCountry) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.country#c3878e23: field country_codes: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.CountryCodes = make([]HelpCountryCode, 0, headerLen)
+		if headerLen > 0 {
+			c.CountryCodes = make([]HelpCountryCode, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HelpCountryCode

--- a/tg/tl_help_deep_link_info_gen.go
+++ b/tg/tl_help_deep_link_info_gen.go
@@ -358,8 +358,8 @@ func (d *HelpDeepLinkInfo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.deepLinkInfo#6a4ee832: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_help_deep_link_info_gen.go
+++ b/tg/tl_help_deep_link_info_gen.go
@@ -357,6 +357,10 @@ func (d *HelpDeepLinkInfo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.deepLinkInfo#6a4ee832: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_help_edit_user_info_gen.go
+++ b/tg/tl_help_edit_user_info_gen.go
@@ -213,8 +213,8 @@ func (e *HelpEditUserInfoRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.editUserInfo#66b91b70: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_help_edit_user_info_gen.go
+++ b/tg/tl_help_edit_user_info_gen.go
@@ -212,6 +212,10 @@ func (e *HelpEditUserInfoRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.editUserInfo#66b91b70: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_help_promo_data_gen.go
+++ b/tg/tl_help_promo_data_gen.go
@@ -495,6 +495,10 @@ func (p *HelpPromoData) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.promoData#8c39793f: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -507,6 +511,10 @@ func (p *HelpPromoData) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode help.promoData#8c39793f: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_help_promo_data_gen.go
+++ b/tg/tl_help_promo_data_gen.go
@@ -496,8 +496,8 @@ func (p *HelpPromoData) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.promoData#8c39793f: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -513,8 +513,8 @@ func (p *HelpPromoData) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.promoData#8c39793f: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_help_recent_me_urls_gen.go
+++ b/tg/tl_help_recent_me_urls_gen.go
@@ -217,8 +217,8 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field urls: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.URLs = make([]RecentMeURLClass, 0, headerLen)
+		if headerLen > 0 {
+			r.URLs = make([]RecentMeURLClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeRecentMeURL(b)
@@ -234,8 +234,8 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -251,8 +251,8 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_help_recent_me_urls_gen.go
+++ b/tg/tl_help_recent_me_urls_gen.go
@@ -216,6 +216,10 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field urls: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.URLs = make([]RecentMeURLClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeRecentMeURL(b)
 			if err != nil {
@@ -229,6 +233,10 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -241,6 +249,10 @@ func (r *HelpRecentMeURLs) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode help.recentMeUrls#e0310d7: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			r.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_help_save_app_log_gen.go
+++ b/tg/tl_help_save_app_log_gen.go
@@ -148,6 +148,10 @@ func (s *HelpSaveAppLogRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.saveAppLog#6f02f748: field events: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Events = make([]InputAppEvent, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputAppEvent
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_help_save_app_log_gen.go
+++ b/tg/tl_help_save_app_log_gen.go
@@ -149,8 +149,8 @@ func (s *HelpSaveAppLogRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.saveAppLog#6f02f748: field events: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Events = make([]InputAppEvent, 0, headerLen)
+		if headerLen > 0 {
+			s.Events = make([]InputAppEvent, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputAppEvent

--- a/tg/tl_help_terms_of_service_gen.go
+++ b/tg/tl_help_terms_of_service_gen.go
@@ -294,6 +294,10 @@ func (t *HelpTermsOfService) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.termsOfService#780a0310: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_help_terms_of_service_gen.go
+++ b/tg/tl_help_terms_of_service_gen.go
@@ -295,8 +295,8 @@ func (t *HelpTermsOfService) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.termsOfService#780a0310: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			t.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_help_user_info_gen.go
+++ b/tg/tl_help_user_info_gen.go
@@ -319,6 +319,10 @@ func (u *HelpUserInfo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode help.userInfo#1eb3758: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_help_user_info_gen.go
+++ b/tg/tl_help_user_info_gen.go
@@ -320,8 +320,8 @@ func (u *HelpUserInfo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode help.userInfo#1eb3758: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_bot_inline_message_gen.go
+++ b/tg/tl_input_bot_inline_message_gen.go
@@ -267,8 +267,8 @@ func (i *InputBotInlineMessageMediaAuto) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputBotInlineMessageMediaAuto#3380c786: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -571,8 +571,8 @@ func (i *InputBotInlineMessageText) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputBotInlineMessageText#3dcd7a87: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_bot_inline_message_gen.go
+++ b/tg/tl_input_bot_inline_message_gen.go
@@ -266,6 +266,10 @@ func (i *InputBotInlineMessageMediaAuto) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputBotInlineMessageMediaAuto#3380c786: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -565,6 +569,10 @@ func (i *InputBotInlineMessageText) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode inputBotInlineMessageText#3dcd7a87: field entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_media_gen.go
+++ b/tg/tl_input_media_gen.go
@@ -368,6 +368,10 @@ func (i *InputMediaUploadedPhoto) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputMediaUploadedPhoto#1e287d04: field stickers: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Stickers = make([]InputDocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDocument(b)
 			if err != nil {
@@ -1344,6 +1348,10 @@ func (i *InputMediaUploadedDocument) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputMediaUploadedDocument#5b38c6c1: field attributes: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
 			if err != nil {
@@ -1356,6 +1364,10 @@ func (i *InputMediaUploadedDocument) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode inputMediaUploadedDocument#5b38c6c1: field stickers: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Stickers = make([]InputDocumentClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDocument(b)
@@ -3381,6 +3393,10 @@ func (i *InputMediaPoll) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputMediaPoll#f94e5f1: field correct_answers: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.CorrectAnswers = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {
@@ -3400,6 +3416,10 @@ func (i *InputMediaPoll) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode inputMediaPoll#f94e5f1: field solution_entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.SolutionEntities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_media_gen.go
+++ b/tg/tl_input_media_gen.go
@@ -369,8 +369,8 @@ func (i *InputMediaUploadedPhoto) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputMediaUploadedPhoto#1e287d04: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Stickers = make([]InputDocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Stickers = make([]InputDocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDocument(b)
@@ -1349,8 +1349,8 @@ func (i *InputMediaUploadedDocument) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputMediaUploadedDocument#5b38c6c1: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
@@ -1366,8 +1366,8 @@ func (i *InputMediaUploadedDocument) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputMediaUploadedDocument#5b38c6c1: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Stickers = make([]InputDocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Stickers = make([]InputDocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDocument(b)
@@ -3394,8 +3394,8 @@ func (i *InputMediaPoll) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputMediaPoll#f94e5f1: field correct_answers: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.CorrectAnswers = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			i.CorrectAnswers = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
@@ -3418,8 +3418,8 @@ func (i *InputMediaPoll) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputMediaPoll#f94e5f1: field solution_entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.SolutionEntities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			i.SolutionEntities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_privacy_rule_gen.go
+++ b/tg/tl_input_privacy_rule_gen.go
@@ -361,8 +361,8 @@ func (i *InputPrivacyValueAllowUsers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputPrivacyValueAllowUsers#131cc67f: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
@@ -720,8 +720,8 @@ func (i *InputPrivacyValueDisallowUsers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputPrivacyValueDisallowUsers#90110467: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
@@ -865,8 +865,8 @@ func (i *InputPrivacyValueAllowChatParticipants) DecodeBare(b *bin.Buffer) error
 			return fmt.Errorf("unable to decode inputPrivacyValueAllowChatParticipants#4c81c1ba: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Chats = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			i.Chats = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -1010,8 +1010,8 @@ func (i *InputPrivacyValueDisallowChatParticipants) DecodeBare(b *bin.Buffer) er
 			return fmt.Errorf("unable to decode inputPrivacyValueDisallowChatParticipants#d82363af: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Chats = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			i.Chats = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_input_privacy_rule_gen.go
+++ b/tg/tl_input_privacy_rule_gen.go
@@ -360,6 +360,10 @@ func (i *InputPrivacyValueAllowUsers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputPrivacyValueAllowUsers#131cc67f: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Users = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {
@@ -715,6 +719,10 @@ func (i *InputPrivacyValueDisallowUsers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputPrivacyValueDisallowUsers#90110467: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Users = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {
@@ -856,6 +864,10 @@ func (i *InputPrivacyValueAllowChatParticipants) DecodeBare(b *bin.Buffer) error
 		if err != nil {
 			return fmt.Errorf("unable to decode inputPrivacyValueAllowChatParticipants#4c81c1ba: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Chats = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -996,6 +1008,10 @@ func (i *InputPrivacyValueDisallowChatParticipants) DecodeBare(b *bin.Buffer) er
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode inputPrivacyValueDisallowChatParticipants#d82363af: field chats: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Chats = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_input_secure_value_gen.go
+++ b/tg/tl_input_secure_value_gen.go
@@ -545,8 +545,8 @@ func (i *InputSecureValue) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputSecureValue#db21d0a7: field translation: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Translation = make([]InputSecureFileClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Translation = make([]InputSecureFileClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputSecureFile(b)
@@ -562,8 +562,8 @@ func (i *InputSecureValue) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputSecureValue#db21d0a7: field files: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Files = make([]InputSecureFileClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Files = make([]InputSecureFileClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputSecureFile(b)

--- a/tg/tl_input_secure_value_gen.go
+++ b/tg/tl_input_secure_value_gen.go
@@ -544,6 +544,10 @@ func (i *InputSecureValue) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputSecureValue#db21d0a7: field translation: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Translation = make([]InputSecureFileClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputSecureFile(b)
 			if err != nil {
@@ -556,6 +560,10 @@ func (i *InputSecureValue) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode inputSecureValue#db21d0a7: field files: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Files = make([]InputSecureFileClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputSecureFile(b)

--- a/tg/tl_input_single_media_gen.go
+++ b/tg/tl_input_single_media_gen.go
@@ -280,6 +280,10 @@ func (i *InputSingleMedia) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputSingleMedia#1cc6e91f: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_input_single_media_gen.go
+++ b/tg/tl_input_single_media_gen.go
@@ -281,8 +281,8 @@ func (i *InputSingleMedia) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputSingleMedia#1cc6e91f: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_input_web_document_gen.go
+++ b/tg/tl_input_web_document_gen.go
@@ -232,8 +232,8 @@ func (i *InputWebDocument) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode inputWebDocument#9bed434d: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_input_web_document_gen.go
+++ b/tg/tl_input_web_document_gen.go
@@ -231,6 +231,10 @@ func (i *InputWebDocument) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode inputWebDocument#9bed434d: field attributes: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
 			if err != nil {

--- a/tg/tl_int_vector_gen.go
+++ b/tg/tl_int_vector_gen.go
@@ -142,8 +142,8 @@ func (vec *IntVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<int>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_int_vector_gen.go
+++ b/tg/tl_int_vector_gen.go
@@ -141,6 +141,10 @@ func (vec *IntVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<int>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_invoice_gen.go
+++ b/tg/tl_invoice_gen.go
@@ -528,8 +528,8 @@ func (i *Invoice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode invoice#cd886e0: field prices: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Prices = make([]LabeledPrice, 0, headerLen)
+		if headerLen > 0 {
+			i.Prices = make([]LabeledPrice, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LabeledPrice
@@ -552,8 +552,8 @@ func (i *Invoice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode invoice#cd886e0: field suggested_tip_amounts: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.SuggestedTipAmounts = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			i.SuggestedTipAmounts = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_invoice_gen.go
+++ b/tg/tl_invoice_gen.go
@@ -527,6 +527,10 @@ func (i *Invoice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode invoice#cd886e0: field prices: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Prices = make([]LabeledPrice, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LabeledPrice
 			if err := value.Decode(b); err != nil {
@@ -546,6 +550,10 @@ func (i *Invoice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode invoice#cd886e0: field suggested_tip_amounts: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.SuggestedTipAmounts = make([]int64, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_invoke_after_msgs_gen.go
+++ b/tg/tl_invoke_after_msgs_gen.go
@@ -165,6 +165,10 @@ func (i *InvokeAfterMsgsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode invokeAfterMsgs#3dc4b4f0: field msg_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.MsgIDs = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_invoke_after_msgs_gen.go
+++ b/tg/tl_invoke_after_msgs_gen.go
@@ -166,8 +166,8 @@ func (i *InvokeAfterMsgsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode invokeAfterMsgs#3dc4b4f0: field msg_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.MsgIDs = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			i.MsgIDs = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_json_value_gen.go
+++ b/tg/tl_json_value_gen.go
@@ -655,8 +655,8 @@ func (j *JSONArray) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode jsonArray#f7444763: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			j.Value = make([]JSONValueClass, 0, headerLen)
+		if headerLen > 0 {
+			j.Value = make([]JSONValueClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeJSONValue(b)
@@ -802,8 +802,8 @@ func (j *JSONObject) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode jsonObject#99c1d49d: field value: %w", err)
 		}
 
-		if headerLen != 0 {
-			j.Value = make([]JSONObjectValue, 0, headerLen)
+		if headerLen > 0 {
+			j.Value = make([]JSONObjectValue, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value JSONObjectValue

--- a/tg/tl_json_value_gen.go
+++ b/tg/tl_json_value_gen.go
@@ -654,6 +654,10 @@ func (j *JSONArray) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode jsonArray#f7444763: field value: %w", err)
 		}
+
+		if headerLen != 0 {
+			j.Value = make([]JSONValueClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeJSONValue(b)
 			if err != nil {
@@ -796,6 +800,10 @@ func (j *JSONObject) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode jsonObject#99c1d49d: field value: %w", err)
+		}
+
+		if headerLen != 0 {
+			j.Value = make([]JSONObjectValue, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value JSONObjectValue

--- a/tg/tl_keyboard_button_row_gen.go
+++ b/tg/tl_keyboard_button_row_gen.go
@@ -156,6 +156,10 @@ func (k *KeyboardButtonRow) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode keyboardButtonRow#77608b83: field buttons: %w", err)
 		}
+
+		if headerLen != 0 {
+			k.Buttons = make([]KeyboardButtonClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeKeyboardButton(b)
 			if err != nil {

--- a/tg/tl_keyboard_button_row_gen.go
+++ b/tg/tl_keyboard_button_row_gen.go
@@ -157,8 +157,8 @@ func (k *KeyboardButtonRow) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode keyboardButtonRow#77608b83: field buttons: %w", err)
 		}
 
-		if headerLen != 0 {
-			k.Buttons = make([]KeyboardButtonClass, 0, headerLen)
+		if headerLen > 0 {
+			k.Buttons = make([]KeyboardButtonClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeKeyboardButton(b)

--- a/tg/tl_lang_pack_difference_gen.go
+++ b/tg/tl_lang_pack_difference_gen.go
@@ -229,8 +229,8 @@ func (l *LangPackDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode langPackDifference#f385c1f6: field strings: %w", err)
 		}
 
-		if headerLen != 0 {
-			l.Strings = make([]LangPackStringClass, 0, headerLen)
+		if headerLen > 0 {
+			l.Strings = make([]LangPackStringClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeLangPackString(b)

--- a/tg/tl_lang_pack_difference_gen.go
+++ b/tg/tl_lang_pack_difference_gen.go
@@ -228,6 +228,10 @@ func (l *LangPackDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode langPackDifference#f385c1f6: field strings: %w", err)
 		}
+
+		if headerLen != 0 {
+			l.Strings = make([]LangPackStringClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeLangPackString(b)
 			if err != nil {

--- a/tg/tl_lang_pack_language_vector_gen.go
+++ b/tg/tl_lang_pack_language_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *LangPackLanguageVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<LangPackLanguage>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]LangPackLanguage, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LangPackLanguage
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_lang_pack_language_vector_gen.go
+++ b/tg/tl_lang_pack_language_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *LangPackLanguageVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<LangPackLanguage>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]LangPackLanguage, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]LangPackLanguage, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LangPackLanguage

--- a/tg/tl_lang_pack_string_class_vector_gen.go
+++ b/tg/tl_lang_pack_string_class_vector_gen.go
@@ -152,8 +152,8 @@ func (vec *LangPackStringClassVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<LangPackString>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]LangPackStringClass, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]LangPackStringClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeLangPackString(b)

--- a/tg/tl_lang_pack_string_class_vector_gen.go
+++ b/tg/tl_lang_pack_string_class_vector_gen.go
@@ -151,6 +151,10 @@ func (vec *LangPackStringClassVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<LangPackString>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]LangPackStringClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeLangPackString(b)
 			if err != nil {

--- a/tg/tl_langpack_get_strings_gen.go
+++ b/tg/tl_langpack_get_strings_gen.go
@@ -195,8 +195,8 @@ func (g *LangpackGetStringsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode langpack.getStrings#efea3803: field keys: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Keys = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			g.Keys = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_langpack_get_strings_gen.go
+++ b/tg/tl_langpack_get_strings_gen.go
@@ -194,6 +194,10 @@ func (g *LangpackGetStringsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode langpack.getStrings#efea3803: field keys: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Keys = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {

--- a/tg/tl_long_vector_gen.go
+++ b/tg/tl_long_vector_gen.go
@@ -141,6 +141,10 @@ func (vec *LongVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<long>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_long_vector_gen.go
+++ b/tg/tl_long_vector_gen.go
@@ -142,8 +142,8 @@ func (vec *LongVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<long>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_message_action_gen.go
+++ b/tg/tl_message_action_gen.go
@@ -273,8 +273,8 @@ func (m *MessageActionChatCreate) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageActionChatCreate#a6638b9a: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -789,8 +789,8 @@ func (m *MessageActionChatAddUser) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageActionChatAddUser#488a7337: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -3139,8 +3139,8 @@ func (m *MessageActionSecureValuesSentMe) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageActionSecureValuesSentMe#1b287353: field values: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Values = make([]SecureValue, 0, headerLen)
+		if headerLen > 0 {
+			m.Values = make([]SecureValue, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue
@@ -3302,8 +3302,8 @@ func (m *MessageActionSecureValuesSent) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageActionSecureValuesSent#d95c6154: field types: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Types = make([]SecureValueTypeClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Types = make([]SecureValueTypeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)
@@ -3954,8 +3954,8 @@ func (m *MessageActionInviteToGroupCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageActionInviteToGroupCall#76b9f11a: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_message_action_gen.go
+++ b/tg/tl_message_action_gen.go
@@ -272,6 +272,10 @@ func (m *MessageActionChatCreate) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messageActionChatCreate#a6638b9a: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Users = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -783,6 +787,10 @@ func (m *MessageActionChatAddUser) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messageActionChatAddUser#488a7337: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -3130,6 +3138,10 @@ func (m *MessageActionSecureValuesSentMe) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messageActionSecureValuesSentMe#1b287353: field values: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Values = make([]SecureValue, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue
 			if err := value.Decode(b); err != nil {
@@ -3288,6 +3300,10 @@ func (m *MessageActionSecureValuesSent) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messageActionSecureValuesSent#d95c6154: field types: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Types = make([]SecureValueTypeClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueType(b)
@@ -3936,6 +3952,10 @@ func (m *MessageActionInviteToGroupCall) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messageActionInviteToGroupCall#76b9f11a: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_message_gen.go
+++ b/tg/tl_message_gen.go
@@ -1398,8 +1398,8 @@ func (m *Message) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode message#bce383d2: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -1455,8 +1455,8 @@ func (m *Message) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode message#bce383d2: field restriction_reason: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.RestrictionReason = make([]RestrictionReason, 0, headerLen)
+		if headerLen > 0 {
+			m.RestrictionReason = make([]RestrictionReason, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason

--- a/tg/tl_message_gen.go
+++ b/tg/tl_message_gen.go
@@ -1397,6 +1397,10 @@ func (m *Message) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode message#bce383d2: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -1449,6 +1453,10 @@ func (m *Message) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode message#bce383d2: field restriction_reason: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.RestrictionReason = make([]RestrictionReason, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason

--- a/tg/tl_message_range_vector_gen.go
+++ b/tg/tl_message_range_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *MessageRangeVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<MessageRange>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]MessageRange, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageRange
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_message_range_vector_gen.go
+++ b/tg/tl_message_range_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *MessageRangeVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<MessageRange>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]MessageRange, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]MessageRange, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageRange

--- a/tg/tl_message_replies_gen.go
+++ b/tg/tl_message_replies_gen.go
@@ -405,6 +405,10 @@ func (m *MessageReplies) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messageReplies#4128faac: field recent_repliers: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.RecentRepliers = make([]PeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
 			if err != nil {

--- a/tg/tl_message_replies_gen.go
+++ b/tg/tl_message_replies_gen.go
@@ -406,8 +406,8 @@ func (m *MessageReplies) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageReplies#4128faac: field recent_repliers: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.RecentRepliers = make([]PeerClass, 0, headerLen)
+		if headerLen > 0 {
+			m.RecentRepliers = make([]PeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)

--- a/tg/tl_message_user_vote_gen.go
+++ b/tg/tl_message_user_vote_gen.go
@@ -528,8 +528,8 @@ func (m *MessageUserVoteMultiple) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messageUserVoteMultiple#e8fe0de: field options: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Options = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			m.Options = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()

--- a/tg/tl_message_user_vote_gen.go
+++ b/tg/tl_message_user_vote_gen.go
@@ -527,6 +527,10 @@ func (m *MessageUserVoteMultiple) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messageUserVoteMultiple#e8fe0de: field options: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Options = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {

--- a/tg/tl_messages_affected_found_messages_gen.go
+++ b/tg/tl_messages_affected_found_messages_gen.go
@@ -218,8 +218,8 @@ func (a *MessagesAffectedFoundMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.affectedFoundMessages#ef8d3e6c: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			a.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_affected_found_messages_gen.go
+++ b/tg/tl_messages_affected_found_messages_gen.go
@@ -217,6 +217,10 @@ func (a *MessagesAffectedFoundMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.affectedFoundMessages#ef8d3e6c: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_all_stickers_gen.go
+++ b/tg/tl_messages_all_stickers_gen.go
@@ -278,8 +278,8 @@ func (a *MessagesAllStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.allStickers#edfd405f: field sets: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Sets = make([]StickerSet, 0, headerLen)
+		if headerLen > 0 {
+			a.Sets = make([]StickerSet, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerSet

--- a/tg/tl_messages_all_stickers_gen.go
+++ b/tg/tl_messages_all_stickers_gen.go
@@ -277,6 +277,10 @@ func (a *MessagesAllStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.allStickers#edfd405f: field sets: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Sets = make([]StickerSet, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerSet
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_messages_archived_stickers_gen.go
+++ b/tg/tl_messages_archived_stickers_gen.go
@@ -180,6 +180,10 @@ func (a *MessagesArchivedStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.archivedStickers#4fcba9c8: field sets: %w", err)
 		}
+
+		if headerLen != 0 {
+			a.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
 			if err != nil {

--- a/tg/tl_messages_archived_stickers_gen.go
+++ b/tg/tl_messages_archived_stickers_gen.go
@@ -181,8 +181,8 @@ func (a *MessagesArchivedStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.archivedStickers#4fcba9c8: field sets: %w", err)
 		}
 
-		if headerLen != 0 {
-			a.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		if headerLen > 0 {
+			a.Sets = make([]StickerSetCoveredClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)

--- a/tg/tl_messages_bot_results_gen.go
+++ b/tg/tl_messages_bot_results_gen.go
@@ -366,8 +366,8 @@ func (b *MessagesBotResults) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.botResults#947ca848: field results: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Results = make([]BotInlineResultClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Results = make([]BotInlineResultClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeBotInlineResult(buf)
@@ -390,8 +390,8 @@ func (b *MessagesBotResults) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.botResults#947ca848: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			b.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)

--- a/tg/tl_messages_bot_results_gen.go
+++ b/tg/tl_messages_bot_results_gen.go
@@ -365,6 +365,10 @@ func (b *MessagesBotResults) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.botResults#947ca848: field results: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.Results = make([]BotInlineResultClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeBotInlineResult(buf)
 			if err != nil {
@@ -384,6 +388,10 @@ func (b *MessagesBotResults) DecodeBare(buf *bin.Buffer) error {
 		headerLen, err := buf.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.botResults#947ca848: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			b.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(buf)

--- a/tg/tl_messages_chat_admins_with_invites_gen.go
+++ b/tg/tl_messages_chat_admins_with_invites_gen.go
@@ -178,8 +178,8 @@ func (c *MessagesChatAdminsWithInvites) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatAdminsWithInvites#b69b72d7: field admins: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Admins = make([]ChatAdminWithInvites, 0, headerLen)
+		if headerLen > 0 {
+			c.Admins = make([]ChatAdminWithInvites, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatAdminWithInvites
@@ -195,8 +195,8 @@ func (c *MessagesChatAdminsWithInvites) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatAdminsWithInvites#b69b72d7: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chat_admins_with_invites_gen.go
+++ b/tg/tl_messages_chat_admins_with_invites_gen.go
@@ -177,6 +177,10 @@ func (c *MessagesChatAdminsWithInvites) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatAdminsWithInvites#b69b72d7: field admins: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Admins = make([]ChatAdminWithInvites, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatAdminWithInvites
 			if err := value.Decode(b); err != nil {
@@ -189,6 +193,10 @@ func (c *MessagesChatAdminsWithInvites) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatAdminsWithInvites#b69b72d7: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chat_full_gen.go
+++ b/tg/tl_messages_chat_full_gen.go
@@ -215,6 +215,10 @@ func (c *MessagesChatFull) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatFull#e5d7d19c: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -227,6 +231,10 @@ func (c *MessagesChatFull) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatFull#e5d7d19c: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chat_full_gen.go
+++ b/tg/tl_messages_chat_full_gen.go
@@ -216,8 +216,8 @@ func (c *MessagesChatFull) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatFull#e5d7d19c: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -233,8 +233,8 @@ func (c *MessagesChatFull) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatFull#e5d7d19c: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chat_invite_importers_gen.go
+++ b/tg/tl_messages_chat_invite_importers_gen.go
@@ -201,6 +201,10 @@ func (c *MessagesChatInviteImporters) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatInviteImporters#81b6b00a: field importers: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Importers = make([]ChatInviteImporter, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatInviteImporter
 			if err := value.Decode(b); err != nil {
@@ -213,6 +217,10 @@ func (c *MessagesChatInviteImporters) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatInviteImporters#81b6b00a: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chat_invite_importers_gen.go
+++ b/tg/tl_messages_chat_invite_importers_gen.go
@@ -202,8 +202,8 @@ func (c *MessagesChatInviteImporters) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatInviteImporters#81b6b00a: field importers: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Importers = make([]ChatInviteImporter, 0, headerLen)
+		if headerLen > 0 {
+			c.Importers = make([]ChatInviteImporter, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatInviteImporter
@@ -219,8 +219,8 @@ func (c *MessagesChatInviteImporters) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatInviteImporters#81b6b00a: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_chats_gen.go
+++ b/tg/tl_messages_chats_gen.go
@@ -157,8 +157,8 @@ func (c *MessagesChats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chats#64ff9fd5: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -339,8 +339,8 @@ func (c *MessagesChatsSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.chatsSlice#9cd81144: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)

--- a/tg/tl_messages_chats_gen.go
+++ b/tg/tl_messages_chats_gen.go
@@ -156,6 +156,10 @@ func (c *MessagesChats) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chats#64ff9fd5: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -333,6 +337,10 @@ func (c *MessagesChatsSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.chatsSlice#9cd81144: field chats: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)

--- a/tg/tl_messages_create_chat_gen.go
+++ b/tg/tl_messages_create_chat_gen.go
@@ -174,8 +174,8 @@ func (c *MessagesCreateChatRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.createChat#9cb126e: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_messages_create_chat_gen.go
+++ b/tg/tl_messages_create_chat_gen.go
@@ -173,6 +173,10 @@ func (c *MessagesCreateChatRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.createChat#9cb126e: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Users = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_messages_delete_messages_gen.go
+++ b/tg/tl_messages_delete_messages_gen.go
@@ -194,6 +194,10 @@ func (d *MessagesDeleteMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.deleteMessages#e58e95d2: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_delete_messages_gen.go
+++ b/tg/tl_messages_delete_messages_gen.go
@@ -195,8 +195,8 @@ func (d *MessagesDeleteMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.deleteMessages#e58e95d2: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			d.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_delete_scheduled_messages_gen.go
+++ b/tg/tl_messages_delete_scheduled_messages_gen.go
@@ -176,8 +176,8 @@ func (d *MessagesDeleteScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error
 			return fmt.Errorf("unable to decode messages.deleteScheduledMessages#59ae2b16: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			d.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_delete_scheduled_messages_gen.go
+++ b/tg/tl_messages_delete_scheduled_messages_gen.go
@@ -175,6 +175,10 @@ func (d *MessagesDeleteScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.deleteScheduledMessages#59ae2b16: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_dialogs_gen.go
+++ b/tg/tl_messages_dialogs_gen.go
@@ -246,6 +246,10 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field dialogs: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Dialogs = make([]DialogClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
 			if err != nil {
@@ -258,6 +262,10 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Messages = make([]MessageClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -272,6 +280,10 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -284,6 +296,10 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -550,6 +566,10 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field dialogs: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Dialogs = make([]DialogClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
 			if err != nil {
@@ -562,6 +582,10 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Messages = make([]MessageClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -576,6 +600,10 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -588,6 +616,10 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_dialogs_gen.go
+++ b/tg/tl_messages_dialogs_gen.go
@@ -247,8 +247,8 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field dialogs: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Dialogs = make([]DialogClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Dialogs = make([]DialogClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
@@ -264,8 +264,8 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -281,8 +281,8 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -298,8 +298,8 @@ func (d *MessagesDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogs#15ba6c40: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -567,8 +567,8 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field dialogs: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Dialogs = make([]DialogClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Dialogs = make([]DialogClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
@@ -584,8 +584,8 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -601,8 +601,8 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -618,8 +618,8 @@ func (d *MessagesDialogsSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.dialogsSlice#71e094f3: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_discussion_message_gen.go
+++ b/tg/tl_messages_discussion_message_gen.go
@@ -359,8 +359,8 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -397,8 +397,8 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -414,8 +414,8 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_discussion_message_gen.go
+++ b/tg/tl_messages_discussion_message_gen.go
@@ -358,6 +358,10 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Messages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -392,6 +396,10 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -404,6 +412,10 @@ func (d *MessagesDiscussionMessage) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.discussionMessage#f5dd8f9d: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_edit_inline_bot_message_gen.go
+++ b/tg/tl_messages_edit_inline_bot_message_gen.go
@@ -400,6 +400,10 @@ func (e *MessagesEditInlineBotMessageRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.editInlineBotMessage#83557dba: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_edit_inline_bot_message_gen.go
+++ b/tg/tl_messages_edit_inline_bot_message_gen.go
@@ -401,8 +401,8 @@ func (e *MessagesEditInlineBotMessageRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.editInlineBotMessage#83557dba: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_edit_message_gen.go
+++ b/tg/tl_messages_edit_message_gen.go
@@ -471,8 +471,8 @@ func (e *MessagesEditMessageRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.editMessage#48f71778: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_edit_message_gen.go
+++ b/tg/tl_messages_edit_message_gen.go
@@ -470,6 +470,10 @@ func (e *MessagesEditMessageRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.editMessage#48f71778: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_exported_chat_invite_gen.go
+++ b/tg/tl_messages_exported_chat_invite_gen.go
@@ -180,8 +180,8 @@ func (e *MessagesExportedChatInvite) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.exportedChatInvite#1871be50: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -382,8 +382,8 @@ func (e *MessagesExportedChatInviteReplaced) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.exportedChatInviteReplaced#222600ef: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_exported_chat_invite_gen.go
+++ b/tg/tl_messages_exported_chat_invite_gen.go
@@ -179,6 +179,10 @@ func (e *MessagesExportedChatInvite) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.exportedChatInvite#1871be50: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {
@@ -376,6 +380,10 @@ func (e *MessagesExportedChatInviteReplaced) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.exportedChatInviteReplaced#222600ef: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			e.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_exported_chat_invites_gen.go
+++ b/tg/tl_messages_exported_chat_invites_gen.go
@@ -201,6 +201,10 @@ func (e *MessagesExportedChatInvites) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.exportedChatInvites#bdc62dcc: field invites: %w", err)
 		}
+
+		if headerLen != 0 {
+			e.Invites = make([]ChatInviteExported, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatInviteExported
 			if err := value.Decode(b); err != nil {
@@ -213,6 +217,10 @@ func (e *MessagesExportedChatInvites) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.exportedChatInvites#bdc62dcc: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			e.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_exported_chat_invites_gen.go
+++ b/tg/tl_messages_exported_chat_invites_gen.go
@@ -202,8 +202,8 @@ func (e *MessagesExportedChatInvites) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.exportedChatInvites#bdc62dcc: field invites: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Invites = make([]ChatInviteExported, 0, headerLen)
+		if headerLen > 0 {
+			e.Invites = make([]ChatInviteExported, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ChatInviteExported
@@ -219,8 +219,8 @@ func (e *MessagesExportedChatInvites) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.exportedChatInvites#bdc62dcc: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			e.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			e.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_faved_stickers_gen.go
+++ b/tg/tl_messages_faved_stickers_gen.go
@@ -307,6 +307,10 @@ func (f *MessagesFavedStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.favedStickers#f37f2f16: field packs: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.Packs = make([]StickerPack, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
 			if err := value.Decode(b); err != nil {
@@ -319,6 +323,10 @@ func (f *MessagesFavedStickers) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.favedStickers#f37f2f16: field stickers: %w", err)
+		}
+
+		if headerLen != 0 {
+			f.Stickers = make([]DocumentClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_faved_stickers_gen.go
+++ b/tg/tl_messages_faved_stickers_gen.go
@@ -308,8 +308,8 @@ func (f *MessagesFavedStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.favedStickers#f37f2f16: field packs: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Packs = make([]StickerPack, 0, headerLen)
+		if headerLen > 0 {
+			f.Packs = make([]StickerPack, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
@@ -325,8 +325,8 @@ func (f *MessagesFavedStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.favedStickers#f37f2f16: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Stickers = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Stickers = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_featured_stickers_gen.go
+++ b/tg/tl_messages_featured_stickers_gen.go
@@ -359,6 +359,10 @@ func (f *MessagesFeaturedStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.featuredStickers#b6abc341: field sets: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
 			if err != nil {
@@ -371,6 +375,10 @@ func (f *MessagesFeaturedStickers) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.featuredStickers#b6abc341: field unread: %w", err)
+		}
+
+		if headerLen != 0 {
+			f.Unread = make([]int64, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_featured_stickers_gen.go
+++ b/tg/tl_messages_featured_stickers_gen.go
@@ -360,8 +360,8 @@ func (f *MessagesFeaturedStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.featuredStickers#b6abc341: field sets: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Sets = make([]StickerSetCoveredClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
@@ -377,8 +377,8 @@ func (f *MessagesFeaturedStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.featuredStickers#b6abc341: field unread: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Unread = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			f.Unread = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_forward_messages_gen.go
+++ b/tg/tl_messages_forward_messages_gen.go
@@ -369,8 +369,8 @@ func (f *MessagesForwardMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.forwardMessages#d9fee60e: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			f.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -386,8 +386,8 @@ func (f *MessagesForwardMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.forwardMessages#d9fee60e: field random_id: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.RandomID = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			f.RandomID = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_forward_messages_gen.go
+++ b/tg/tl_messages_forward_messages_gen.go
@@ -368,6 +368,10 @@ func (f *MessagesForwardMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.forwardMessages#d9fee60e: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -380,6 +384,10 @@ func (f *MessagesForwardMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.forwardMessages#d9fee60e: field random_id: %w", err)
+		}
+
+		if headerLen != 0 {
+			f.RandomID = make([]int64, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_found_sticker_sets_gen.go
+++ b/tg/tl_messages_found_sticker_sets_gen.go
@@ -286,8 +286,8 @@ func (f *MessagesFoundStickerSets) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.foundStickerSets#5108d648: field sets: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		if headerLen > 0 {
+			f.Sets = make([]StickerSetCoveredClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)

--- a/tg/tl_messages_found_sticker_sets_gen.go
+++ b/tg/tl_messages_found_sticker_sets_gen.go
@@ -285,6 +285,10 @@ func (f *MessagesFoundStickerSets) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.foundStickerSets#5108d648: field sets: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
 			if err != nil {

--- a/tg/tl_messages_get_all_chats_gen.go
+++ b/tg/tl_messages_get_all_chats_gen.go
@@ -147,8 +147,8 @@ func (g *MessagesGetAllChatsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getAllChats#eba80ff0: field except_ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ExceptIDs = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.ExceptIDs = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_get_all_chats_gen.go
+++ b/tg/tl_messages_get_all_chats_gen.go
@@ -146,6 +146,10 @@ func (g *MessagesGetAllChatsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getAllChats#eba80ff0: field except_ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ExceptIDs = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_get_chats_gen.go
+++ b/tg/tl_messages_get_chats_gen.go
@@ -147,8 +147,8 @@ func (g *MessagesGetChatsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getChats#3c6aa187: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_get_chats_gen.go
+++ b/tg/tl_messages_get_chats_gen.go
@@ -146,6 +146,10 @@ func (g *MessagesGetChatsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getChats#3c6aa187: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_get_emoji_keywords_languages_gen.go
+++ b/tg/tl_messages_get_emoji_keywords_languages_gen.go
@@ -147,8 +147,8 @@ func (g *MessagesGetEmojiKeywordsLanguagesRequest) DecodeBare(b *bin.Buffer) err
 			return fmt.Errorf("unable to decode messages.getEmojiKeywordsLanguages#4e9963b2: field lang_codes: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.LangCodes = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			g.LangCodes = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_messages_get_emoji_keywords_languages_gen.go
+++ b/tg/tl_messages_get_emoji_keywords_languages_gen.go
@@ -146,6 +146,10 @@ func (g *MessagesGetEmojiKeywordsLanguagesRequest) DecodeBare(b *bin.Buffer) err
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getEmojiKeywordsLanguages#4e9963b2: field lang_codes: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.LangCodes = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {

--- a/tg/tl_messages_get_messages_gen.go
+++ b/tg/tl_messages_get_messages_gen.go
@@ -157,8 +157,8 @@ func (g *MessagesGetMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getMessages#63c66506: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]InputMessageClass, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]InputMessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputMessage(b)

--- a/tg/tl_messages_get_messages_gen.go
+++ b/tg/tl_messages_get_messages_gen.go
@@ -156,6 +156,10 @@ func (g *MessagesGetMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getMessages#63c66506: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]InputMessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputMessage(b)
 			if err != nil {

--- a/tg/tl_messages_get_messages_views_gen.go
+++ b/tg/tl_messages_get_messages_views_gen.go
@@ -196,8 +196,8 @@ func (g *MessagesGetMessagesViewsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getMessagesViews#5784d3e1: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_get_messages_views_gen.go
+++ b/tg/tl_messages_get_messages_views_gen.go
@@ -195,6 +195,10 @@ func (g *MessagesGetMessagesViewsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getMessagesViews#5784d3e1: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_get_peer_dialogs_gen.go
+++ b/tg/tl_messages_get_peer_dialogs_gen.go
@@ -156,6 +156,10 @@ func (g *MessagesGetPeerDialogsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getPeerDialogs#e470bcfd: field peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Peers = make([]InputDialogPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDialogPeer(b)
 			if err != nil {

--- a/tg/tl_messages_get_peer_dialogs_gen.go
+++ b/tg/tl_messages_get_peer_dialogs_gen.go
@@ -157,8 +157,8 @@ func (g *MessagesGetPeerDialogsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getPeerDialogs#e470bcfd: field peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Peers = make([]InputDialogPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Peers = make([]InputDialogPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDialogPeer(b)

--- a/tg/tl_messages_get_scheduled_messages_gen.go
+++ b/tg/tl_messages_get_scheduled_messages_gen.go
@@ -175,6 +175,10 @@ func (g *MessagesGetScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getScheduledMessages#bdbb0464: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_get_scheduled_messages_gen.go
+++ b/tg/tl_messages_get_scheduled_messages_gen.go
@@ -176,8 +176,8 @@ func (g *MessagesGetScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getScheduledMessages#bdbb0464: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_get_search_counters_gen.go
+++ b/tg/tl_messages_get_search_counters_gen.go
@@ -190,8 +190,8 @@ func (g *MessagesGetSearchCountersRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getSearchCounters#732eef00: field filters: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Filters = make([]MessagesFilterClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Filters = make([]MessagesFilterClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessagesFilter(b)

--- a/tg/tl_messages_get_search_counters_gen.go
+++ b/tg/tl_messages_get_search_counters_gen.go
@@ -189,6 +189,10 @@ func (g *MessagesGetSearchCountersRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getSearchCounters#732eef00: field filters: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Filters = make([]MessagesFilterClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessagesFilter(b)
 			if err != nil {

--- a/tg/tl_messages_get_web_page_preview_gen.go
+++ b/tg/tl_messages_get_web_page_preview_gen.go
@@ -224,8 +224,8 @@ func (g *MessagesGetWebPagePreviewRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.getWebPagePreview#8b68b0cc: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_get_web_page_preview_gen.go
+++ b/tg/tl_messages_get_web_page_preview_gen.go
@@ -223,6 +223,10 @@ func (g *MessagesGetWebPagePreviewRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.getWebPagePreview#8b68b0cc: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_high_scores_gen.go
+++ b/tg/tl_messages_high_scores_gen.go
@@ -179,8 +179,8 @@ func (h *MessagesHighScores) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.highScores#9a3bfd99: field scores: %w", err)
 		}
 
-		if headerLen != 0 {
-			h.Scores = make([]HighScore, 0, headerLen)
+		if headerLen > 0 {
+			h.Scores = make([]HighScore, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HighScore
@@ -196,8 +196,8 @@ func (h *MessagesHighScores) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.highScores#9a3bfd99: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			h.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			h.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_high_scores_gen.go
+++ b/tg/tl_messages_high_scores_gen.go
@@ -178,6 +178,10 @@ func (h *MessagesHighScores) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.highScores#9a3bfd99: field scores: %w", err)
 		}
+
+		if headerLen != 0 {
+			h.Scores = make([]HighScore, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value HighScore
 			if err := value.Decode(b); err != nil {
@@ -190,6 +194,10 @@ func (h *MessagesHighScores) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.highScores#9a3bfd99: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			h.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_inactive_chats_gen.go
+++ b/tg/tl_messages_inactive_chats_gen.go
@@ -206,6 +206,10 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field dates: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Dates = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -219,6 +223,10 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -231,6 +239,10 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			i.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_inactive_chats_gen.go
+++ b/tg/tl_messages_inactive_chats_gen.go
@@ -207,8 +207,8 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field dates: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Dates = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			i.Dates = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -224,8 +224,8 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -241,8 +241,8 @@ func (i *MessagesInactiveChats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.inactiveChats#a927fec5: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_message_views_gen.go
+++ b/tg/tl_messages_message_views_gen.go
@@ -208,6 +208,10 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field views: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Views = make([]MessageViews, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageViews
 			if err := value.Decode(b); err != nil {
@@ -221,6 +225,10 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -233,6 +241,10 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_message_views_gen.go
+++ b/tg/tl_messages_message_views_gen.go
@@ -209,8 +209,8 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field views: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Views = make([]MessageViews, 0, headerLen)
+		if headerLen > 0 {
+			m.Views = make([]MessageViews, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageViews
@@ -226,8 +226,8 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -243,8 +243,8 @@ func (m *MessagesMessageViews) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messageViews#b6c4f543: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_messages_gen.go
+++ b/tg/tl_messages_messages_gen.go
@@ -217,8 +217,8 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -234,8 +234,8 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -251,8 +251,8 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -634,8 +634,8 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -651,8 +651,8 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -668,8 +668,8 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -1030,8 +1030,8 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -1047,8 +1047,8 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -1064,8 +1064,8 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_messages_gen.go
+++ b/tg/tl_messages_messages_gen.go
@@ -216,6 +216,10 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Messages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -229,6 +233,10 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -241,6 +249,10 @@ func (m *MessagesMessages) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messages#8c718e87: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -621,6 +633,10 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Messages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -634,6 +650,10 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -646,6 +666,10 @@ func (m *MessagesMessagesSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.messagesSlice#3a54685e: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -1005,6 +1029,10 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Messages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -1018,6 +1046,10 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -1030,6 +1062,10 @@ func (c *MessagesChannelMessages) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.channelMessages#64479808: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_peer_dialogs_gen.go
+++ b/tg/tl_messages_peer_dialogs_gen.go
@@ -268,6 +268,10 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field dialogs: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Dialogs = make([]DialogClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
 			if err != nil {
@@ -280,6 +284,10 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Messages = make([]MessageClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -294,6 +302,10 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -306,6 +318,10 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_peer_dialogs_gen.go
+++ b/tg/tl_messages_peer_dialogs_gen.go
@@ -269,8 +269,8 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field dialogs: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Dialogs = make([]DialogClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Dialogs = make([]DialogClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialog(b)
@@ -286,8 +286,8 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -303,8 +303,8 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -320,8 +320,8 @@ func (p *MessagesPeerDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.peerDialogs#3371c354: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_read_featured_stickers_gen.go
+++ b/tg/tl_messages_read_featured_stickers_gen.go
@@ -147,8 +147,8 @@ func (r *MessagesReadFeaturedStickersRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.readFeaturedStickers#5b118126: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ID = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			r.ID = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_read_featured_stickers_gen.go
+++ b/tg/tl_messages_read_featured_stickers_gen.go
@@ -146,6 +146,10 @@ func (r *MessagesReadFeaturedStickersRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.readFeaturedStickers#5b118126: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ID = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_messages_read_message_contents_gen.go
+++ b/tg/tl_messages_read_message_contents_gen.go
@@ -147,6 +147,10 @@ func (r *MessagesReadMessageContentsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.readMessageContents#36a73f77: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_read_message_contents_gen.go
+++ b/tg/tl_messages_read_message_contents_gen.go
@@ -148,8 +148,8 @@ func (r *MessagesReadMessageContentsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.readMessageContents#36a73f77: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_recent_stickers_gen.go
+++ b/tg/tl_messages_recent_stickers_gen.go
@@ -328,8 +328,8 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field packs: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Packs = make([]StickerPack, 0, headerLen)
+		if headerLen > 0 {
+			r.Packs = make([]StickerPack, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
@@ -345,8 +345,8 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Stickers = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Stickers = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
@@ -362,8 +362,8 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field dates: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Dates = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.Dates = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_recent_stickers_gen.go
+++ b/tg/tl_messages_recent_stickers_gen.go
@@ -327,6 +327,10 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field packs: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Packs = make([]StickerPack, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
 			if err := value.Decode(b); err != nil {
@@ -340,6 +344,10 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field stickers: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Stickers = make([]DocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
 			if err != nil {
@@ -352,6 +360,10 @@ func (r *MessagesRecentStickers) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.recentStickers#22f3afb3: field dates: %w", err)
+		}
+
+		if headerLen != 0 {
+			r.Dates = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_reorder_pinned_dialogs_gen.go
+++ b/tg/tl_messages_reorder_pinned_dialogs_gen.go
@@ -232,8 +232,8 @@ func (r *MessagesReorderPinnedDialogsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.reorderPinnedDialogs#3b1adf37: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Order = make([]InputDialogPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			r.Order = make([]InputDialogPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDialogPeer(b)

--- a/tg/tl_messages_reorder_pinned_dialogs_gen.go
+++ b/tg/tl_messages_reorder_pinned_dialogs_gen.go
@@ -231,6 +231,10 @@ func (r *MessagesReorderPinnedDialogsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.reorderPinnedDialogs#3b1adf37: field order: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Order = make([]InputDialogPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputDialogPeer(b)
 			if err != nil {

--- a/tg/tl_messages_reorder_sticker_sets_gen.go
+++ b/tg/tl_messages_reorder_sticker_sets_gen.go
@@ -195,8 +195,8 @@ func (r *MessagesReorderStickerSetsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.reorderStickerSets#78337739: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Order = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			r.Order = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_messages_reorder_sticker_sets_gen.go
+++ b/tg/tl_messages_reorder_sticker_sets_gen.go
@@ -194,6 +194,10 @@ func (r *MessagesReorderStickerSetsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.reorderStickerSets#78337739: field order: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Order = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_messages_report_gen.go
+++ b/tg/tl_messages_report_gen.go
@@ -214,6 +214,10 @@ func (r *MessagesReportRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.report#8953ab4e: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_report_gen.go
+++ b/tg/tl_messages_report_gen.go
@@ -215,8 +215,8 @@ func (r *MessagesReportRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.report#8953ab4e: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			r.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_save_draft_gen.go
+++ b/tg/tl_messages_save_draft_gen.go
@@ -333,8 +333,8 @@ func (s *MessagesSaveDraftRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.saveDraft#bc39e14b: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_save_draft_gen.go
+++ b/tg/tl_messages_save_draft_gen.go
@@ -332,6 +332,10 @@ func (s *MessagesSaveDraftRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.saveDraft#bc39e14b: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_saved_gifs_gen.go
+++ b/tg/tl_messages_saved_gifs_gen.go
@@ -285,6 +285,10 @@ func (s *MessagesSavedGifs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.savedGifs#2e0709a5: field gifs: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Gifs = make([]DocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
 			if err != nil {

--- a/tg/tl_messages_saved_gifs_gen.go
+++ b/tg/tl_messages_saved_gifs_gen.go
@@ -286,8 +286,8 @@ func (s *MessagesSavedGifs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.savedGifs#2e0709a5: field gifs: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Gifs = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Gifs = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_search_counter_vector_gen.go
+++ b/tg/tl_messages_search_counter_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *MessagesSearchCounterVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<messages.SearchCounter>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]MessagesSearchCounter, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessagesSearchCounter
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_messages_search_counter_vector_gen.go
+++ b/tg/tl_messages_search_counter_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *MessagesSearchCounterVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<messages.SearchCounter>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]MessagesSearchCounter, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]MessagesSearchCounter, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessagesSearchCounter

--- a/tg/tl_messages_send_media_gen.go
+++ b/tg/tl_messages_send_media_gen.go
@@ -538,8 +538,8 @@ func (s *MessagesSendMediaRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.sendMedia#3491eba9: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_send_media_gen.go
+++ b/tg/tl_messages_send_media_gen.go
@@ -537,6 +537,10 @@ func (s *MessagesSendMediaRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.sendMedia#3491eba9: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_send_message_gen.go
+++ b/tg/tl_messages_send_message_gen.go
@@ -541,8 +541,8 @@ func (s *MessagesSendMessageRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.sendMessage#520c3870: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_messages_send_message_gen.go
+++ b/tg/tl_messages_send_message_gen.go
@@ -540,6 +540,10 @@ func (s *MessagesSendMessageRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.sendMessage#520c3870: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {

--- a/tg/tl_messages_send_multi_media_gen.go
+++ b/tg/tl_messages_send_multi_media_gen.go
@@ -378,6 +378,10 @@ func (s *MessagesSendMultiMediaRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.sendMultiMedia#cc0110cb: field multi_media: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.MultiMedia = make([]InputSingleMedia, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputSingleMedia
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_messages_send_multi_media_gen.go
+++ b/tg/tl_messages_send_multi_media_gen.go
@@ -379,8 +379,8 @@ func (s *MessagesSendMultiMediaRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.sendMultiMedia#cc0110cb: field multi_media: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.MultiMedia = make([]InputSingleMedia, 0, headerLen)
+		if headerLen > 0 {
+			s.MultiMedia = make([]InputSingleMedia, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputSingleMedia

--- a/tg/tl_messages_send_scheduled_messages_gen.go
+++ b/tg/tl_messages_send_scheduled_messages_gen.go
@@ -175,6 +175,10 @@ func (s *MessagesSendScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.sendScheduledMessages#bd38850a: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.ID = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_send_scheduled_messages_gen.go
+++ b/tg/tl_messages_send_scheduled_messages_gen.go
@@ -176,8 +176,8 @@ func (s *MessagesSendScheduledMessagesRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.sendScheduledMessages#bd38850a: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.ID = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			s.ID = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_send_vote_gen.go
+++ b/tg/tl_messages_send_vote_gen.go
@@ -203,8 +203,8 @@ func (s *MessagesSendVoteRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.sendVote#10ea6184: field options: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Options = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			s.Options = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()

--- a/tg/tl_messages_send_vote_gen.go
+++ b/tg/tl_messages_send_vote_gen.go
@@ -202,6 +202,10 @@ func (s *MessagesSendVoteRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.sendVote#10ea6184: field options: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Options = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {

--- a/tg/tl_messages_set_bot_shipping_results_gen.go
+++ b/tg/tl_messages_set_bot_shipping_results_gen.go
@@ -262,8 +262,8 @@ func (s *MessagesSetBotShippingResultsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.setBotShippingResults#e5f672fa: field shipping_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.ShippingOptions = make([]ShippingOption, 0, headerLen)
+		if headerLen > 0 {
+			s.ShippingOptions = make([]ShippingOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ShippingOption

--- a/tg/tl_messages_set_bot_shipping_results_gen.go
+++ b/tg/tl_messages_set_bot_shipping_results_gen.go
@@ -261,6 +261,10 @@ func (s *MessagesSetBotShippingResultsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.setBotShippingResults#e5f672fa: field shipping_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.ShippingOptions = make([]ShippingOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ShippingOption
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_messages_set_inline_bot_results_gen.go
+++ b/tg/tl_messages_set_inline_bot_results_gen.go
@@ -361,8 +361,8 @@ func (s *MessagesSetInlineBotResultsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.setInlineBotResults#eb5ea206: field results: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Results = make([]InputBotInlineResultClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Results = make([]InputBotInlineResultClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputBotInlineResult(b)

--- a/tg/tl_messages_set_inline_bot_results_gen.go
+++ b/tg/tl_messages_set_inline_bot_results_gen.go
@@ -360,6 +360,10 @@ func (s *MessagesSetInlineBotResultsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.setInlineBotResults#eb5ea206: field results: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Results = make([]InputBotInlineResultClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputBotInlineResult(b)
 			if err != nil {

--- a/tg/tl_messages_sticker_set_gen.go
+++ b/tg/tl_messages_sticker_set_gen.go
@@ -202,6 +202,10 @@ func (s *MessagesStickerSet) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.stickerSet#b60a24a6: field packs: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Packs = make([]StickerPack, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
 			if err := value.Decode(b); err != nil {
@@ -214,6 +218,10 @@ func (s *MessagesStickerSet) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.stickerSet#b60a24a6: field documents: %w", err)
+		}
+
+		if headerLen != 0 {
+			s.Documents = make([]DocumentClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_sticker_set_gen.go
+++ b/tg/tl_messages_sticker_set_gen.go
@@ -203,8 +203,8 @@ func (s *MessagesStickerSet) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.stickerSet#b60a24a6: field packs: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Packs = make([]StickerPack, 0, headerLen)
+		if headerLen > 0 {
+			s.Packs = make([]StickerPack, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StickerPack
@@ -220,8 +220,8 @@ func (s *MessagesStickerSet) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.stickerSet#b60a24a6: field documents: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Documents = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Documents = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_sticker_set_install_result_gen.go
+++ b/tg/tl_messages_sticker_set_install_result_gen.go
@@ -262,8 +262,8 @@ func (s *MessagesStickerSetInstallResultArchive) DecodeBare(b *bin.Buffer) error
 			return fmt.Errorf("unable to decode messages.stickerSetInstallResultArchive#35e410a8: field sets: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Sets = make([]StickerSetCoveredClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)

--- a/tg/tl_messages_sticker_set_install_result_gen.go
+++ b/tg/tl_messages_sticker_set_install_result_gen.go
@@ -261,6 +261,10 @@ func (s *MessagesStickerSetInstallResultArchive) DecodeBare(b *bin.Buffer) error
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.stickerSetInstallResultArchive#35e410a8: field sets: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Sets = make([]StickerSetCoveredClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
 			if err != nil {

--- a/tg/tl_messages_stickers_gen.go
+++ b/tg/tl_messages_stickers_gen.go
@@ -285,6 +285,10 @@ func (s *MessagesStickers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.stickers#e4599bbd: field stickers: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Stickers = make([]DocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
 			if err != nil {

--- a/tg/tl_messages_stickers_gen.go
+++ b/tg/tl_messages_stickers_gen.go
@@ -286,8 +286,8 @@ func (s *MessagesStickers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.stickers#e4599bbd: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Stickers = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Stickers = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_messages_toggle_sticker_sets_gen.go
+++ b/tg/tl_messages_toggle_sticker_sets_gen.go
@@ -269,8 +269,8 @@ func (t *MessagesToggleStickerSetsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.toggleStickerSets#b5052fea: field stickersets: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Stickersets = make([]InputStickerSetClass, 0, headerLen)
+		if headerLen > 0 {
+			t.Stickersets = make([]InputStickerSetClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputStickerSet(b)

--- a/tg/tl_messages_toggle_sticker_sets_gen.go
+++ b/tg/tl_messages_toggle_sticker_sets_gen.go
@@ -268,6 +268,10 @@ func (t *MessagesToggleStickerSetsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.toggleStickerSets#b5052fea: field stickersets: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Stickersets = make([]InputStickerSetClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputStickerSet(b)
 			if err != nil {

--- a/tg/tl_messages_update_dialog_filters_order_gen.go
+++ b/tg/tl_messages_update_dialog_filters_order_gen.go
@@ -152,6 +152,10 @@ func (u *MessagesUpdateDialogFiltersOrderRequest) DecodeBare(b *bin.Buffer) erro
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.updateDialogFiltersOrder#c563c1e4: field order: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Order = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_messages_update_dialog_filters_order_gen.go
+++ b/tg/tl_messages_update_dialog_filters_order_gen.go
@@ -153,8 +153,8 @@ func (u *MessagesUpdateDialogFiltersOrderRequest) DecodeBare(b *bin.Buffer) erro
 			return fmt.Errorf("unable to decode messages.updateDialogFiltersOrder#c563c1e4: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Order = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Order = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_messages_votes_list_gen.go
+++ b/tg/tl_messages_votes_list_gen.go
@@ -273,8 +273,8 @@ func (v *MessagesVotesList) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.votesList#823f649: field votes: %w", err)
 		}
 
-		if headerLen != 0 {
-			v.Votes = make([]MessageUserVoteClass, 0, headerLen)
+		if headerLen > 0 {
+			v.Votes = make([]MessageUserVoteClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageUserVote(b)
@@ -290,8 +290,8 @@ func (v *MessagesVotesList) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode messages.votesList#823f649: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			v.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			v.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_messages_votes_list_gen.go
+++ b/tg/tl_messages_votes_list_gen.go
@@ -272,6 +272,10 @@ func (v *MessagesVotesList) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.votesList#823f649: field votes: %w", err)
 		}
+
+		if headerLen != 0 {
+			v.Votes = make([]MessageUserVoteClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageUserVote(b)
 			if err != nil {
@@ -284,6 +288,10 @@ func (v *MessagesVotesList) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode messages.votesList#823f649: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			v.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_page_block_gen.go
+++ b/tg/tl_page_block_gen.go
@@ -1636,6 +1636,10 @@ func (p *PageBlockList) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockList#e4e88011: field items: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Items = make([]PageListItemClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageListItem(b)
 			if err != nil {
@@ -3330,6 +3334,10 @@ func (p *PageBlockEmbedPost) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockEmbedPost#f259a80b: field blocks: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {
@@ -3505,6 +3513,10 @@ func (p *PageBlockCollage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockCollage#65a0fa4d: field items: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Items = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {
@@ -3679,6 +3691,10 @@ func (p *PageBlockSlideshow) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockSlideshow#31f9590: field items: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Items = make([]PageBlockClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -4370,6 +4386,10 @@ func (p *PageBlockTable) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockTable#bf4dea82: field rows: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Rows = make([]PageTableRow, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageTableRow
 			if err := value.Decode(b); err != nil {
@@ -4520,6 +4540,10 @@ func (p *PageBlockOrderedList) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockOrderedList#9a8ae1e1: field items: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Items = make([]PageListOrderedItemClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageListOrderedItem(b)
@@ -4742,6 +4766,10 @@ func (p *PageBlockDetails) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockDetails#76768bed: field blocks: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {
@@ -4920,6 +4948,10 @@ func (p *PageBlockRelatedArticles) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode pageBlockRelatedArticles#16115a96: field articles: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Articles = make([]PageRelatedArticle, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageRelatedArticle

--- a/tg/tl_page_block_gen.go
+++ b/tg/tl_page_block_gen.go
@@ -1637,8 +1637,8 @@ func (p *PageBlockList) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockList#e4e88011: field items: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Items = make([]PageListItemClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Items = make([]PageListItemClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageListItem(b)
@@ -3335,8 +3335,8 @@ func (p *PageBlockEmbedPost) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockEmbedPost#f259a80b: field blocks: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -3514,8 +3514,8 @@ func (p *PageBlockCollage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockCollage#65a0fa4d: field items: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Items = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Items = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -3693,8 +3693,8 @@ func (p *PageBlockSlideshow) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockSlideshow#31f9590: field items: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Items = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Items = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -4387,8 +4387,8 @@ func (p *PageBlockTable) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockTable#bf4dea82: field rows: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Rows = make([]PageTableRow, 0, headerLen)
+		if headerLen > 0 {
+			p.Rows = make([]PageTableRow, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageTableRow
@@ -4542,8 +4542,8 @@ func (p *PageBlockOrderedList) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockOrderedList#9a8ae1e1: field items: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Items = make([]PageListOrderedItemClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Items = make([]PageListOrderedItemClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageListOrderedItem(b)
@@ -4767,8 +4767,8 @@ func (p *PageBlockDetails) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockDetails#76768bed: field blocks: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -4950,8 +4950,8 @@ func (p *PageBlockRelatedArticles) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageBlockRelatedArticles#16115a96: field articles: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Articles = make([]PageRelatedArticle, 0, headerLen)
+		if headerLen > 0 {
+			p.Articles = make([]PageRelatedArticle, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageRelatedArticle

--- a/tg/tl_page_gen.go
+++ b/tg/tl_page_gen.go
@@ -401,8 +401,8 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode page#98657f0d: field blocks: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
@@ -418,8 +418,8 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode page#98657f0d: field photos: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Photos = make([]PhotoClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
@@ -435,8 +435,8 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode page#98657f0d: field documents: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Documents = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Documents = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_page_gen.go
+++ b/tg/tl_page_gen.go
@@ -400,6 +400,10 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode page#98657f0d: field blocks: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {
@@ -413,6 +417,10 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode page#98657f0d: field photos: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
 			if err != nil {
@@ -425,6 +433,10 @@ func (p *Page) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode page#98657f0d: field documents: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Documents = make([]DocumentClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_page_list_item_gen.go
+++ b/tg/tl_page_list_item_gen.go
@@ -293,6 +293,10 @@ func (p *PageListItemBlocks) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageListItemBlocks#25e073fc: field blocks: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {

--- a/tg/tl_page_list_item_gen.go
+++ b/tg/tl_page_list_item_gen.go
@@ -294,8 +294,8 @@ func (p *PageListItemBlocks) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageListItemBlocks#25e073fc: field blocks: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)

--- a/tg/tl_page_list_ordered_item_gen.go
+++ b/tg/tl_page_list_ordered_item_gen.go
@@ -344,6 +344,10 @@ func (p *PageListOrderedItemBlocks) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageListOrderedItemBlocks#98dd8936: field blocks: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)
 			if err != nil {

--- a/tg/tl_page_list_ordered_item_gen.go
+++ b/tg/tl_page_list_ordered_item_gen.go
@@ -345,8 +345,8 @@ func (p *PageListOrderedItemBlocks) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageListOrderedItemBlocks#98dd8936: field blocks: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Blocks = make([]PageBlockClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Blocks = make([]PageBlockClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePageBlock(b)

--- a/tg/tl_page_table_row_gen.go
+++ b/tg/tl_page_table_row_gen.go
@@ -148,6 +148,10 @@ func (p *PageTableRow) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pageTableRow#e0c0c5e5: field cells: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Cells = make([]PageTableCell, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageTableCell
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_page_table_row_gen.go
+++ b/tg/tl_page_table_row_gen.go
@@ -149,8 +149,8 @@ func (p *PageTableRow) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pageTableRow#e0c0c5e5: field cells: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Cells = make([]PageTableCell, 0, headerLen)
+		if headerLen > 0 {
+			p.Cells = make([]PageTableCell, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PageTableCell

--- a/tg/tl_payments_bank_card_data_gen.go
+++ b/tg/tl_payments_bank_card_data_gen.go
@@ -172,6 +172,10 @@ func (b *PaymentsBankCardData) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode payments.bankCardData#3e24e573: field open_urls: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.OpenURLs = make([]BankCardOpenURL, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BankCardOpenURL
 			if err := value.Decode(buf); err != nil {

--- a/tg/tl_payments_bank_card_data_gen.go
+++ b/tg/tl_payments_bank_card_data_gen.go
@@ -173,8 +173,8 @@ func (b *PaymentsBankCardData) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode payments.bankCardData#3e24e573: field open_urls: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.OpenURLs = make([]BankCardOpenURL, 0, headerLen)
+		if headerLen > 0 {
+			b.OpenURLs = make([]BankCardOpenURL, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BankCardOpenURL

--- a/tg/tl_payments_payment_form_gen.go
+++ b/tg/tl_payments_payment_form_gen.go
@@ -549,8 +549,8 @@ func (p *PaymentsPaymentForm) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode payments.paymentForm#8d0b2415: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_payments_payment_form_gen.go
+++ b/tg/tl_payments_payment_form_gen.go
@@ -548,6 +548,10 @@ func (p *PaymentsPaymentForm) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode payments.paymentForm#8d0b2415: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_payments_payment_receipt_gen.go
+++ b/tg/tl_payments_payment_receipt_gen.go
@@ -582,6 +582,10 @@ func (p *PaymentsPaymentReceipt) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode payments.paymentReceipt#10b555d0: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_payments_payment_receipt_gen.go
+++ b/tg/tl_payments_payment_receipt_gen.go
@@ -583,8 +583,8 @@ func (p *PaymentsPaymentReceipt) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode payments.paymentReceipt#10b555d0: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_payments_validated_requested_info_gen.go
+++ b/tg/tl_payments_validated_requested_info_gen.go
@@ -226,6 +226,10 @@ func (v *PaymentsValidatedRequestedInfo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode payments.validatedRequestedInfo#d1451883: field shipping_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			v.ShippingOptions = make([]ShippingOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ShippingOption
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_payments_validated_requested_info_gen.go
+++ b/tg/tl_payments_validated_requested_info_gen.go
@@ -227,8 +227,8 @@ func (v *PaymentsValidatedRequestedInfo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode payments.validatedRequestedInfo#d1451883: field shipping_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			v.ShippingOptions = make([]ShippingOption, 0, headerLen)
+		if headerLen > 0 {
+			v.ShippingOptions = make([]ShippingOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ShippingOption

--- a/tg/tl_phone_call_gen.go
+++ b/tg/tl_phone_call_gen.go
@@ -1583,8 +1583,8 @@ func (p *PhoneCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phoneCall#8742ae7f: field connections: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Connections = make([]PhoneConnectionClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Connections = make([]PhoneConnectionClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoneConnection(b)

--- a/tg/tl_phone_call_gen.go
+++ b/tg/tl_phone_call_gen.go
@@ -1582,6 +1582,10 @@ func (p *PhoneCall) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phoneCall#8742ae7f: field connections: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Connections = make([]PhoneConnectionClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoneConnection(b)
 			if err != nil {

--- a/tg/tl_phone_call_protocol_gen.go
+++ b/tg/tl_phone_call_protocol_gen.go
@@ -284,8 +284,8 @@ func (p *PhoneCallProtocol) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phoneCallProtocol#fc878fc8: field library_versions: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.LibraryVersions = make([]string, 0, headerLen)
+		if headerLen > 0 {
+			p.LibraryVersions = make([]string, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()

--- a/tg/tl_phone_call_protocol_gen.go
+++ b/tg/tl_phone_call_protocol_gen.go
@@ -283,6 +283,10 @@ func (p *PhoneCallProtocol) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phoneCallProtocol#fc878fc8: field library_versions: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.LibraryVersions = make([]string, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.String()
 			if err != nil {

--- a/tg/tl_phone_check_group_call_gen.go
+++ b/tg/tl_phone_check_group_call_gen.go
@@ -170,8 +170,8 @@ func (c *PhoneCheckGroupCallRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.checkGroupCall#b59cf977: field sources: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Sources = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			c.Sources = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_phone_check_group_call_gen.go
+++ b/tg/tl_phone_check_group_call_gen.go
@@ -169,6 +169,10 @@ func (c *PhoneCheckGroupCallRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.checkGroupCall#b59cf977: field sources: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Sources = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_phone_get_group_participants_gen.go
+++ b/tg/tl_phone_get_group_participants_gen.go
@@ -233,6 +233,10 @@ func (g *PhoneGetGroupParticipantsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.getGroupParticipants#c558d8ab: field ids: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.IDs = make([]InputPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
 			if err != nil {
@@ -245,6 +249,10 @@ func (g *PhoneGetGroupParticipantsRequest) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.getGroupParticipants#c558d8ab: field sources: %w", err)
+		}
+
+		if headerLen != 0 {
+			g.Sources = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_phone_get_group_participants_gen.go
+++ b/tg/tl_phone_get_group_participants_gen.go
@@ -234,8 +234,8 @@ func (g *PhoneGetGroupParticipantsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.getGroupParticipants#c558d8ab: field ids: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.IDs = make([]InputPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			g.IDs = make([]InputPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPeer(b)
@@ -251,8 +251,8 @@ func (g *PhoneGetGroupParticipantsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.getGroupParticipants#c558d8ab: field sources: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Sources = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			g.Sources = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_phone_group_call_gen.go
+++ b/tg/tl_phone_group_call_gen.go
@@ -253,6 +253,10 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field participants: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Participants = make([]GroupCallParticipant, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
 			if err := value.Decode(b); err != nil {
@@ -273,6 +277,10 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -285,6 +293,10 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			g.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_group_call_gen.go
+++ b/tg/tl_phone_group_call_gen.go
@@ -254,8 +254,8 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Participants = make([]GroupCallParticipant, 0, headerLen)
+		if headerLen > 0 {
+			g.Participants = make([]GroupCallParticipant, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
@@ -278,8 +278,8 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -295,8 +295,8 @@ func (g *PhoneGroupCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupCall#9e727aad: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_group_participants_gen.go
+++ b/tg/tl_phone_group_participants_gen.go
@@ -266,8 +266,8 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Participants = make([]GroupCallParticipant, 0, headerLen)
+		if headerLen > 0 {
+			g.Participants = make([]GroupCallParticipant, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
@@ -290,8 +290,8 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -307,8 +307,8 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			g.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_group_participants_gen.go
+++ b/tg/tl_phone_group_participants_gen.go
@@ -265,6 +265,10 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field participants: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Participants = make([]GroupCallParticipant, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
 			if err := value.Decode(b); err != nil {
@@ -285,6 +289,10 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -297,6 +305,10 @@ func (g *PhoneGroupParticipants) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.groupParticipants#f47751b6: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			g.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_invite_to_group_call_gen.go
+++ b/tg/tl_phone_invite_to_group_call_gen.go
@@ -180,8 +180,8 @@ func (i *PhoneInviteToGroupCallRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.inviteToGroupCall#7b393160: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			i.Users = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			i.Users = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_phone_invite_to_group_call_gen.go
+++ b/tg/tl_phone_invite_to_group_call_gen.go
@@ -179,6 +179,10 @@ func (i *PhoneInviteToGroupCallRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.inviteToGroupCall#7b393160: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			i.Users = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_phone_join_as_peers_gen.go
+++ b/tg/tl_phone_join_as_peers_gen.go
@@ -215,6 +215,10 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			j.Peers = make([]PeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
 			if err != nil {
@@ -228,6 +232,10 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			j.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -240,6 +248,10 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			j.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_join_as_peers_gen.go
+++ b/tg/tl_phone_join_as_peers_gen.go
@@ -216,8 +216,8 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			j.Peers = make([]PeerClass, 0, headerLen)
+		if headerLen > 0 {
+			j.Peers = make([]PeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeer(b)
@@ -233,8 +233,8 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			j.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			j.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -250,8 +250,8 @@ func (j *PhoneJoinAsPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.joinAsPeers#afe5623f: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			j.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			j.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_phone_call_gen.go
+++ b/tg/tl_phone_phone_call_gen.go
@@ -191,8 +191,8 @@ func (p *PhonePhoneCall) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode phone.phoneCall#ec82e140: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_phone_phone_call_gen.go
+++ b/tg/tl_phone_phone_call_gen.go
@@ -190,6 +190,10 @@ func (p *PhonePhoneCall) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode phone.phoneCall#ec82e140: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_photo_gen.go
+++ b/tg/tl_photo_gen.go
@@ -499,8 +499,8 @@ func (p *Photo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photo#fb197a65: field sizes: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Sizes = make([]PhotoSizeClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Sizes = make([]PhotoSizeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)
@@ -516,8 +516,8 @@ func (p *Photo) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photo#fb197a65: field video_sizes: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.VideoSizes = make([]VideoSize, 0, headerLen)
+		if headerLen > 0 {
+			p.VideoSizes = make([]VideoSize, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value VideoSize

--- a/tg/tl_photo_gen.go
+++ b/tg/tl_photo_gen.go
@@ -498,6 +498,10 @@ func (p *Photo) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photo#fb197a65: field sizes: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Sizes = make([]PhotoSizeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)
 			if err != nil {
@@ -510,6 +514,10 @@ func (p *Photo) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode photo#fb197a65: field video_sizes: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.VideoSizes = make([]VideoSize, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value VideoSize

--- a/tg/tl_photo_size_gen.go
+++ b/tg/tl_photo_size_gen.go
@@ -922,8 +922,8 @@ func (p *PhotoSizeProgressive) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photoSizeProgressive#fa3efb95: field sizes: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Sizes = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.Sizes = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_photo_size_gen.go
+++ b/tg/tl_photo_size_gen.go
@@ -921,6 +921,10 @@ func (p *PhotoSizeProgressive) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photoSizeProgressive#fa3efb95: field sizes: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Sizes = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {

--- a/tg/tl_photos_delete_photos_gen.go
+++ b/tg/tl_photos_delete_photos_gen.go
@@ -156,6 +156,10 @@ func (d *PhotosDeletePhotosRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.deletePhotos#87cf7f2f: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.ID = make([]InputPhotoClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPhoto(b)
 			if err != nil {

--- a/tg/tl_photos_delete_photos_gen.go
+++ b/tg/tl_photos_delete_photos_gen.go
@@ -157,8 +157,8 @@ func (d *PhotosDeletePhotosRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.deletePhotos#87cf7f2f: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.ID = make([]InputPhotoClass, 0, headerLen)
+		if headerLen > 0 {
+			d.ID = make([]InputPhotoClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputPhoto(b)

--- a/tg/tl_photos_photo_gen.go
+++ b/tg/tl_photos_photo_gen.go
@@ -190,6 +190,10 @@ func (p *PhotosPhoto) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.photo#20212ca8: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_photos_photo_gen.go
+++ b/tg/tl_photos_photo_gen.go
@@ -191,8 +191,8 @@ func (p *PhotosPhoto) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.photo#20212ca8: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_photos_photos_gen.go
+++ b/tg/tl_photos_photos_gen.go
@@ -186,6 +186,10 @@ func (p *PhotosPhotos) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.photos#8dca6aa5: field photos: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
 			if err != nil {
@@ -198,6 +202,10 @@ func (p *PhotosPhotos) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.photos#8dca6aa5: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -404,6 +412,10 @@ func (p *PhotosPhotosSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.photosSlice#15051f54: field photos: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
 			if err != nil {
@@ -416,6 +428,10 @@ func (p *PhotosPhotosSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode photos.photosSlice#15051f54: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_photos_photos_gen.go
+++ b/tg/tl_photos_photos_gen.go
@@ -187,8 +187,8 @@ func (p *PhotosPhotos) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.photos#8dca6aa5: field photos: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Photos = make([]PhotoClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
@@ -204,8 +204,8 @@ func (p *PhotosPhotos) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.photos#8dca6aa5: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -413,8 +413,8 @@ func (p *PhotosPhotosSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.photosSlice#15051f54: field photos: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Photos = make([]PhotoClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Photos = make([]PhotoClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhoto(b)
@@ -430,8 +430,8 @@ func (p *PhotosPhotosSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode photos.photosSlice#15051f54: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_poll_gen.go
+++ b/tg/tl_poll_gen.go
@@ -424,8 +424,8 @@ func (p *Poll) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode poll#86e18161: field answers: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Answers = make([]PollAnswer, 0, headerLen)
+		if headerLen > 0 {
+			p.Answers = make([]PollAnswer, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PollAnswer

--- a/tg/tl_poll_gen.go
+++ b/tg/tl_poll_gen.go
@@ -423,6 +423,10 @@ func (p *Poll) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode poll#86e18161: field answers: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Answers = make([]PollAnswer, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PollAnswer
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_poll_results_gen.go
+++ b/tg/tl_poll_results_gen.go
@@ -397,6 +397,10 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field results: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Results = make([]PollAnswerVoters, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PollAnswerVoters
 			if err := value.Decode(b); err != nil {
@@ -417,6 +421,10 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field recent_voters: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.RecentVoters = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -436,6 +444,10 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field solution_entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.SolutionEntities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_poll_results_gen.go
+++ b/tg/tl_poll_results_gen.go
@@ -398,8 +398,8 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field results: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Results = make([]PollAnswerVoters, 0, headerLen)
+		if headerLen > 0 {
+			p.Results = make([]PollAnswerVoters, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value PollAnswerVoters
@@ -422,8 +422,8 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field recent_voters: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.RecentVoters = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.RecentVoters = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -446,8 +446,8 @@ func (p *PollResults) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode pollResults#badcc1a3: field solution_entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.SolutionEntities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			p.SolutionEntities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_privacy_rule_gen.go
+++ b/tg/tl_privacy_rule_gen.go
@@ -350,6 +350,10 @@ func (p *PrivacyValueAllowUsers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode privacyValueAllowUsers#4d5bbe0c: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -695,6 +699,10 @@ func (p *PrivacyValueDisallowUsers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode privacyValueDisallowUsers#c7f49b7: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Users = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -836,6 +844,10 @@ func (p *PrivacyValueAllowChatParticipants) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode privacyValueAllowChatParticipants#18be796b: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			p.Chats = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -976,6 +988,10 @@ func (p *PrivacyValueDisallowChatParticipants) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode privacyValueDisallowChatParticipants#acae0690: field chats: %w", err)
+		}
+
+		if headerLen != 0 {
+			p.Chats = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_privacy_rule_gen.go
+++ b/tg/tl_privacy_rule_gen.go
@@ -351,8 +351,8 @@ func (p *PrivacyValueAllowUsers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode privacyValueAllowUsers#4d5bbe0c: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -700,8 +700,8 @@ func (p *PrivacyValueDisallowUsers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode privacyValueDisallowUsers#c7f49b7: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Users = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.Users = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -845,8 +845,8 @@ func (p *PrivacyValueAllowChatParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode privacyValueAllowChatParticipants#18be796b: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Chats = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.Chats = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -990,8 +990,8 @@ func (p *PrivacyValueDisallowChatParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode privacyValueDisallowChatParticipants#acae0690: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			p.Chats = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			p.Chats = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()

--- a/tg/tl_received_notify_message_vector_gen.go
+++ b/tg/tl_received_notify_message_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *ReceivedNotifyMessageVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<ReceivedNotifyMessage>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]ReceivedNotifyMessage, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ReceivedNotifyMessage
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_received_notify_message_vector_gen.go
+++ b/tg/tl_received_notify_message_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *ReceivedNotifyMessageVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<ReceivedNotifyMessage>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]ReceivedNotifyMessage, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]ReceivedNotifyMessage, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value ReceivedNotifyMessage

--- a/tg/tl_reply_markup_gen.go
+++ b/tg/tl_reply_markup_gen.go
@@ -709,8 +709,8 @@ func (r *ReplyKeyboardMarkup) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode replyKeyboardMarkup#85dd99d1: field rows: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Rows = make([]KeyboardButtonRow, 0, headerLen)
+		if headerLen > 0 {
+			r.Rows = make([]KeyboardButtonRow, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value KeyboardButtonRow
@@ -863,8 +863,8 @@ func (r *ReplyInlineMarkup) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode replyInlineMarkup#48a30254: field rows: %w", err)
 		}
 
-		if headerLen != 0 {
-			r.Rows = make([]KeyboardButtonRow, 0, headerLen)
+		if headerLen > 0 {
+			r.Rows = make([]KeyboardButtonRow, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value KeyboardButtonRow

--- a/tg/tl_reply_markup_gen.go
+++ b/tg/tl_reply_markup_gen.go
@@ -708,6 +708,10 @@ func (r *ReplyKeyboardMarkup) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode replyKeyboardMarkup#85dd99d1: field rows: %w", err)
 		}
+
+		if headerLen != 0 {
+			r.Rows = make([]KeyboardButtonRow, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value KeyboardButtonRow
 			if err := value.Decode(b); err != nil {
@@ -857,6 +861,10 @@ func (r *ReplyInlineMarkup) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode replyInlineMarkup#48a30254: field rows: %w", err)
+		}
+
+		if headerLen != 0 {
+			r.Rows = make([]KeyboardButtonRow, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value KeyboardButtonRow

--- a/tg/tl_rich_text_gen.go
+++ b/tg/tl_rich_text_gen.go
@@ -1421,6 +1421,10 @@ func (t *TextConcat) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode textConcat#7e6260d7: field texts: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Texts = make([]RichTextClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeRichText(b)
 			if err != nil {

--- a/tg/tl_rich_text_gen.go
+++ b/tg/tl_rich_text_gen.go
@@ -1422,8 +1422,8 @@ func (t *TextConcat) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode textConcat#7e6260d7: field texts: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Texts = make([]RichTextClass, 0, headerLen)
+		if headerLen > 0 {
+			t.Texts = make([]RichTextClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeRichText(b)

--- a/tg/tl_saved_phone_contact_vector_gen.go
+++ b/tg/tl_saved_phone_contact_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *SavedPhoneContactVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<SavedContact>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]SavedPhoneContact, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]SavedPhoneContact, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SavedPhoneContact

--- a/tg/tl_saved_phone_contact_vector_gen.go
+++ b/tg/tl_saved_phone_contact_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *SavedPhoneContactVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<SavedContact>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]SavedPhoneContact, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SavedPhoneContact
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_secure_required_type_gen.go
+++ b/tg/tl_secure_required_type_gen.go
@@ -405,6 +405,10 @@ func (s *SecureRequiredTypeOneOf) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode secureRequiredTypeOneOf#27477b4: field types: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Types = make([]SecureRequiredTypeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureRequiredType(b)
 			if err != nil {

--- a/tg/tl_secure_required_type_gen.go
+++ b/tg/tl_secure_required_type_gen.go
@@ -406,8 +406,8 @@ func (s *SecureRequiredTypeOneOf) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode secureRequiredTypeOneOf#27477b4: field types: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Types = make([]SecureRequiredTypeClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Types = make([]SecureRequiredTypeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureRequiredType(b)

--- a/tg/tl_secure_value_error_gen.go
+++ b/tg/tl_secure_value_error_gen.go
@@ -1195,8 +1195,8 @@ func (s *SecureValueErrorFiles) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode secureValueErrorFiles#666220e9: field file_hash: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.FileHash = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			s.FileHash = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
@@ -1797,8 +1797,8 @@ func (s *SecureValueErrorTranslationFiles) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode secureValueErrorTranslationFiles#34636dd8: field file_hash: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.FileHash = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			s.FileHash = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()

--- a/tg/tl_secure_value_error_gen.go
+++ b/tg/tl_secure_value_error_gen.go
@@ -1194,6 +1194,10 @@ func (s *SecureValueErrorFiles) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode secureValueErrorFiles#666220e9: field file_hash: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.FileHash = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {
@@ -1791,6 +1795,10 @@ func (s *SecureValueErrorTranslationFiles) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode secureValueErrorTranslationFiles#34636dd8: field file_hash: %w", err)
+		}
+
+		if headerLen != 0 {
+			s.FileHash = make([][]byte, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()

--- a/tg/tl_secure_value_gen.go
+++ b/tg/tl_secure_value_gen.go
@@ -586,8 +586,8 @@ func (s *SecureValue) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode secureValue#187fa0ca: field translation: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Translation = make([]SecureFileClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Translation = make([]SecureFileClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureFile(b)
@@ -603,8 +603,8 @@ func (s *SecureValue) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode secureValue#187fa0ca: field files: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Files = make([]SecureFileClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Files = make([]SecureFileClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureFile(b)

--- a/tg/tl_secure_value_gen.go
+++ b/tg/tl_secure_value_gen.go
@@ -585,6 +585,10 @@ func (s *SecureValue) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode secureValue#187fa0ca: field translation: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Translation = make([]SecureFileClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureFile(b)
 			if err != nil {
@@ -597,6 +601,10 @@ func (s *SecureValue) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode secureValue#187fa0ca: field files: %w", err)
+		}
+
+		if headerLen != 0 {
+			s.Files = make([]SecureFileClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureFile(b)

--- a/tg/tl_secure_value_vector_gen.go
+++ b/tg/tl_secure_value_vector_gen.go
@@ -144,8 +144,8 @@ func (vec *SecureValueVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<SecureValue>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]SecureValue, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]SecureValue, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue

--- a/tg/tl_secure_value_vector_gen.go
+++ b/tg/tl_secure_value_vector_gen.go
@@ -143,6 +143,10 @@ func (vec *SecureValueVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<SecureValue>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]SecureValue, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value SecureValue
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_shipping_option_gen.go
+++ b/tg/tl_shipping_option_gen.go
@@ -197,8 +197,8 @@ func (s *ShippingOption) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode shippingOption#b6213cdf: field prices: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Prices = make([]LabeledPrice, 0, headerLen)
+		if headerLen > 0 {
+			s.Prices = make([]LabeledPrice, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LabeledPrice

--- a/tg/tl_shipping_option_gen.go
+++ b/tg/tl_shipping_option_gen.go
@@ -196,6 +196,10 @@ func (s *ShippingOption) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode shippingOption#b6213cdf: field prices: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Prices = make([]LabeledPrice, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value LabeledPrice
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_stats_broadcast_stats_gen.go
+++ b/tg/tl_stats_broadcast_stats_gen.go
@@ -539,8 +539,8 @@ func (b *StatsBroadcastStats) DecodeBare(buf *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stats.broadcastStats#bdf78394: field recent_message_interactions: %w", err)
 		}
 
-		if headerLen != 0 {
-			b.RecentMessageInteractions = make([]MessageInteractionCounters, 0, headerLen)
+		if headerLen > 0 {
+			b.RecentMessageInteractions = make([]MessageInteractionCounters, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageInteractionCounters

--- a/tg/tl_stats_broadcast_stats_gen.go
+++ b/tg/tl_stats_broadcast_stats_gen.go
@@ -538,6 +538,10 @@ func (b *StatsBroadcastStats) DecodeBare(buf *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stats.broadcastStats#bdf78394: field recent_message_interactions: %w", err)
 		}
+
+		if headerLen != 0 {
+			b.RecentMessageInteractions = make([]MessageInteractionCounters, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value MessageInteractionCounters
 			if err := value.Decode(buf); err != nil {

--- a/tg/tl_stats_megagroup_stats_gen.go
+++ b/tg/tl_stats_megagroup_stats_gen.go
@@ -577,6 +577,10 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_posters: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.TopPosters = make([]StatsGroupTopPoster, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopPoster
 			if err := value.Decode(b); err != nil {
@@ -589,6 +593,10 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_admins: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.TopAdmins = make([]StatsGroupTopAdmin, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopAdmin
@@ -603,6 +611,10 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_inviters: %w", err)
 		}
+
+		if headerLen != 0 {
+			m.TopInviters = make([]StatsGroupTopInviter, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopInviter
 			if err := value.Decode(b); err != nil {
@@ -615,6 +627,10 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			m.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_stats_megagroup_stats_gen.go
+++ b/tg/tl_stats_megagroup_stats_gen.go
@@ -578,8 +578,8 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_posters: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.TopPosters = make([]StatsGroupTopPoster, 0, headerLen)
+		if headerLen > 0 {
+			m.TopPosters = make([]StatsGroupTopPoster, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopPoster
@@ -595,8 +595,8 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_admins: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.TopAdmins = make([]StatsGroupTopAdmin, 0, headerLen)
+		if headerLen > 0 {
+			m.TopAdmins = make([]StatsGroupTopAdmin, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopAdmin
@@ -612,8 +612,8 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field top_inviters: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.TopInviters = make([]StatsGroupTopInviter, 0, headerLen)
+		if headerLen > 0 {
+			m.TopInviters = make([]StatsGroupTopInviter, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value StatsGroupTopInviter
@@ -629,8 +629,8 @@ func (m *StatsMegagroupStats) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stats.megagroupStats#ef7ff916: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			m.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			m.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_sticker_pack_gen.go
+++ b/tg/tl_sticker_pack_gen.go
@@ -176,8 +176,8 @@ func (s *StickerPack) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stickerPack#12b299d4: field documents: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Documents = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			s.Documents = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()

--- a/tg/tl_sticker_pack_gen.go
+++ b/tg/tl_sticker_pack_gen.go
@@ -175,6 +175,10 @@ func (s *StickerPack) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stickerPack#12b299d4: field documents: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Documents = make([]int64, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
 			if err != nil {

--- a/tg/tl_sticker_set_covered_class_vector_gen.go
+++ b/tg/tl_sticker_set_covered_class_vector_gen.go
@@ -151,6 +151,10 @@ func (vec *StickerSetCoveredClassVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<StickerSetCovered>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]StickerSetCoveredClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)
 			if err != nil {

--- a/tg/tl_sticker_set_covered_class_vector_gen.go
+++ b/tg/tl_sticker_set_covered_class_vector_gen.go
@@ -152,8 +152,8 @@ func (vec *StickerSetCoveredClassVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<StickerSetCovered>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]StickerSetCoveredClass, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]StickerSetCoveredClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeStickerSetCovered(b)

--- a/tg/tl_sticker_set_covered_gen.go
+++ b/tg/tl_sticker_set_covered_gen.go
@@ -341,6 +341,10 @@ func (s *StickerSetMultiCovered) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stickerSetMultiCovered#3407e51b: field covers: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Covers = make([]DocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
 			if err != nil {

--- a/tg/tl_sticker_set_covered_gen.go
+++ b/tg/tl_sticker_set_covered_gen.go
@@ -342,8 +342,8 @@ func (s *StickerSetMultiCovered) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stickerSetMultiCovered#3407e51b: field covers: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Covers = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Covers = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_sticker_set_gen.go
+++ b/tg/tl_sticker_set_gen.go
@@ -576,6 +576,10 @@ func (s *StickerSet) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stickerSet#d7df217a: field thumbs: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Thumbs = make([]PhotoSizeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)
 			if err != nil {

--- a/tg/tl_sticker_set_gen.go
+++ b/tg/tl_sticker_set_gen.go
@@ -577,8 +577,8 @@ func (s *StickerSet) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stickerSet#d7df217a: field thumbs: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Thumbs = make([]PhotoSizeClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Thumbs = make([]PhotoSizeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePhotoSize(b)

--- a/tg/tl_stickers_create_sticker_set_gen.go
+++ b/tg/tl_stickers_create_sticker_set_gen.go
@@ -403,6 +403,10 @@ func (c *StickersCreateStickerSetRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode stickers.createStickerSet#9021ab67: field stickers: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Stickers = make([]InputStickerSetItem, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputStickerSetItem
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_stickers_create_sticker_set_gen.go
+++ b/tg/tl_stickers_create_sticker_set_gen.go
@@ -404,8 +404,8 @@ func (c *StickersCreateStickerSetRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode stickers.createStickerSet#9021ab67: field stickers: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Stickers = make([]InputStickerSetItem, 0, headerLen)
+		if headerLen > 0 {
+			c.Stickers = make([]InputStickerSetItem, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value InputStickerSetItem

--- a/tg/tl_top_peer_category_peers_gen.go
+++ b/tg/tl_top_peer_category_peers_gen.go
@@ -201,6 +201,10 @@ func (t *TopPeerCategoryPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode topPeerCategoryPeers#fb834291: field peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			t.Peers = make([]TopPeer, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TopPeer
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_top_peer_category_peers_gen.go
+++ b/tg/tl_top_peer_category_peers_gen.go
@@ -202,8 +202,8 @@ func (t *TopPeerCategoryPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode topPeerCategoryPeers#fb834291: field peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			t.Peers = make([]TopPeer, 0, headerLen)
+		if headerLen > 0 {
+			t.Peers = make([]TopPeer, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value TopPeer

--- a/tg/tl_update_gen.go
+++ b/tg/tl_update_gen.go
@@ -531,8 +531,8 @@ func (u *UpdateDeleteMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateDeleteMessages#a20db0e5: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -2822,8 +2822,8 @@ func (u *UpdateDCOptions) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateDcOptions#8e5e9873: field dc_options: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.DCOptions = make([]DCOption, 0, headerLen)
+		if headerLen > 0 {
+			u.DCOptions = make([]DCOption, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption
@@ -3323,8 +3323,8 @@ func (u *UpdateServiceNotification) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateServiceNotification#ebe46819: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -3507,8 +3507,8 @@ func (u *UpdatePrivacy) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatePrivacy#ee3b272a: field rules: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Rules = make([]PrivacyRuleClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Rules = make([]PrivacyRuleClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePrivacyRule(b)
@@ -4563,8 +4563,8 @@ func (u *UpdateReadMessagesContents) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateReadMessagesContents#68c13933: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -5587,8 +5587,8 @@ func (u *UpdateDeleteChannelMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateDeleteChannelMessages#c37521c9: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -6313,8 +6313,8 @@ func (u *UpdateStickerSetsOrder) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateStickerSetsOrder#bb2d201: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Order = make([]int64, 0, headerLen)
+		if headerLen > 0 {
+			u.Order = make([]int64, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
@@ -9623,8 +9623,8 @@ func (u *UpdatePinnedDialogs) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatePinnedDialogs#fa0f3ca2: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Order = make([]DialogPeerClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Order = make([]DialogPeerClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialogPeer(b)
@@ -11168,8 +11168,8 @@ func (u *UpdateChannelReadMessagesContents) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateChannelReadMessagesContents#89893b45: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -12209,8 +12209,8 @@ func (u *UpdateFolderPeers) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateFolderPeers#19360dc0: field folder_peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.FolderPeers = make([]FolderPeer, 0, headerLen)
+		if headerLen > 0 {
+			u.FolderPeers = make([]FolderPeer, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FolderPeer
@@ -12539,8 +12539,8 @@ func (u *UpdatePeerLocated) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatePeerLocated#b4afcfb0: field peers: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Peers = make([]PeerLocatedClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Peers = make([]PeerLocatedClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeerLocated(b)
@@ -12856,8 +12856,8 @@ func (u *UpdateDeleteScheduledMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateDeleteScheduledMessages#90866cee: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -13461,8 +13461,8 @@ func (u *UpdateMessagePollVote) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateMessagePollVote#37f69f0b: field options: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Options = make([][]byte, 0, headerLen)
+		if headerLen > 0 {
+			u.Options = make([][]byte, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
@@ -13821,8 +13821,8 @@ func (u *UpdateDialogFilterOrder) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateDialogFilterOrder#a5d72105: field order: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Order = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Order = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -15441,8 +15441,8 @@ func (u *UpdatePinnedMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatePinnedMessages#ed85eab5: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -15715,8 +15715,8 @@ func (u *UpdatePinnedChannelMessages) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatePinnedChannelMessages#8588878b: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Messages = make([]int, 0, headerLen)
+		if headerLen > 0 {
+			u.Messages = make([]int, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -16047,8 +16047,8 @@ func (u *UpdateGroupCallParticipants) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateGroupCallParticipants#f2ebdb4e: field participants: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Participants = make([]GroupCallParticipant, 0, headerLen)
+		if headerLen > 0 {
+			u.Participants = make([]GroupCallParticipant, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
@@ -17766,8 +17766,8 @@ func (u *UpdateBotCommands) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateBotCommands#cf7e0873: field commands: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Commands = make([]BotCommand, 0, headerLen)
+		if headerLen > 0 {
+			u.Commands = make([]BotCommand, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand

--- a/tg/tl_update_gen.go
+++ b/tg/tl_update_gen.go
@@ -530,6 +530,10 @@ func (u *UpdateDeleteMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateDeleteMessages#a20db0e5: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -2817,6 +2821,10 @@ func (u *UpdateDCOptions) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateDcOptions#8e5e9873: field dc_options: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.DCOptions = make([]DCOption, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value DCOption
 			if err := value.Decode(b); err != nil {
@@ -3314,6 +3322,10 @@ func (u *UpdateServiceNotification) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateServiceNotification#ebe46819: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -3493,6 +3505,10 @@ func (u *UpdatePrivacy) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updatePrivacy#ee3b272a: field rules: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Rules = make([]PrivacyRuleClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePrivacyRule(b)
@@ -4546,6 +4562,10 @@ func (u *UpdateReadMessagesContents) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateReadMessagesContents#68c13933: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -5566,6 +5586,10 @@ func (u *UpdateDeleteChannelMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateDeleteChannelMessages#c37521c9: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -6287,6 +6311,10 @@ func (u *UpdateStickerSetsOrder) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateStickerSetsOrder#bb2d201: field order: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Order = make([]int64, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Long()
@@ -9594,6 +9622,10 @@ func (u *UpdatePinnedDialogs) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updatePinnedDialogs#fa0f3ca2: field order: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Order = make([]DialogPeerClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDialogPeer(b)
 			if err != nil {
@@ -11135,6 +11167,10 @@ func (u *UpdateChannelReadMessagesContents) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateChannelReadMessagesContents#89893b45: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -12172,6 +12208,10 @@ func (u *UpdateFolderPeers) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateFolderPeers#19360dc0: field folder_peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.FolderPeers = make([]FolderPeer, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FolderPeer
 			if err := value.Decode(b); err != nil {
@@ -12498,6 +12538,10 @@ func (u *UpdatePeerLocated) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updatePeerLocated#b4afcfb0: field peers: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Peers = make([]PeerLocatedClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodePeerLocated(b)
 			if err != nil {
@@ -12810,6 +12854,10 @@ func (u *UpdateDeleteScheduledMessages) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateDeleteScheduledMessages#90866cee: field messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -13412,6 +13460,10 @@ func (u *UpdateMessagePollVote) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateMessagePollVote#37f69f0b: field options: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Options = make([][]byte, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Bytes()
 			if err != nil {
@@ -13767,6 +13819,10 @@ func (u *UpdateDialogFilterOrder) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateDialogFilterOrder#a5d72105: field order: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Order = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -15384,6 +15440,10 @@ func (u *UpdatePinnedMessages) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updatePinnedMessages#ed85eab5: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
 			if err != nil {
@@ -15653,6 +15713,10 @@ func (u *UpdatePinnedChannelMessages) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updatePinnedChannelMessages#8588878b: field messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Messages = make([]int, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := b.Int()
@@ -15981,6 +16045,10 @@ func (u *UpdateGroupCallParticipants) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateGroupCallParticipants#f2ebdb4e: field participants: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Participants = make([]GroupCallParticipant, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value GroupCallParticipant
@@ -17696,6 +17764,10 @@ func (u *UpdateBotCommands) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateBotCommands#cf7e0873: field commands: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Commands = make([]BotCommand, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value BotCommand

--- a/tg/tl_updates_channel_difference_gen.go
+++ b/tg/tl_updates_channel_difference_gen.go
@@ -573,6 +573,10 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Messages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -586,6 +590,10 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -598,6 +606,10 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -962,6 +974,10 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field new_messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.NewMessages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -974,6 +990,10 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field other_updates: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.OtherUpdates = make([]UpdateClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -988,6 +1008,10 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			c.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -1000,6 +1024,10 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			c.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_updates_channel_difference_gen.go
+++ b/tg/tl_updates_channel_difference_gen.go
@@ -574,8 +574,8 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Messages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Messages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -591,8 +591,8 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -608,8 +608,8 @@ func (c *UpdatesChannelDifferenceTooLong) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifferenceTooLong#a4bcc6fe: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -975,8 +975,8 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field new_messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.NewMessages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			c.NewMessages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -992,8 +992,8 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field other_updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.OtherUpdates = make([]UpdateClass, 0, headerLen)
+		if headerLen > 0 {
+			c.OtherUpdates = make([]UpdateClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -1009,8 +1009,8 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -1026,8 +1026,8 @@ func (c *UpdatesChannelDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.channelDifference#2064674e: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			c.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			c.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_updates_difference_gen.go
+++ b/tg/tl_updates_difference_gen.go
@@ -451,6 +451,10 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field new_messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.NewMessages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -463,6 +467,10 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field new_encrypted_messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEncryptedMessage(b)
@@ -477,6 +485,10 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field other_updates: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.OtherUpdates = make([]UpdateClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
 			if err != nil {
@@ -490,6 +502,10 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -502,6 +518,10 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -801,6 +821,10 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field new_messages: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.NewMessages = make([]MessageClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
 			if err != nil {
@@ -813,6 +837,10 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field new_encrypted_messages: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEncryptedMessage(b)
@@ -827,6 +855,10 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field other_updates: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.OtherUpdates = make([]UpdateClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
 			if err != nil {
@@ -840,6 +872,10 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field chats: %w", err)
 		}
+
+		if headerLen != 0 {
+			d.Chats = make([]ChatClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
 			if err != nil {
@@ -852,6 +888,10 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field users: %w", err)
+		}
+
+		if headerLen != 0 {
+			d.Users = make([]UserClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_updates_difference_gen.go
+++ b/tg/tl_updates_difference_gen.go
@@ -452,8 +452,8 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field new_messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.NewMessages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.NewMessages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -469,8 +469,8 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field new_encrypted_messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEncryptedMessage(b)
@@ -486,8 +486,8 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field other_updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.OtherUpdates = make([]UpdateClass, 0, headerLen)
+		if headerLen > 0 {
+			d.OtherUpdates = make([]UpdateClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -503,8 +503,8 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -520,8 +520,8 @@ func (d *UpdatesDifference) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.difference#f49ca0: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -822,8 +822,8 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field new_messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.NewMessages = make([]MessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.NewMessages = make([]MessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessage(b)
@@ -839,8 +839,8 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field new_encrypted_messages: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen)
+		if headerLen > 0 {
+			d.NewEncryptedMessages = make([]EncryptedMessageClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeEncryptedMessage(b)
@@ -856,8 +856,8 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field other_updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.OtherUpdates = make([]UpdateClass, 0, headerLen)
+		if headerLen > 0 {
+			d.OtherUpdates = make([]UpdateClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -873,8 +873,8 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -890,8 +890,8 @@ func (d *UpdatesDifferenceSlice) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates.differenceSlice#a8fb1981: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			d.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			d.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_updates_gen.go
+++ b/tg/tl_updates_gen.go
@@ -762,8 +762,8 @@ func (u *UpdateShortMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateShortMessage#faeff833: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -1445,8 +1445,8 @@ func (u *UpdateShortChatMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateShortChatMessage#1157b858: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
@@ -1879,8 +1879,8 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Updates = make([]UpdateClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Updates = make([]UpdateClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -1896,8 +1896,8 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -1913,8 +1913,8 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -2182,8 +2182,8 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates#74ae4240: field updates: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Updates = make([]UpdateClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Updates = make([]UpdateClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
@@ -2199,8 +2199,8 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates#74ae4240: field users: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Users = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Users = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
@@ -2216,8 +2216,8 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updates#74ae4240: field chats: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Chats = make([]ChatClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Chats = make([]ChatClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -2654,8 +2654,8 @@ func (u *UpdateShortSentMessage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode updateShortSentMessage#9015e101: field entities: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		if headerLen > 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_updates_gen.go
+++ b/tg/tl_updates_gen.go
@@ -761,6 +761,10 @@ func (u *UpdateShortMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateShortMessage#faeff833: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -1440,6 +1444,10 @@ func (u *UpdateShortChatMessage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updateShortChatMessage#1157b858: field entities: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)
 			if err != nil {
@@ -1870,6 +1878,10 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field updates: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Updates = make([]UpdateClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
 			if err != nil {
@@ -1883,6 +1895,10 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {
@@ -1895,6 +1911,10 @@ func (u *UpdatesCombined) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updatesCombined#725b04c3: field chats: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Chats = make([]ChatClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -2161,6 +2181,10 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates#74ae4240: field updates: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Updates = make([]UpdateClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUpdate(b)
 			if err != nil {
@@ -2174,6 +2198,10 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode updates#74ae4240: field users: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.Users = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {
@@ -2186,6 +2214,10 @@ func (u *Updates) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updates#74ae4240: field chats: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Chats = make([]ChatClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeChat(b)
@@ -2620,6 +2652,10 @@ func (u *UpdateShortSentMessage) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode updateShortSentMessage#9015e101: field entities: %w", err)
+		}
+
+		if headerLen != 0 {
+			u.Entities = make([]MessageEntityClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeMessageEntity(b)

--- a/tg/tl_upload_file_gen.go
+++ b/tg/tl_upload_file_gen.go
@@ -447,6 +447,10 @@ func (f *UploadFileCDNRedirect) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode upload.fileCdnRedirect#f18cda44: field file_hashes: %w", err)
 		}
+
+		if headerLen != 0 {
+			f.FileHashes = make([]FileHash, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FileHash
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_upload_file_gen.go
+++ b/tg/tl_upload_file_gen.go
@@ -448,8 +448,8 @@ func (f *UploadFileCDNRedirect) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode upload.fileCdnRedirect#f18cda44: field file_hashes: %w", err)
 		}
 
-		if headerLen != 0 {
-			f.FileHashes = make([]FileHash, 0, headerLen)
+		if headerLen > 0 {
+			f.FileHashes = make([]FileHash, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value FileHash

--- a/tg/tl_user_class_vector_gen.go
+++ b/tg/tl_user_class_vector_gen.go
@@ -151,6 +151,10 @@ func (vec *UserClassVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<User>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]UserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)
 			if err != nil {

--- a/tg/tl_user_class_vector_gen.go
+++ b/tg/tl_user_class_vector_gen.go
@@ -152,8 +152,8 @@ func (vec *UserClassVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<User>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]UserClass, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]UserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeUser(b)

--- a/tg/tl_user_gen.go
+++ b/tg/tl_user_gen.go
@@ -1273,6 +1273,10 @@ func (u *User) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode user#938458c1: field restriction_reason: %w", err)
 		}
+
+		if headerLen != 0 {
+			u.RestrictionReason = make([]RestrictionReason, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_user_gen.go
+++ b/tg/tl_user_gen.go
@@ -1274,8 +1274,8 @@ func (u *User) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode user#938458c1: field restriction_reason: %w", err)
 		}
 
-		if headerLen != 0 {
-			u.RestrictionReason = make([]RestrictionReason, 0, headerLen)
+		if headerLen > 0 {
+			u.RestrictionReason = make([]RestrictionReason, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value RestrictionReason

--- a/tg/tl_users_get_users_gen.go
+++ b/tg/tl_users_get_users_gen.go
@@ -157,8 +157,8 @@ func (g *UsersGetUsersRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode users.getUsers#d91a548: field id: %w", err)
 		}
 
-		if headerLen != 0 {
-			g.ID = make([]InputUserClass, 0, headerLen)
+		if headerLen > 0 {
+			g.ID = make([]InputUserClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)

--- a/tg/tl_users_get_users_gen.go
+++ b/tg/tl_users_get_users_gen.go
@@ -156,6 +156,10 @@ func (g *UsersGetUsersRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode users.getUsers#d91a548: field id: %w", err)
 		}
+
+		if headerLen != 0 {
+			g.ID = make([]InputUserClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeInputUser(b)
 			if err != nil {

--- a/tg/tl_users_set_secure_value_errors_gen.go
+++ b/tg/tl_users_set_secure_value_errors_gen.go
@@ -195,8 +195,8 @@ func (s *UsersSetSecureValueErrorsRequest) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode users.setSecureValueErrors#90c894b5: field errors: %w", err)
 		}
 
-		if headerLen != 0 {
-			s.Errors = make([]SecureValueErrorClass, 0, headerLen)
+		if headerLen > 0 {
+			s.Errors = make([]SecureValueErrorClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueError(b)

--- a/tg/tl_users_set_secure_value_errors_gen.go
+++ b/tg/tl_users_set_secure_value_errors_gen.go
@@ -194,6 +194,10 @@ func (s *UsersSetSecureValueErrorsRequest) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode users.setSecureValueErrors#90c894b5: field errors: %w", err)
 		}
+
+		if headerLen != 0 {
+			s.Errors = make([]SecureValueErrorClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeSecureValueError(b)
 			if err != nil {

--- a/tg/tl_wall_paper_class_vector_gen.go
+++ b/tg/tl_wall_paper_class_vector_gen.go
@@ -152,8 +152,8 @@ func (vec *WallPaperClassVector) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode Vector<WallPaper>: field Elems: %w", err)
 		}
 
-		if headerLen != 0 {
-			vec.Elems = make([]WallPaperClass, 0, headerLen)
+		if headerLen > 0 {
+			vec.Elems = make([]WallPaperClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeWallPaper(b)

--- a/tg/tl_wall_paper_class_vector_gen.go
+++ b/tg/tl_wall_paper_class_vector_gen.go
@@ -151,6 +151,10 @@ func (vec *WallPaperClassVector) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode Vector<WallPaper>: field Elems: %w", err)
 		}
+
+		if headerLen != 0 {
+			vec.Elems = make([]WallPaperClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeWallPaper(b)
 			if err != nil {

--- a/tg/tl_web_document_gen.go
+++ b/tg/tl_web_document_gen.go
@@ -253,8 +253,8 @@ func (w *WebDocument) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode webDocument#1c570ed1: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			w.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
@@ -483,8 +483,8 @@ func (w *WebDocumentNoProxy) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode webDocumentNoProxy#f9c8bcc6: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		if headerLen > 0 {
+			w.Attributes = make([]DocumentAttributeClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_web_document_gen.go
+++ b/tg/tl_web_document_gen.go
@@ -252,6 +252,10 @@ func (w *WebDocument) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode webDocument#1c570ed1: field attributes: %w", err)
 		}
+
+		if headerLen != 0 {
+			w.Attributes = make([]DocumentAttributeClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)
 			if err != nil {
@@ -477,6 +481,10 @@ func (w *WebDocumentNoProxy) DecodeBare(b *bin.Buffer) error {
 		headerLen, err := b.VectorHeader()
 		if err != nil {
 			return fmt.Errorf("unable to decode webDocumentNoProxy#f9c8bcc6: field attributes: %w", err)
+		}
+
+		if headerLen != 0 {
+			w.Attributes = make([]DocumentAttributeClass, 0, headerLen)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocumentAttribute(b)

--- a/tg/tl_web_page_attribute_theme_gen.go
+++ b/tg/tl_web_page_attribute_theme_gen.go
@@ -236,6 +236,10 @@ func (w *WebPageAttributeTheme) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode webPageAttributeTheme#54b56617: field documents: %w", err)
 		}
+
+		if headerLen != 0 {
+			w.Documents = make([]DocumentClass, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)
 			if err != nil {

--- a/tg/tl_web_page_attribute_theme_gen.go
+++ b/tg/tl_web_page_attribute_theme_gen.go
@@ -237,8 +237,8 @@ func (w *WebPageAttributeTheme) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode webPageAttributeTheme#54b56617: field documents: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Documents = make([]DocumentClass, 0, headerLen)
+		if headerLen > 0 {
+			w.Documents = make([]DocumentClass, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			value, err := DecodeDocument(b)

--- a/tg/tl_web_page_gen.go
+++ b/tg/tl_web_page_gen.go
@@ -1171,6 +1171,10 @@ func (w *WebPage) DecodeBare(b *bin.Buffer) error {
 		if err != nil {
 			return fmt.Errorf("unable to decode webPage#e89c45b2: field attributes: %w", err)
 		}
+
+		if headerLen != 0 {
+			w.Attributes = make([]WebPageAttributeTheme, 0, headerLen)
+		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value WebPageAttributeTheme
 			if err := value.Decode(b); err != nil {

--- a/tg/tl_web_page_gen.go
+++ b/tg/tl_web_page_gen.go
@@ -1172,8 +1172,8 @@ func (w *WebPage) DecodeBare(b *bin.Buffer) error {
 			return fmt.Errorf("unable to decode webPage#e89c45b2: field attributes: %w", err)
 		}
 
-		if headerLen != 0 {
-			w.Attributes = make([]WebPageAttributeTheme, 0, headerLen)
+		if headerLen > 0 {
+			w.Attributes = make([]WebPageAttributeTheme, 0, headerLen%bin.PreallocateLimit)
 		}
 		for idx := 0; idx < headerLen; idx++ {
 			var value WebPageAttributeTheme


### PR DESCRIPTION
```
name            old time/op    new time/op    delta
DecodeSlice-12    1.70µs ±80%    0.97µs ± 1%  -43.01%  (p=0.016 n=5+4)

name            old alloc/op   new alloc/op   delta
DecodeSlice-12    1.06kB ± 0%    0.82kB ± 0%  -22.56%  (p=0.008 n=5+5)

name            old allocs/op  new allocs/op  delta
DecodeSlice-12      25.0 ± 0%      21.0 ± 0%  -16.00%  (p=0.008 n=5+5)
```