### PR TITLE
fix(faketls): fix encoding SNI in faketls ClientHello

### DIFF
--- a/mtproxy/faketls/client_hello.go
+++ b/mtproxy/faketls/client_hello.go
@@ -44,7 +44,7 @@ func createClientHello(b *bin.Buffer, sessionID [32]byte, domain string, key [32
 		s := stack[lastIdx]
 		stack = stack[:lastIdx]
 
-		length := b.Len() - s + 2
+		length := b.Len() - (s + 2)
 		binary.BigEndian.PutUint16(b.Buf[s:], uint16(length))
 	}
 


### PR DESCRIPTION
Hi, I found a really annoying bug that prevented me from being able to use faketls based mtproto proxies.
It took a couple of days to figure out why, but I finally found the problem. Luckily it's a quick fix.

Just FYI, the telegram android and desktop codebases have updated their faketls implementation and I was wondering if you'd be interested in me contributing a follow-up PR with those improvements.


> The offset calculation used in the stack code in the ClientHello creation function was incorrect, resulting in the SNI field not being correctly encoded and therefore not being able to connect to faketls mtproto proxies.
> 
> Added parenthesis to fix the math.