### PR TITLE
Use mutable buffer for password

### DIFF
--- a/examples/auth/main.go
+++ b/examples/auth/main.go
@@ -3,6 +3,7 @@ package main
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
@@ -41,13 +42,13 @@ func (a termAuth) Phone(_ context.Context) (string, error) {
 	return a.phone, nil
 }
 
-func (a termAuth) Password(_ context.Context) (string, error) {
+func (a termAuth) Password(_ context.Context) ([]byte, error) {
 	fmt.Print("Enter 2FA password: ")
 	bytePwd, err := terminal.ReadPassword(0)
 	if err != nil {
-		return "", err
+		return []byte{}, err
 	}
-	return strings.TrimSpace(string(bytePwd)), nil
+	return bytes.TrimSpace(bytePwd), nil
 }
 
 func (a termAuth) Code(_ context.Context, _ *tg.AuthSentCode) (string, error) {

--- a/telegram/auth/flow_test.go
+++ b/telegram/auth/flow_test.go
@@ -20,7 +20,7 @@ func askCode(code string, err error) auth.CodeAuthenticatorFunc {
 
 func TestConstantAuth(t *testing.T) {
 	a := require.New(t)
-	authConst := auth.Constant("phone", "password", askCode("123", nil))
+	authConst := auth.Constant("phone", []byte("password"), askCode("123", nil))
 	ctx := context.Background()
 
 	result, err := authConst.Code(ctx, nil)
@@ -31,9 +31,9 @@ func TestConstantAuth(t *testing.T) {
 	a.NoError(err)
 	a.Equal("phone", result)
 
-	result, err = authConst.Password(ctx)
+	byteResult, err := authConst.Password(ctx)
 	a.NoError(err)
-	a.Equal("password", result)
+	a.Equal("password", string(byteResult))
 }
 
 func TestCodeOnlyAuth(t *testing.T) {
@@ -78,9 +78,9 @@ func TestEnvAuth(t *testing.T) {
 	a.NoError(err)
 	a.Equal("phone", result)
 
-	result, err = authEnv.Password(ctx)
+	byteResult, err := authEnv.Password(ctx)
 	a.NoError(err)
-	a.Equal("password", result)
+	a.Equal("password", string(byteResult))
 }
 
 func TestTestAuth(t *testing.T) {

--- a/telegram/auth/password.go
+++ b/telegram/auth/password.go
@@ -79,7 +79,7 @@ type UpdatePasswordOptions struct {
 // See https://core.telegram.org/api/srp#setting-a-new-2fa-password.
 func (c *Client) UpdatePassword(
 	ctx context.Context,
-	newPassword string,
+	newPassword []byte,
 	opts UpdatePasswordOptions,
 ) error {
 	p, err := c.api.AccountGetPassword(ctx)

--- a/telegram/auth/password_example_test.go
+++ b/telegram/auth/password_example_test.go
@@ -15,7 +15,7 @@ func ExampleClient_UpdatePassword() {
 	client := telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{})
 	if err := client.Run(ctx, func(ctx context.Context) error {
 		// Updating password.
-		if err := client.Auth().UpdatePassword(ctx, "new_password", auth.UpdatePasswordOptions{
+		if err := client.Auth().UpdatePassword(ctx, []byte("new_password"), auth.UpdatePasswordOptions{
 			// Hint sets new password hint.
 			Hint: "new password hint",
 			// Password will be called if old password is requested by Telegram.

--- a/telegram/auth/password_test.go
+++ b/telegram/auth/password_test.go
@@ -80,10 +80,10 @@ func TestClient_UpdatePassword(t *testing.T) {
 		client *Client,
 	) {
 		m.ExpectCall(&tg.AccountGetPasswordRequest{}).ThenErr(testutil.TestError())
-		a.Error(client.UpdatePassword(ctx, "", UpdatePasswordOptions{}))
+		a.Error(client.UpdatePassword(ctx, []byte{}, UpdatePasswordOptions{}))
 
 		expectCall(a, m, false).ThenTrue()
-		a.NoError(client.UpdatePassword(ctx, "", UpdatePasswordOptions{
+		a.NoError(client.UpdatePassword(ctx, []byte{}, UpdatePasswordOptions{
 			Hint: "hint",
 		}))
 	}))
@@ -100,7 +100,7 @@ func TestClient_UpdatePassword(t *testing.T) {
 				CurrentAlgo:   testAlgo,
 				NewSecureAlgo: &tg.SecurePasswordKdfAlgoUnknown{},
 			})
-		a.ErrorIs(client.UpdatePassword(ctx, "", UpdatePasswordOptions{}), ErrPasswordNotProvided)
+		a.ErrorIs(client.UpdatePassword(ctx, []byte{}, UpdatePasswordOptions{}), ErrPasswordNotProvided)
 
 		m.ExpectCall(&tg.AccountGetPasswordRequest{}).
 			ThenResult(&tg.AccountPassword{
@@ -109,7 +109,7 @@ func TestClient_UpdatePassword(t *testing.T) {
 				CurrentAlgo:   testAlgo,
 				NewSecureAlgo: &tg.SecurePasswordKdfAlgoUnknown{},
 			})
-		a.ErrorIs(client.UpdatePassword(ctx, "", UpdatePasswordOptions{
+		a.ErrorIs(client.UpdatePassword(ctx, []byte{}, UpdatePasswordOptions{
 			Hint: "hint",
 			Password: func(ctx context.Context) (string, error) {
 				return "", testutil.TestError()
@@ -117,7 +117,7 @@ func TestClient_UpdatePassword(t *testing.T) {
 		}), testutil.TestError())
 
 		expectCall(a, m, true).ThenTrue()
-		a.NoError(client.UpdatePassword(ctx, "", UpdatePasswordOptions{
+		a.NoError(client.UpdatePassword(ctx, []byte{}, UpdatePasswordOptions{
 			Hint: "hint",
 			Password: func(ctx context.Context) (string, error) {
 				return "password", nil

--- a/telegram/auth/user.go
+++ b/telegram/auth/user.go
@@ -19,13 +19,13 @@ var ErrPasswordInvalid = errors.New("invalid password")
 // Password performs login via secure remote password (aka 2FA).
 //
 // Method can be called after SignIn to provide password if requested.
-func (c *Client) Password(ctx context.Context, password string) (*tg.AuthAuthorization, error) {
+func (c *Client) Password(ctx context.Context, password []byte) (*tg.AuthAuthorization, error) {
 	p, err := c.api.AccountGetPassword(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "get SRP parameters")
 	}
 
-	a, err := PasswordHash([]byte(password), p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
+	a, err := PasswordHash(password, p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
 	if err != nil {
 		return nil, errors.Wrap(err, "compute password hash")
 	}

--- a/telegram/auth/user_test.go
+++ b/telegram/auth/user_test.go
@@ -33,6 +33,9 @@ func TestClient_AuthSignIn(t *testing.T) {
 		password = "secret"
 		codeHash = "hash"
 	)
+
+	passwordBytes := []byte(password)
+
 	ctx := context.Background()
 	testUser := &tg.User{ID: 1}
 	invoker := tgmock.Invoker(func(body bin.Encoder) (bin.Encoder, error) {
@@ -114,13 +117,13 @@ func TestClient_AuthSignIn(t *testing.T) {
 		require.ErrorIs(t, signInErr, ErrPasswordAuthNeeded)
 
 		// 3. Provide 2FA password.
-		result, err := client.Password(ctx, password)
+		result, err := client.Password(ctx, passwordBytes)
 		require.NoError(t, err)
 		require.Equal(t, testUser, result.User)
 	})
 
 	flow := NewFlow(
-		Constant(phone, password, CodeAuthenticatorFunc(
+		Constant(phone, passwordBytes, CodeAuthenticatorFunc(
 			func(ctx context.Context, _ *tg.AuthSentCode) (string, error) {
 				return code, nil
 			},

--- a/telegram/auth_example_test.go
+++ b/telegram/auth_example_test.go
@@ -68,6 +68,8 @@ func ExampleClient_Auth_password() {
 		phone       = os.Getenv("PHONE")
 		pass        = os.Getenv("PASSWORD")
 	)
+	passBytes := []byte(pass)
+
 	if appIDString == "" || appHash == "" || phone == "" || pass == "" {
 		log.Fatal("PHONE, PASSWORD, APP_ID or APP_HASH is not set")
 	}
@@ -89,7 +91,7 @@ func ExampleClient_Auth_password() {
 
 	check(client.Run(ctx, func(ctx context.Context) error {
 		return auth.NewFlow(
-			auth.Constant(phone, pass, auth.CodeAuthenticatorFunc(codeAsk)),
+			auth.Constant(phone, passBytes, auth.CodeAuthenticatorFunc(codeAsk)),
 			auth.SendCodeOptions{},
 		).Run(ctx, client.Auth())
 	}))

--- a/telegram/internal/e2etest/auth_test.go
+++ b/telegram/internal/e2etest/auth_test.go
@@ -25,7 +25,7 @@ func (m *mockFlow) SignIn(context.Context, string, string, string) (*tg.AuthAuth
 		return nil, auth.ErrPasswordAuthNeeded
 	}
 
-	return m.Password(context.Background(), "")
+	return m.Password(context.Background(), []byte{})
 }
 
 func (m *mockFlow) SendCode(context.Context, string, auth.SendCodeOptions) (*tg.AuthSentCode, error) {
@@ -36,7 +36,7 @@ func (m *mockFlow) SendCode(context.Context, string, auth.SendCodeOptions) (*tg.
 	}, nil
 }
 
-func (m *mockFlow) Password(context.Context, string) (*tg.AuthAuthorization, error) {
+func (m *mockFlow) Password(context.Context, []byte) (*tg.AuthAuthorization, error) {
 	return &tg.AuthAuthorization{
 		User: &tg.User{
 			ID:       10,


### PR DESCRIPTION
As i know golang's strings are immutable. [So they are not good for storing passwords in terms of security](https://stackoverflow.com/questions/39968084/is-it-possible-to-zero-a-golang-strings-memory-safely). As a solutuion i suggest to use []byte for passwords. This also removes bad conversions in terminal password input and password hashing, becase they actually use []byte, not string.