### PR TITLE
fix(updates): prevent deadlock when relaying channel difference

### DIFF
--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -256,17 +256,15 @@ func (s *channelState) getDifference(ctx context.Context) error {
 	switch diff := diff.(type) {
 	case *tg.UpdatesChannelDifference:
 		if len(diff.OtherUpdates) > 0 {
-			select {
-			case s.out <- tracedUpdate{
+			if err := s.sendOut(ctx, tracedUpdate{
 				span: trace.SpanContextFromContext(ctx),
 				update: &tg.Updates{
 					Updates: diff.OtherUpdates,
 					Users:   diff.Users,
 					Chats:   diff.Chats,
 				},
-			}:
-			case <-ctx.Done():
-				return ctx.Err()
+			}); err != nil {
+				return err
 			}
 		}
 
@@ -328,6 +326,33 @@ func (s *channelState) getDifference(ctx context.Context) error {
 
 	default:
 		return errors.Errorf("unexpected channel diff type: %T", diff)
+	}
+}
+
+// sendOut hands off updates to the *internalState worker via s.out.
+//
+// While waiting for the worker to accept the update, it keeps draining its own
+// input queue. Otherwise the worker may block pushing into s.updates while this
+// goroutine blocks pushing into s.out, producing a deadlock (both queues are
+// bounded and the worker is the only reader of s.out).
+//
+// Drained updates are ignored on purpose: they are restored by a future
+// getChannelDifference call, same as in the diffTimeout wait above.
+func (s *channelState) sendOut(ctx context.Context, out tracedUpdate) error {
+	for {
+		select {
+		case s.out <- out:
+			return nil
+		case u, ok := <-s.updates:
+			if !ok {
+				continue
+			}
+			s.log.Debug("Ignoring update while sending channel difference",
+				zap.Any("update", u.update),
+			)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

A circular wait can hang update processing between the two worker goroutines:

- The `internalState` worker (main `Run` loop) is the **only** reader of `internalQueue`. While processing a batch in `applyCombined` → `handleChannel` → `channelState.Push`, it blocks writing into a channel's bounded `updates` queue (cap 10) when full.
- The `channelState` worker, inside `getDifference`, blocks writing `diff.OtherUpdates` into `s.out` (= `internalQueue`, cap 10) when full — and it's full precisely because the main worker is stuck above and not draining it.

Both selects only release on `ctx.Done()`, so updates stop flowing until shutdown.

The same hazard is already mitigated in the `diffTimeout` wait branch of `getDifference` ("Ignoring updates to prevent *internalState worker from blocking"), but the actual `s.out <-` hand-off had no such protection.

## Fix

Add `channelState.sendOut`, which keeps draining the channel's own input queue while waiting for the worker to accept the hand-off. This guarantees the main worker can always complete its `Push` and return to its select to drain `internalQueue`, so the cycle can no longer form.

This reuses the existing drain-and-ignore pattern; dropped updates are recovered by a future `getChannelDifference` call (or the idle timeout), so there is no permanent loss.

## Safety

- `getDifference`/`sendOut` run only on the single `channelState.Run` goroutine, so there is no concurrent read of `s.updates` and no new data race (verified with `-race`).
- `s.out` now has exactly one send site.
- The only new behavior — possibly dropping concurrent channel updates during the hand-off — is identical in kind to the pre-existing `diffTimeout` drain and is recoverable via the gap mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)