### PR TITLE
fix(proto): validate plaintext message length before allocation

### DIFF
--- a/proto/unencrypted_message.go
+++ b/proto/unencrypted_message.go
@@ -1,6 +1,8 @@
 package proto
 
 import (
+	"io"
+
 	"github.com/go-faster/errors"
 
 	"github.com/gotd/td/bin"
@@ -36,6 +38,15 @@ func (u *UnencryptedMessage) Decode(b *bin.Buffer) error {
 	dataLen, err := b.Int32()
 	if err != nil {
 		return err
+	}
+	if dataLen < 0 {
+		return &bin.InvalidLengthError{
+			Length: int(dataLen),
+			Where:  "plaintext message data",
+		}
+	}
+	if int(dataLen) > b.Len() {
+		return errors.Wrap(io.ErrUnexpectedEOF, "consume payload")
 	}
 	u.MessageData = append(u.MessageData[:0], make([]byte, dataLen)...)
 	if err := b.ConsumeN(u.MessageData, int(dataLen)); err != nil {

--- a/proto/unencrypted_message_test.go
+++ b/proto/unencrypted_message_test.go
@@ -1,6 +1,7 @@
 package proto
 
 import (
+	"io"
 	"testing"
 
 	"github.com/gotd/td/bin"
@@ -23,4 +24,33 @@ func TestUnencryptedMessage_Encode(t *testing.T) {
 	}
 	require.Equal(t, d, decoded)
 	require.Zero(t, b.Len(), "buffer should be consumed")
+}
+
+func TestUnencryptedMessage_DecodeInvalidDataLength(t *testing.T) {
+	t.Run("Negative", func(t *testing.T) {
+		b := new(bin.Buffer)
+		b.PutLong(0)
+		b.PutLong(1)
+		b.PutInt32(-1)
+
+		var decoded UnencryptedMessage
+		err := decoded.Decode(b)
+		require.Error(t, err)
+
+		var lengthErr *bin.InvalidLengthError
+		require.ErrorAs(t, err, &lengthErr)
+		require.Zero(t, decoded.MessageData)
+	})
+
+	t.Run("ExceedsRemainingBuffer", func(t *testing.T) {
+		b := new(bin.Buffer)
+		b.PutLong(0)
+		b.PutLong(1)
+		b.PutInt32(1024)
+
+		var decoded UnencryptedMessage
+		err := decoded.Decode(b)
+		require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+		require.Zero(t, decoded.MessageData)
+	})
 }


### PR DESCRIPTION
## Summary

Validate `proto.UnencryptedMessage` payload lengths before allocating `MessageData`.

This prevents malformed plaintext MTProto packets from forcing heap allocation based on an attacker-controlled `message_data_length` value before the decoder knows whether the buffer actually contains that many bytes.

Closes #1711.

## Background

Telegram's MTProto description defines unencrypted messages as:

- `auth_key_id = 0` (`int64`)
- `message_id` (`int64`)
- `message_data_length` (`int32`)
- `message_data` (`bytes`)

Reference: https://core.telegram.org/mtproto/description#unencrypted-messages

Because `message_data_length` is part of the untrusted inbound packet, the decoder must validate it before using it as an allocation size. The existing implementation allocated `make([]byte, dataLen)` before `ConsumeN` checked whether the buffer contained enough payload bytes.

## Implementation

- Reject negative `message_data_length` values with `bin.InvalidLengthError`.
- Return `consume payload: unexpected EOF` before allocation when the declared payload length exceeds the remaining buffer.
- Keep the existing successful decode path unchanged after validation.
- Add regression coverage for:
  - negative plaintext message data length
  - declared payload length larger than the remaining buffer

## Testing

```console
$ go test ./proto -run 'TestUnencryptedMessage' -count=1
ok  	github.com/gotd/td/proto	0.347s

$ go test ./proto ./exchange -count=1
ok  	github.com/gotd/td/proto	0.558s
ok  	github.com/gotd/td/exchange	4.209s

$ git diff --check
```

I also reproduced the previous behavior with the new regression test before applying the fix: a negative length panicked at `make([]byte, dataLen)`.

## Security impact

This narrows a pre-authentication plaintext MTProto parsing path so malformed packets cannot trigger allocation from an invalid or impossible payload length. A packet that claims a payload larger than the bytes already present in the buffer now fails before allocation.
