### PR TITLE
fix: per-user locks on authorization transfer

### DIFF
--- a/telegram/transfer.go
+++ b/telegram/transfer.go
@@ -2,11 +2,15 @@ package telegram
 
 import (
 	"context"
-
 	"github.com/go-faster/errors"
 
 	"github.com/gotd/td/tg"
+
+	"sync"
 )
+
+var authorizationTransferLocks = make(map[int64]*sync.Mutex)
+var authorizationTransferLocksMutex = sync.Mutex{}
 
 func (c *Client) exportAuth(ctx context.Context, dcID int) (*tg.AuthExportedAuthorization, error) {
 	export, err := c.tg.AuthExportAuthorization(ctx, dcID)
@@ -20,6 +24,22 @@ func (c *Client) exportAuth(ctx context.Context, dcID int) (*tg.AuthExportedAuth
 // transfer exports current authorization and imports it to another DC.
 // See https://core.telegram.org/api/datacenter#authorization-transfer.
 func (c *Client) transfer(ctx context.Context, to *tg.Client, dc int) (tg.AuthAuthorizationClass, error) {
+	u, err := c.Self(context.Background())
+	if err != nil {
+		return nil, errors.Wrap(err, "get self")
+	}
+
+	authorizationTransferLocksMutex.Lock()
+	mx, ok := authorizationTransferLocks[u.ID]
+	if !ok {
+		mx = &sync.Mutex{}
+		authorizationTransferLocks[u.ID] = mx
+	}
+	authorizationTransferLocksMutex.Unlock()
+
+	mx.Lock()
+	defer mx.Unlock()
+
 	auth, err := c.exportAuth(ctx, dc)
 	if err != nil {
 		return nil, errors.Wrapf(err, "export to %d", dc)


### PR DESCRIPTION
Telegram does not seem to allow parallel import of authorization for the same account, even if this is done from different sessions. This commit adds per-autorization

It also would be more efficient not to call `.Self()` on every transfer (although this is an infrequent), help appreciated.

Closes #1213.