### PR TITLE
chore(updates): cleanup blocked channels

### DIFF
--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -98,10 +98,6 @@ func (s *channelState) Push(ctx context.Context, u channelUpdate) error {
 func (s *channelState) Run(ctx context.Context) error {
 	// Subscribe to channel updates.
 	if err := s.getDifference(ctx); err != nil {
-		if tg.IsChannelPrivate(err) {
-			s.storage.DeleteChannelPts(ctx, s.selfID, s.channelID)
-			s.log.Debug("Channel is private. Deleting state")
-		}
 		s.log.Error("Failed to subscribe to channel updates", zap.Error(err))
 	}
 
@@ -254,6 +250,10 @@ func (s *channelState) getDifference(ctx context.Context) error {
 		Limit:  s.diffLim,
 	})
 	if err != nil {
+		if tg.IsChannelPrivate(err) {
+			s.storage.DeleteChannelPts(ctx, s.selfID, s.channelID)
+			s.log.Debug("Channel is private. Deleting state")
+		}
 		return errors.Wrap(err, "get channel difference")
 	}
 

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -98,6 +98,10 @@ func (s *channelState) Push(ctx context.Context, u channelUpdate) error {
 func (s *channelState) Run(ctx context.Context) error {
 	// Subscribe to channel updates.
 	if err := s.getDifference(ctx); err != nil {
+		if tg.IsChannelPrivate(err) {
+			s.storage.DeleteChannelPts(ctx, s.selfID, s.channelID)
+			s.log.Debug("Channel is private. Deleting state")
+		}
 		s.log.Error("Failed to subscribe to channel updates", zap.Error(err))
 	}
 

--- a/telegram/updates/storage.go
+++ b/telegram/updates/storage.go
@@ -35,6 +35,7 @@ type StateStorage interface {
 	SetDateSeq(ctx context.Context, userID int64, date, seq int) error
 	GetChannelPts(ctx context.Context, userID, channelID int64) (pts int, found bool, err error)
 	SetChannelPts(ctx context.Context, userID, channelID int64, pts int) error
+	DeleteChannelPts(ctx context.Context, userID, channelID int64) error
 	ForEachChannels(ctx context.Context, userID int64, f func(ctx context.Context, channelID int64, pts int) error) error
 }
 

--- a/telegram/updates/storage_mem.go
+++ b/telegram/updates/storage_mem.go
@@ -136,6 +136,19 @@ func (s *memStorage) GetChannelPts(ctx context.Context, userID, channelID int64)
 	return
 }
 
+func (s *memStorage) DeleteChannelPts(ctx context.Context, userID, channelID int64) error {
+	s.mux.Lock()
+	defer s.mux.Unlock()
+
+	channels, ok := s.channels[userID]
+	if !ok {
+		return errors.New("user internalState does not exist")
+	}
+
+	delete(channels, channelID)
+	return nil
+}
+
 func (s *memStorage) ForEachChannels(ctx context.Context, userID int64, f func(ctx context.Context, channelID int64, pts int) error) error {
 	s.mux.Lock()
 	defer s.mux.Unlock()


### PR DESCRIPTION
This is the first step in better channels gaps management

Todo: stop checking gaps after connection loss or timeout in blocked channels