### PR TITLE
feat(message): add missing inline & markup builders

### DIFF
--- a/telegram/message/inline/inline.go
+++ b/telegram/message/inline/inline.go
@@ -31,6 +31,9 @@ type ResultBuilder struct {
 	// If passed, clients will display a button with specified text that switches the user to
 	// a private chat with the bot and sends the bot a start message with a certain parameter.
 	switchPm tg.InlineBotSwitchPM
+	// If passed, clients will display a button on top of the remaining inline result list
+	// with the specified text, that switches the user to the specified bot web app.
+	switchWebview tg.InlineBotWebView
 }
 
 // New creates new ResultBuilder.
@@ -84,6 +87,18 @@ func (r *ResultBuilder) SwitchPM(text, startParam string) *ResultBuilder {
 	return r
 }
 
+// SwitchWebview sets SwitchWebview field.
+//
+// If passed, clients will display a button on top of the remaining inline result list
+// with the specified text, that switches the user to the specified bot web app.
+func (r *ResultBuilder) SwitchWebview(text, url string) *ResultBuilder {
+	r.switchWebview = tg.InlineBotWebView{
+		Text: text,
+		URL:  url,
+	}
+	return r
+}
+
 // Set sets inline results for given query.
 func (r *ResultBuilder) Set(ctx context.Context, opts ...ResultOption) (bool, error) {
 	res := resultPageBuilder{
@@ -98,13 +113,14 @@ func (r *ResultBuilder) Set(ctx context.Context, opts ...ResultOption) (bool, er
 	}
 
 	ok, err := r.raw.MessagesSetInlineBotResults(ctx, &tg.MessagesSetInlineBotResultsRequest{
-		Private:    r.private,
-		QueryID:    r.queryID,
-		Results:    res.results,
-		CacheTime:  r.cacheTime,
-		NextOffset: r.nextOffset,
-		SwitchPm:   r.switchPm,
-		Gallery:    r.gallery,
+		Private:       r.private,
+		QueryID:       r.queryID,
+		Results:       res.results,
+		CacheTime:     r.cacheTime,
+		NextOffset:    r.nextOffset,
+		SwitchPm:      r.switchPm,
+		Gallery:       r.gallery,
+		SwitchWebview: r.switchWebview,
 	})
 	if err != nil {
 		return false, errors.Wrap(err, "set inline results")

--- a/telegram/message/markup/button.go
+++ b/telegram/message/markup/button.go
@@ -74,7 +74,20 @@ func Buy(text string) *tg.KeyboardButtonBuy {
 	}
 }
 
+// InputURLAuth creates button to request a user to authorize via URL using Seamless Telegram Login.
+// Can only be sent or received as part of an inline keyboard, use URLAuth for reply keyboards.
+func InputURLAuth(requestWriteAccess bool, text, fwdText, url string, bot tg.InputUserClass) *tg.InputKeyboardButtonURLAuth {
+	return &tg.InputKeyboardButtonURLAuth{
+		RequestWriteAccess: requestWriteAccess,
+		Text:               text,
+		FwdText:            fwdText,
+		URL:                url,
+		Bot:                bot,
+	}
+}
+
 // URLAuth creates button to request a user to authorize via URL using Seamless Telegram Login.
+// Can only be sent or received as part of a reply keyboard, use InputURLAuth for inline keyboards.
 func URLAuth(text, url string, buttonID int, fwdText string) *tg.KeyboardButtonURLAuth {
 	return &tg.KeyboardButtonURLAuth{
 		Text:     text,
@@ -90,5 +103,53 @@ func RequestPoll(text string, quiz bool) *tg.KeyboardButtonRequestPoll {
 	return &tg.KeyboardButtonRequestPoll{
 		Text: text,
 		Quiz: quiz,
+	}
+}
+
+// InputUserProfile creates button that links directly to a user profile.
+// Can only be sent or received as part of an inline keyboard, use UserProfile for reply keyboards.
+func InputUserProfile(text string, user tg.InputUserClass) *tg.InputKeyboardButtonUserProfile {
+	return &tg.InputKeyboardButtonUserProfile{
+		Text:   text,
+		UserID: user,
+	}
+}
+
+// UserProfile creates button that links directly to a user profile.
+// Can only be sent or received as part of a reply keyboard, use InputUserProfile for inline keyboards.
+func UserProfile(text string, userID int64) *tg.KeyboardButtonUserProfile {
+	return &tg.KeyboardButtonUserProfile{
+		Text:   text,
+		UserID: userID,
+	}
+}
+
+// WebView creates button to open a bot web app using messages.requestWebView, sending over user information after
+// user confirmation.
+// Can only be sent or received as part of an inline keyboard, use SimpleWebView for reply keyboards.
+func WebView(text, url string) *tg.KeyboardButtonWebView {
+	return &tg.KeyboardButtonWebView{
+		Text: text,
+		URL:  url,
+	}
+}
+
+// SimpleWebView creates button to open a bot web app using messages.requestSimpleWebView, without sending user
+// information to the web app.
+// Can only be sent or received as part of a reply keyboard, use WebView for inline keyboards.
+func SimpleWebView(text, url string) *tg.KeyboardButtonSimpleWebView {
+	return &tg.KeyboardButtonSimpleWebView{
+		Text: text,
+		URL:  url,
+	}
+}
+
+// RequestPeer creates button that prompts the user to select and share a peer with the bot using
+// messages.sendBotRequestedPeer.
+func RequestPeer(text string, buttonID int, peerType tg.RequestPeerTypeClass) *tg.KeyboardButtonRequestPeer {
+	return &tg.KeyboardButtonRequestPeer{
+		Text:     text,
+		ButtonID: buttonID,
+		PeerType: peerType,
 	}
 }

--- a/telegram/message/markup/inline_test.go
+++ b/telegram/message/markup/inline_test.go
@@ -19,8 +19,10 @@ func TestInlineRow(t *testing.T) {
 		SwitchInline("inline", "query", true),
 		Game("game"),
 		Buy("buy"),
-		URLAuth("text", "url", 1, "fwd"),
+		InputURLAuth(false, "text", "fwdText", "url", &tg.InputUserSelf{}),
 		RequestPoll("poll", true),
+		InputUserProfile("me", &tg.InputUserSelf{}),
+		WebView("demo", "https://webappcontent.telegram.org/demo"),
 	}
 
 	v, ok := InlineRow(buttons...).(*tg.ReplyInlineMarkup)

--- a/telegram/message/markup/keyboard_test.go
+++ b/telegram/message/markup/keyboard_test.go
@@ -21,6 +21,9 @@ func TestSingleRow(t *testing.T) {
 		Buy("buy"),
 		URLAuth("text", "url", 1, "fwd"),
 		RequestPoll("poll", true),
+		UserProfile("BotFather", 93372553),
+		SimpleWebView("demo", "https://webappcontent.telegram.org/demo"),
+		RequestPeer("peer", 0, &tg.RequestPeerTypeUser{}),
 	}
 
 	v, ok := SingleRow(buttons...).(*tg.ReplyKeyboardMarkup)


### PR DESCRIPTION
For inline:
* new builder for `switch_webview` parameter in [messages.setInlineBotResults](https://core.telegram.org/method/messages.setInlineBotResults).

And for markup I've added builders for all missing buttons:
* [inputKeyboardButtonUrlAuth](https://core.telegram.org/constructor/inputKeyboardButtonUrlAuth) — `InputURLAuth` + doc comment fix for `URLAuth`;
* [inputKeyboardButtonUserProfile](https://core.telegram.org/constructor/inputKeyboardButtonUserProfile) — `InputUserProfile` and [keyboardButtonUserProfile](https://core.telegram.org/constructor/keyboardButtonUserProfile) — `UserProfile`;
* [keyboardButtonWebView](https://core.telegram.org/constructor/keyboardButtonWebView) — `WebView` and [keyboardButtonSimpleWebView](https://core.telegram.org/constructor/keyboardButtonSimpleWebView) — `SimpleWebView`;
* new button [keyboardButtonRequestPeer](https://core.telegram.org/constructor/keyboardButtonRequestPeer) — `RequestPeer`.