### PR TITLE
chore: ignore dependency upgrades in release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,4 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies


### PR DESCRIPTION
- Stops listing the Dependa PRs in the auto-generated release notes.