### PR TITLE
feat(upload): add support for streamed uploads of Big File

### DIFF
--- a/telegram/uploader/helpers.go
+++ b/telegram/uploader/helpers.go
@@ -60,6 +60,8 @@ func (u *Uploader) FromFS(ctx context.Context, filesystem fs.FS, path string) (_
 // FromReader uploads file from given io.Reader.
 // NB: totally stream should not exceed the limit for
 // small files (10 MB as docs says, may be a bit bigger).
+// Support For Big Files
+// https://core.telegram.org/api/files#streamed-uploads
 func (u *Uploader) FromReader(ctx context.Context, name string, f io.Reader) (tg.InputFileClass, error) {
 	return u.Upload(ctx, NewUpload(name, f, -1))
 }

--- a/telegram/uploader/uploader.go
+++ b/telegram/uploader/uploader.go
@@ -82,6 +82,10 @@ func (u *Uploader) Upload(ctx context.Context, upload *Upload) (tg.InputFileClas
 	if err := u.initUpload(upload); err != nil {
 		return nil, err
 	}
+	if upload.totalBytes == -1 {
+		upload.big = true
+		upload.totalParts = -1
+	}
 
 	if !upload.big {
 		return u.uploadSmall(ctx, upload)


### PR DESCRIPTION
[Streamed uploads](https://core.telegram.org/api/files#streamed-uploads)
- A total_stream_size variable must be used to keep track of the total number of bytes read from the stream.

- upload.saveBigFilePart must always be used, even if the stream turns out to be smaller than 10MB.

- The file_total_parts field must be set to -1 for all parts except for the last one, using the following logic: