### PR TITLE
feat(telegram): add sugared wrapper for takeout sessions

### DIFF
--- a/telegram/takeout/takeout.go
+++ b/telegram/takeout/takeout.go
@@ -1,0 +1,108 @@
+// Package takeout provides a wrapper for Telegram takeout sessions.
+//
+// Takeout sessions allow exporting user data from Telegram. See
+// https://core.telegram.org/api/takeout for more information.
+package takeout
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+)
+
+// Client wraps tg.Invoker to use a takeout session.
+type Client struct {
+	id  int64
+	raw tg.Invoker
+}
+
+// Invoke implements tg.Invoker.
+func (c *Client) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+	obj, ok := input.(bin.Object)
+	if !ok {
+		return errors.Errorf("input %T does not implement bin.Object", input)
+	}
+	return c.raw.Invoke(ctx, &tg.InvokeWithTakeoutRequest{
+		TakeoutID: c.id,
+		Query:     obj,
+	}, output)
+}
+
+// ID returns takeout session ID.
+func (c *Client) ID() int64 {
+	return c.id
+}
+
+// Raw returns underlying invoker.
+func (c *Client) Raw() tg.Invoker {
+	return c.raw
+}
+
+// Config configures takeout session.
+type Config struct {
+	// Contacts enables exporting contacts.
+	Contacts bool
+	// MessageUsers enables exporting messages from private chats.
+	MessageUsers bool
+	// MessageChats enables exporting messages from basic groups.
+	MessageChats bool
+	// MessageMegagroups enables exporting messages from supergroups.
+	MessageMegagroups bool
+	// MessageChannels enables exporting messages from channels.
+	MessageChannels bool
+	// Files enables exporting files.
+	Files bool
+	// FileMaxSize sets maximum file size to export.
+	// Only used if Files is true.
+	FileMaxSize int64
+}
+
+func (c Config) request() *tg.AccountInitTakeoutSessionRequest {
+	r := &tg.AccountInitTakeoutSessionRequest{}
+	r.SetContacts(c.Contacts)
+	r.SetMessageUsers(c.MessageUsers)
+	r.SetMessageChats(c.MessageChats)
+	r.SetMessageMegagroups(c.MessageMegagroups)
+	r.SetMessageChannels(c.MessageChannels)
+	r.SetFiles(c.Files)
+	if c.FileMaxSize > 0 {
+		r.SetFileMaxSize(c.FileMaxSize)
+	}
+	return r
+}
+
+// Run initializes a takeout session and calls the provided function.
+//
+// The session is automatically finished when the function returns. If the
+// function returns nil, the session is marked as successful. Otherwise, the
+// session is marked as failed.
+func Run(ctx context.Context, invoker tg.Invoker, cfg Config, f func(ctx context.Context, client *Client) error) error {
+	raw := tg.NewClient(invoker)
+
+	takeout, err := raw.AccountInitTakeoutSession(ctx, cfg.request())
+	if err != nil {
+		return errors.Wrap(err, "init takeout session")
+	}
+
+	client := &Client{
+		id:  takeout.ID,
+		raw: invoker,
+	}
+
+	fnErr := f(ctx, client)
+
+	finishReq := &tg.AccountFinishTakeoutSessionRequest{}
+	finishReq.SetSuccess(fnErr == nil)
+
+	if _, err := raw.AccountFinishTakeoutSession(ctx, finishReq); err != nil {
+		if fnErr != nil {
+			return errors.Wrap(fnErr, "function failed")
+		}
+		return errors.Wrap(err, "finish takeout session")
+	}
+
+	return fnErr
+}

--- a/telegram/takeout/takeout_example_test.go
+++ b/telegram/takeout/takeout_example_test.go
@@ -1,0 +1,49 @@
+package takeout_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gotd/td/telegram/takeout"
+	"github.com/gotd/td/tg"
+)
+
+func ExampleRun() {
+	// This example demonstrates how to use the takeout API wrapper.
+	// In a real application, you would use a proper tg.Invoker.
+
+	ctx := context.Background()
+	var invoker tg.Invoker // obtained from telegram.Client
+
+	// Configure what data to export
+	cfg := takeout.Config{
+		Contacts:          true,
+		MessageUsers:      true,
+		MessageChats:      true,
+		MessageMegagroups: true,
+		MessageChannels:   true,
+		Files:             true,
+		FileMaxSize:       512 * 1024 * 1024, // 512 MB
+	}
+
+	err := takeout.Run(ctx, invoker, cfg, func(ctx context.Context, client *takeout.Client) error {
+		// All API calls made with client are wrapped with takeout session.
+		// Use tg.NewClient(client) to get a full API client.
+		api := tg.NewClient(client)
+
+		// For example, get dialogs:
+		dialogs, err := api.MessagesGetDialogs(ctx, &tg.MessagesGetDialogsRequest{
+			Limit: 100,
+		})
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("Got dialogs: %T\n", dialogs)
+		return nil
+	})
+	if err != nil {
+		// Handle error
+		_ = err
+	}
+}

--- a/telegram/takeout/takeout_test.go
+++ b/telegram/takeout/takeout_test.go
@@ -1,0 +1,178 @@
+package takeout
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+)
+
+type mockInvoker struct {
+	initErr   error
+	finishErr error
+	invokeErr error
+	takeoutID int64
+
+	initCalled   bool
+	finishCalled bool
+	lastSuccess  bool
+}
+
+func (m *mockInvoker) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+	switch input.(type) {
+	case *tg.AccountInitTakeoutSessionRequest:
+		m.initCalled = true
+		if m.initErr != nil {
+			return m.initErr
+		}
+		result := output.(*tg.AccountTakeout)
+		result.ID = m.takeoutID
+		return nil
+	case *tg.AccountFinishTakeoutSessionRequest:
+		m.finishCalled = true
+		req := input.(*tg.AccountFinishTakeoutSessionRequest)
+		m.lastSuccess = req.GetSuccess()
+		if m.finishErr != nil {
+			return m.finishErr
+		}
+		return nil
+	case *tg.InvokeWithTakeoutRequest:
+		return m.invokeErr
+	}
+	return nil
+}
+
+func TestRun(t *testing.T) {
+	ctx := context.Background()
+	testErr := errors.New("test error")
+
+	t.Run("Success", func(t *testing.T) {
+		mock := &mockInvoker{takeoutID: 123}
+
+		err := Run(ctx, mock, Config{
+			Contacts:     true,
+			MessageUsers: true,
+		}, func(ctx context.Context, client *Client) error {
+			require.Equal(t, int64(123), client.ID())
+			return nil
+		})
+
+		require.NoError(t, err)
+		require.True(t, mock.initCalled)
+		require.True(t, mock.finishCalled)
+		require.True(t, mock.lastSuccess)
+	})
+
+	t.Run("FunctionError", func(t *testing.T) {
+		mock := &mockInvoker{takeoutID: 123}
+
+		err := Run(ctx, mock, Config{}, func(ctx context.Context, client *Client) error {
+			return testErr
+		})
+
+		require.Error(t, err)
+		require.True(t, mock.finishCalled)
+		require.False(t, mock.lastSuccess)
+	})
+
+	t.Run("InitError", func(t *testing.T) {
+		mock := &mockInvoker{initErr: testErr}
+
+		err := Run(ctx, mock, Config{}, func(ctx context.Context, client *Client) error {
+			t.Fatal("function should not be called")
+			return nil
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "init takeout session")
+	})
+
+	t.Run("FinishError", func(t *testing.T) {
+		mock := &mockInvoker{takeoutID: 123, finishErr: testErr}
+
+		err := Run(ctx, mock, Config{}, func(ctx context.Context, client *Client) error {
+			return nil
+		})
+
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "finish takeout session")
+	})
+}
+
+func TestClient_Invoke(t *testing.T) {
+	ctx := context.Background()
+
+	invoked := false
+	var capturedRequest *tg.InvokeWithTakeoutRequest
+
+	mock := &tg.Client{}
+	invoker := invokerFunc(func(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+		invoked = true
+		var ok bool
+		capturedRequest, ok = input.(*tg.InvokeWithTakeoutRequest)
+		if !ok {
+			t.Fatalf("expected InvokeWithTakeoutRequest, got %T", input)
+		}
+		return nil
+	})
+	_ = mock
+
+	client := &Client{
+		id:  456,
+		raw: invoker,
+	}
+
+	err := client.Invoke(ctx, &tg.MessagesGetHistoryRequest{}, &tg.MessagesMessagesBox{})
+	require.NoError(t, err)
+	require.True(t, invoked)
+	require.NotNil(t, capturedRequest)
+	require.Equal(t, int64(456), capturedRequest.TakeoutID)
+}
+
+type invokerFunc func(ctx context.Context, input bin.Encoder, output bin.Decoder) error
+
+func (f invokerFunc) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+	return f(ctx, input, output)
+}
+
+func TestConfig_request(t *testing.T) {
+	cfg := Config{
+		Contacts:          true,
+		MessageUsers:      true,
+		MessageChats:      true,
+		MessageMegagroups: true,
+		MessageChannels:   true,
+		Files:             true,
+		FileMaxSize:       1024 * 1024,
+	}
+
+	req := cfg.request()
+
+	require.True(t, req.GetContacts())
+	require.True(t, req.GetMessageUsers())
+	require.True(t, req.GetMessageChats())
+	require.True(t, req.GetMessageMegagroups())
+	require.True(t, req.GetMessageChannels())
+	require.True(t, req.GetFiles())
+	size, ok := req.GetFileMaxSize()
+	require.True(t, ok)
+	require.Equal(t, int64(1024*1024), size)
+}
+
+func TestClient_Raw(t *testing.T) {
+	mock := invokerFunc(func(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+		return nil
+	})
+
+	client := &Client{
+		id:  789,
+		raw: mock,
+	}
+
+	require.Equal(t, int64(789), client.ID())
+	require.NotNil(t, client.Raw())
+}


### PR DESCRIPTION
Fixes #1332

## Changes
- Add telegram/takeout package with Client wrapper that implements tg.Invoker
- Client.Invoke automatically wraps calls with InvokeWithTakeoutRequest
- Add Run function to manage takeout session lifecycle (init, callback, cleanup)
- Add Config struct for configuring takeout session options (contacts, messages, files, etc.)