### PR TITLE
fix(downloader): retry wrapped transport timeouts

### DIFF
--- a/telegram/downloader/coverage_extra_test.go
+++ b/telegram/downloader/coverage_extra_test.go
@@ -3,6 +3,7 @@ package downloader
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,6 +42,23 @@ func TestRetryRequestTimeoutLimit(t *testing.T) {
 	require.Len(t, attempts, maxRetryAttempts-1)
 	require.Equal(t, maxRetryAttempts-1, attempts[len(attempts)-1])
 	require.Contains(t, err.Error(), "read chunk: retry limit reached")
+}
+
+func TestIsRetryableTimeout(t *testing.T) {
+	require.True(t, isRetryableTimeout(context.Background(), tgerr.New(500, tg.ErrTimeout)))
+	require.True(t, isRetryableTimeout(
+		context.Background(),
+		fmt.Errorf("create connection to DC 1: %w", testTimeoutError{}),
+	))
+	require.True(t, isRetryableTimeout(
+		context.Background(),
+		fmt.Errorf("request attempt: %w", context.DeadlineExceeded),
+	))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	require.False(t, isRetryableTimeout(ctx, testTimeoutError{}))
+	require.False(t, isRetryableTimeout(context.Background(), errors.New("boom")))
 }
 
 func TestCDNPlanValidationAndSplit(t *testing.T) {

--- a/telegram/downloader/downloader_test.go
+++ b/telegram/downloader/downloader_test.go
@@ -55,6 +55,7 @@ type mock struct {
 	cdnUploadTO    atomic.Bool
 	tokenInvalid   atomic.Bool
 	getTimeout     atomic.Bool
+	getNetTimeout  atomic.Bool
 	cdnGetTimeout  atomic.Bool
 	cdnHashTimeout atomic.Bool
 	cdnFingerprint atomic.Bool
@@ -67,6 +68,20 @@ type mock struct {
 }
 
 var testErr = testutil.TestError()
+
+type testTimeoutError struct{}
+
+func (testTimeoutError) Error() string {
+	return "i/o timeout"
+}
+
+func (testTimeoutError) Timeout() bool {
+	return true
+}
+
+func (testTimeoutError) Temporary() bool {
+	return true
+}
 
 func validCDNRequest(offset int64, limit int) bool {
 	if limit <= 0 {
@@ -115,6 +130,12 @@ func (m *mock) UploadGetFile(ctx context.Context, request *tg.UploadGetFileReque
 	}
 	if m.getTimeout.CompareAndSwap(true, false) {
 		return nil, tgerr.New(500, tg.ErrTimeout)
+	}
+	if m.getNetTimeout.CompareAndSwap(true, false) {
+		return nil, errors.Wrap(
+			testTimeoutError{},
+			"create connection to DC 1: transfer: onTransfer: export to 1",
+		)
 	}
 
 	if request.GetCDNSupported() && m.migrateOnce.CompareAndSwap(true, false) {
@@ -1855,6 +1876,28 @@ func TestDownloader_LegacyRetriesOnTimeout(t *testing.T) {
 		},
 	}
 	m.getTimeout.Store(true)
+
+	output := new(bytes.Buffer)
+	_, err := NewDownloader().Download(m, nil).Stream(ctx, output)
+	require.NoError(t, err)
+	require.Equal(t, data, output.Bytes())
+	require.GreaterOrEqual(t, m.getFileCalls.Load(), int32(2))
+}
+
+func TestDownloader_LegacyRetriesOnNetworkTimeout(t *testing.T) {
+	ctx := context.Background()
+	data := make([]byte, defaultPartSize+13)
+	if _, err := io.ReadFull(rand.Reader, data); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &mock{
+		data: data,
+		hashes: mockHashes{
+			ranges: countHashes(data, 128*1024),
+		},
+	}
+	m.getNetTimeout.Store(true)
 
 	output := new(bytes.Buffer)
 	_, err := NewDownloader().Download(m, nil).Stream(ctx, output)

--- a/telegram/downloader/reader.go
+++ b/telegram/downloader/reader.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/go-faster/errors"
 
-	"github.com/gotd/td/tg"
 	"github.com/gotd/td/tgerr"
 )
 
@@ -93,7 +92,7 @@ func (r *reader) next(ctx context.Context, offset int64, limit int) (block, erro
 		ch, err := r.sch.Chunk(ctx, offset, limit)
 
 		if flood, err := tgerr.FloodWait(ctx, err); err != nil {
-			if flood || tgerr.Is(err, tg.ErrTimeout) {
+			if flood || isRetryableTimeout(ctx, err) {
 				retryAttempt++
 				reportSchemaRetry(r.sch, RetryOperationReaderChunk, retryAttempt, err)
 				continue

--- a/telegram/downloader/retry.go
+++ b/telegram/downloader/retry.go
@@ -2,6 +2,7 @@ package downloader
 
 import (
 	"context"
+	"net"
 
 	"github.com/go-faster/errors"
 
@@ -28,6 +29,21 @@ func isCDNMasterFallbackErr(err error) bool {
 		"FILE_TOKEN_INVALID",
 		"REQUEST_TOKEN_INVALID",
 	)
+}
+
+func isRetryableTimeout(ctx context.Context, err error) bool {
+	if err == nil {
+		return false
+	}
+	if ctx.Err() != nil {
+		return false
+	}
+	if tgerr.Is(err, tg.ErrTimeout) || errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+
+	var netErr net.Error
+	return errors.As(err, &netErr) && netErr.Timeout()
 }
 
 func retryRequest[T any](
@@ -57,10 +73,7 @@ func retryRequest[T any](
 				}
 				continue
 			}
-			if tgerr.Is(waitErr, tg.ErrTimeout) {
-				if ctxErr := ctx.Err(); ctxErr != nil {
-					return zero, ctxErr
-				}
+			if isRetryableTimeout(ctx, waitErr) {
 				// Timeout can happen on unstable proxy links; retry with bounded
 				// attempts to avoid infinite tight loops.
 				timeoutRetries++

--- a/telegram/downloader/verifier.go
+++ b/telegram/downloader/verifier.go
@@ -105,7 +105,7 @@ func (v *verifier) next(ctx context.Context) (tg.FileHash, bool, error) {
 	for {
 		hashes, err := v.client.Hashes(ctx, v.offset)
 		if flood, err := tgerr.FloodWait(ctx, err); err != nil {
-			if flood || tgerr.Is(err, tg.ErrTimeout) {
+			if flood || isRetryableTimeout(ctx, err) {
 				// Keep retrying transient server throttling/timeouts.
 				retryAttempt++
 				reportSchemaRetry(v.client, RetryOperationReaderHashes, retryAttempt, err)


### PR DESCRIPTION
## Summary

Retry wrapped transport-level timeout errors in the downloader.

The downloader already retries Telegram RPC `Timeout` responses in the master, CDN, and hash-reader paths. However, an `upload.getFile` request can also fail before the server returns an RPC error, for example while a redirected file request is creating and authorizing a sub-DC connection. In that case the error is wrapped as a Go transport/context error, such as:

```text
create connection to DC 1: transfer: onTransfer: export to 1: context deadline exceeded
create connection to DC 1: transfer: onTransfer: export to 1: i/o timeout
```

Those wrapped timeout errors were not classified as retryable by downloader retry loops.

Refs #1725.

## Changes

- Add a shared `isRetryableTimeout(ctx, err)` helper for downloader retry paths.
- Treat the following as retryable only while the outer operation context is still active:
  - Telegram RPC `Timeout`
  - wrapped `context.DeadlineExceeded`
  - wrapped `net.Error` values whose `Timeout()` method returns true
- Reuse that classification in:
  - `retryRequest`
  - master reader chunk retries
  - verifier/hash reader retries
- Add regression coverage for a wrapped network timeout shaped like the `upload.getFile` sub-DC transfer failure.
- Add unit coverage for the retry classifier, including the guard that prevents retrying after the caller context is already canceled.

## Important behavior note

This does not ignore or extend the caller's context deadline. If the caller gives the whole download operation a short context, and that context is already expired, the downloader still returns the context error. The new behavior only retries transport-level timeout failures while the outer download context is still usable.

## Testing

```console
$ git diff --check
```

I attempted the focused downloader tests locally:

```console
$ go test ./telegram/downloader -run 'TestIsRetryableTimeout|TestDownloader_LegacyRetriesOnNetworkTimeout' -count=1 -timeout=2m
```

The command did not reach test execution in this environment; it repeatedly stalled in the Go compiler while compiling the package dependency graph. I stopped the stuck compiler processes after several minutes and verified no `go test` processes remained. CI should run the focused downloader tests and the broader package suite.
