### PR TITLE
fix(qrlogin): import token after migration

### DIFF
--- a/telegram/auth/qrlogin/errors.go
+++ b/telegram/auth/qrlogin/errors.go
@@ -9,7 +9,12 @@ import (
 // MigrationNeededError reports that Telegram requested DC migration to continue login.
 type MigrationNeededError struct {
 	MigrateTo *tg.AuthLoginTokenMigrateTo
-	Tried     bool
+
+	// Tried indicates that the migration was attempted.
+	//
+	// Deprecated: do not use. QR login uses migrate function passed via
+	// options.
+	Tried bool
 }
 
 // Error implements error.


### PR DESCRIPTION
This change fixes the DC migration in `qrlogin` package.

>If, however, there is a DC mismatch between the two apps, [auth.loginTokenMigrateTo](https://core.telegram.org/constructor/auth.loginTokenMigrateTo) is returned instead, to which *the app that is trying to login should respond by calling [auth.importLoginToken](https://core.telegram.org/method/auth.importLoginToken) with the specified token, to the specified DC*.
https://core.telegram.org/api/qr-login