### PR TITLE
Update HTML Parser

### DIFF
--- a/telegram/message/html/html_example_test.go
+++ b/telegram/message/html/html_example_test.go
@@ -27,12 +27,16 @@ func sendHTML(ctx context.Context) error {
 <i>italic</i>, <em>italic</em>
 <u>underline</u>, <ins>underline</ins>
 <s>strikethrough</s>, <strike>strikethrough</strike>, <del>strikethrough</del>
-<b>bold <i>italic bold <s>italic bold strikethrough</s> <u>underline italic bold</u></i> bold</b>
+<span class="tg-spoiler">spoiler</span>, <tg-spoiler>spoiler</tg-spoiler>
+<b>bold <i>italic bold <s>italic bold strikethrough <span class="tg-spoiler">italic bold strikethrough spoiler</span></s> <u>underline italic bold</u></i> bold</b>
 <a href="http://www.example.com/">inline URL</a>
 <a href="tg://user?id=123456789">inline mention of a user</a>
+<tg-emoji emoji-id="5368324170671202286">👍</tg-emoji>
 <code>inline fixed-width code</code>
 <pre>pre-formatted fixed-width code block</pre>
-<pre><code class="language-python">pre-formatted fixed-width code block written in the Python programming language</code></pre>`))
+<pre><code class="language-python">pre-formatted fixed-width code block written in the Python programming language</code></pre>
+<blockquote>Block quotation started\nBlock quotation continued\nThe last line of the block quotation</blockquote>
+<blockquote expandable>Expandable block quotation started\nExpandable block quotation continued\nExpandable block quotation continued\nHidden by default part of the block quotation started\nExpandable block quotation continued\nThe last line of the block quotation</blockquote>`))
 		return err
 	})
 }

--- a/telegram/message/html/parser.go
+++ b/telegram/message/html/parser.go
@@ -2,6 +2,7 @@ package html
 
 import (
 	"io"
+	"strconv"
 	"strings"
 
 	"github.com/go-faster/errors"
@@ -45,6 +46,7 @@ const (
 	strong     = "strong"
 	span       = "span"
 	tgSpoiler  = "tg-spoiler"
+	tgEmoji    = "tg-emoji"
 	blockquote = "blockquote"
 )
 
@@ -79,6 +81,8 @@ func (p *htmlParser) tag(tn []byte) string {
 		return span
 	case tgSpoiler:
 		return tgSpoiler
+	case tgEmoji:
+		return tgEmoji
 	case blockquote:
 		return blockquote
 	default:
@@ -157,6 +161,10 @@ func (p *htmlParser) startTag() error {
 		}
 	case tgSpoiler:
 		e.format = entity.Spoiler()
+	case tgEmoji:
+		if id, err := strconv.ParseInt(p.attr["emoji-id"], 10, 64); err == nil {
+			e.format = entity.CustomEmoji(id)
+		}
 	case blockquote:
 		_, collapsed := p.attr["expandable"]
 		e.format = entity.Blockquote(collapsed)

--- a/telegram/message/html/parser.go
+++ b/telegram/message/html/parser.go
@@ -36,15 +36,16 @@ func (p *htmlParser) fillAttrs() {
 }
 
 const (
-	pre       = "pre"
-	code      = "code"
-	em        = "em"
-	ins       = "ins"
-	strike    = "strike"
-	del       = "del"
-	strong    = "strong"
-	span      = "span"
-	tgSpoiler = "tg-spoiler"
+	pre        = "pre"
+	code       = "code"
+	em         = "em"
+	ins        = "ins"
+	strike     = "strike"
+	del        = "del"
+	strong     = "strong"
+	span       = "span"
+	tgSpoiler  = "tg-spoiler"
+	blockquote = "blockquote"
 )
 
 func (p *htmlParser) tag(tn []byte) string {
@@ -78,6 +79,8 @@ func (p *htmlParser) tag(tn []byte) string {
 		return span
 	case tgSpoiler:
 		return tgSpoiler
+	case blockquote:
+		return blockquote
 	default:
 		return string(tn)
 	}
@@ -154,6 +157,9 @@ func (p *htmlParser) startTag() error {
 		}
 	case tgSpoiler:
 		e.format = entity.Spoiler()
+	case blockquote:
+		_, collapsed := p.attr["expandable"]
+		e.format = entity.Blockquote(collapsed)
 	}
 
 	p.stack.push(e)

--- a/telegram/message/html/parser_test.go
+++ b/telegram/message/html/parser_test.go
@@ -107,6 +107,7 @@ func TestHTML(t *testing.T) {
 				entities: getEntities(entity.Pre("python"))},
 			{html: "<b>&lt;</b>", msg: "<", entities: getEntities(entity.Bold())},
 			{html: `<span class="tg-spoiler">spoiler</span>`, msg: "spoiler", entities: getEntities(entity.Spoiler())},
+			{html: "<tg-emoji emoji-id=\"5368324170671202286\">👍</tg-emoji>", msg: "👍", entities: getEntities(entity.CustomEmoji(5368324170671202286))},
 			{html: "<blockquote expandable>quote</blockquote>", msg: "quote", entities: getEntities(entity.Blockquote(true))},
 			{html: "<blockquote>quote</blockquote>", msg: "quote", entities: getEntities(entity.Blockquote(false))},
 		}

--- a/telegram/message/html/parser_test.go
+++ b/telegram/message/html/parser_test.go
@@ -107,6 +107,8 @@ func TestHTML(t *testing.T) {
 				entities: getEntities(entity.Pre("python"))},
 			{html: "<b>&lt;</b>", msg: "<", entities: getEntities(entity.Bold())},
 			{html: `<span class="tg-spoiler">spoiler</span>`, msg: "spoiler", entities: getEntities(entity.Spoiler())},
+			{html: "<blockquote expandable>quote</blockquote>", msg: "quote", entities: getEntities(entity.Blockquote(true))},
+			{html: "<blockquote>quote</blockquote>", msg: "quote", entities: getEntities(entity.Blockquote(false))},
 		}
 		t.Run("Common", runTests(tests, false))
 	}


### PR DESCRIPTION
[https://core.telegram.org/bots/api#html-style]
Added support for the tg-emoji(custom emojis) and blockquote tag
I also updated the test message from bot API docs adding the tg-spoiler, tg-emoji, and blockquote tags.