### PR TITLE
feat(crypto): reduce parameter copying and zeroing

### DIFF
--- a/internal/crypto/keys.go
+++ b/internal/crypto/keys.go
@@ -46,8 +46,7 @@ func msgKeyLarge(r []byte, authKey Key, plaintextPadded []byte, mode Side) []byt
 }
 
 // messageKey returns msg_key = substr (msg_key_large, 8, 16).
-func messageKey(messageKeyLarge []byte) bin.Int128 {
-	var v bin.Int128
+func messageKey(messageKeyLarge []byte) (v bin.Int128) {
 	b := messageKeyLarge[8 : 16+8]
 	copy(v[:len(b)], b)
 	return v
@@ -56,7 +55,7 @@ func messageKey(messageKeyLarge []byte) bin.Int128 {
 // sha256a returns sha256_a value.
 //
 // sha256_a = SHA256 (msg_key + substr (auth_key, x, 36));
-func sha256a(r []byte, authKey Key, msgKey bin.Int128, x int) []byte {
+func sha256a(r []byte, authKey *Key, msgKey *bin.Int128, x int) []byte {
 	h := sha256.New()
 
 	_, _ = h.Write(msgKey[:])
@@ -68,7 +67,7 @@ func sha256a(r []byte, authKey Key, msgKey bin.Int128, x int) []byte {
 // sha256b returns sha256_b value.
 //
 // sha256_b = SHA256 (substr (auth_key, 40+x, 36) + msg_key);
-func sha256b(r []byte, authKey Key, msgKey bin.Int128, x int) []byte {
+func sha256b(r []byte, authKey *Key, msgKey *bin.Int128, x int) []byte {
 	h := sha256.New()
 
 	_, _ = h.Write(authKey[40+x : 40+x+36])
@@ -80,20 +79,18 @@ func sha256b(r []byte, authKey Key, msgKey bin.Int128, x int) []byte {
 // aesKey returns aes_key value.
 //
 // aes_key = substr (sha256_a, 0, 8) + substr (sha256_b, 8, 16) + substr (sha256_a, 24, 8);
-func aesKey(sha256a, sha256b []byte) bin.Int256 {
-	var v bin.Int256
+func aesKey(sha256a, sha256b []byte, v *bin.Int256) {
 	copy(v[:8], sha256a[:8])
 	copy(v[8:], sha256b[8:16+8])
 	copy(v[24:], sha256a[24:24+8])
-	return v
 }
 
 // aesIV returns aes_iv value.
 //
 // aes_iv = substr (sha256_b, 0, 8) + substr (sha256_a, 8, 16) + substr (sha256_b, 24, 8);
-func aesIV(sha256a, sha256b []byte) bin.Int256 {
+func aesIV(sha256a, sha256b []byte, v *bin.Int256) {
 	// Same as aes_key, but with swapped params.
-	return aesKey(sha256b, sha256a)
+	aesKey(sha256b, sha256a, v)
 }
 
 // Keys returns (aes_key, aes_iv) pair for AES-IGE.
@@ -112,11 +109,13 @@ func Keys(authKey Key, msgKey bin.Int128, mode Side) (key, iv bin.Int256) {
 
 	r := make([]byte, 512)
 	// `sha256_a = SHA256 (msg_key + substr (auth_key, x, 36));`
-	a := sha256a(r[0:0], authKey, msgKey, x)
+	a := sha256a(r[0:0], &authKey, &msgKey, x)
 	// `sha256_b = SHA256 (substr (auth_key, 40+x, 36) + msg_key);`
-	b := sha256b(r[256:256], authKey, msgKey, x)
+	b := sha256b(r[256:256], &authKey, &msgKey, x)
 
-	return aesKey(a, b), aesIV(a, b)
+	aesKey(a, b, &key)
+	aesIV(a, b, &iv)
+	return key, iv
 }
 
 // MessageKey computes message key for provided auth_key and padded payload.


### PR DESCRIPTION
```
$ benchstat -geomean old.txt new.txt
name     old time/op    new time/op    delta
Keys-12     401ns ± 2%     381ns ± 1%  -5.13%  (p=0.000 n=23+21)
```