### PR TITLE
Update terminal.go for windows os

### DIFF
--- a/examples/terminal.go
+++ b/examples/terminal.go
@@ -55,7 +55,7 @@ func (a Terminal) Phone(_ context.Context) (string, error) {
 
 func (Terminal) Password(_ context.Context) (string, error) {
 	fmt.Print("Enter 2FA password: ")
-	bytePwd, err := term.ReadPassword(syscall.Stdin)
+	bytePwd, err := term.ReadPassword(int(syscall.Stdin))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
term.ReadPassword() requires an int. On windows passing syscall.Stdin without type casting fails.