### PR TITLE
fix(faketls): handle extra handshake and large records

### DIFF
--- a/mtproxy/faketls/faketls.go
+++ b/mtproxy/faketls/faketls.go
@@ -103,11 +103,11 @@ func (o *FakeTLS) Read(b []byte) (n int, err error) {
 		case RecordTypeChangeCipherSpec:
 			continue
 		case RecordTypeApplication:
-			o.readBuf.Write(rec.Data)
 		case RecordTypeHandshake:
-			return 0, errors.New("unexpected record type handshake during data phase")
+			return 0, errors.New("unexpected record type handshake")
 		default:
-			return 0, errors.Errorf("unsupported record type 0x%02x", rec.Type)
+			return 0, errors.Errorf("unsupported record type %v", rec.Type)
 		}
+		o.readBuf.Write(rec.Data)
 	}
 }

--- a/mtproxy/faketls/faketls.go
+++ b/mtproxy/faketls/faketls.go
@@ -89,24 +89,25 @@ func (o *FakeTLS) Read(b []byte) (n int, err error) {
 	o.readBufMux.Lock()
 	defer o.readBufMux.Unlock()
 
-	if o.readBuf.Len() > 0 {
-		return o.readBuf.Read(b)
-	}
+	for {
+		if o.readBuf.Len() > 0 {
+			return o.readBuf.Read(b)
+		}
 
-	rec, err := readRecord(o.conn)
-	if err != nil {
-		return 0, errors.Wrap(err, "read TLS record")
-	}
+		rec, err := readRecord(o.conn)
+		if err != nil {
+			return 0, errors.Wrap(err, "read TLS record")
+		}
 
-	switch rec.Type {
-	case RecordTypeChangeCipherSpec:
-	case RecordTypeApplication:
-	case RecordTypeHandshake:
-		return 0, errors.New("unexpected record type handshake")
-	default:
-		return 0, errors.Errorf("unsupported record type %v", rec.Type)
+		switch rec.Type {
+		case RecordTypeChangeCipherSpec:
+			continue
+		case RecordTypeApplication:
+			o.readBuf.Write(rec.Data)
+		case RecordTypeHandshake:
+			return 0, errors.New("unexpected record type handshake during data phase")
+		default:
+			return 0, errors.Errorf("unsupported record type 0x%02x", rec.Type)
+		}
 	}
-	o.readBuf.Write(rec.Data)
-
-	return o.readBuf.Read(b)
 }

--- a/mtproxy/faketls/faketls_test.go
+++ b/mtproxy/faketls/faketls_test.go
@@ -2,6 +2,7 @@ package faketls
 
 import (
 	"bytes"
+	"io"
 	"testing"
 	"time"
 
@@ -56,4 +57,29 @@ func TestTLS(t *testing.T) {
 		0x00, 0x00, 0x00, 0x00, 0x00,
 	}
 	a.Equal(testVector, b.Bytes())
+}
+
+func TestFakeTLSRead_SkipsChangeCipherSpecRecords(t *testing.T) {
+	a := require.New(t)
+
+	conn := bytes.NewBuffer(nil)
+	_, err := writeRecord(conn, record{
+		Type:    RecordTypeChangeCipherSpec,
+		Version: Version12Bytes,
+		Data:    []byte{0x01},
+	})
+	a.NoError(err)
+	_, err = writeRecord(conn, record{
+		Type:    RecordTypeApplication,
+		Version: Version12Bytes,
+		Data:    []byte("hello"),
+	})
+	a.NoError(err)
+
+	f := NewFakeTLS(bytes.NewReader(nil), conn)
+	got := make([]byte, len("hello"))
+	n, err := io.ReadFull(f, got)
+	a.NoError(err)
+	a.Equal(len("hello"), n)
+	a.Equal("hello", string(got))
 }

--- a/mtproxy/faketls/faketls_test.go
+++ b/mtproxy/faketls/faketls_test.go
@@ -97,7 +97,7 @@ func TestFakeTLSRead_RejectsUnexpectedRecordTypes(t *testing.T) {
 				Version: Version12Bytes,
 				Data:    []byte{0x01},
 			},
-			msg: "unexpected record type handshake during data phase",
+			msg: "unexpected record type handshake",
 		},
 		{
 			name: "unsupported",

--- a/mtproxy/faketls/faketls_test.go
+++ b/mtproxy/faketls/faketls_test.go
@@ -83,3 +83,44 @@ func TestFakeTLSRead_SkipsChangeCipherSpecRecords(t *testing.T) {
 	a.Equal(len("hello"), n)
 	a.Equal("hello", string(got))
 }
+
+func TestFakeTLSRead_RejectsUnexpectedRecordTypes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rec  record
+		msg  string
+	}{
+		{
+			name: "handshake",
+			rec: record{
+				Type:    RecordTypeHandshake,
+				Version: Version12Bytes,
+				Data:    []byte{0x01},
+			},
+			msg: "unexpected record type handshake during data phase",
+		},
+		{
+			name: "unsupported",
+			rec: record{
+				Type:    RecordTypeAlert,
+				Version: Version12Bytes,
+				Data:    []byte{0x01},
+			},
+			msg: "unsupported record type",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := require.New(t)
+
+			conn := bytes.NewBuffer(nil)
+			_, err := writeRecord(conn, tc.rec)
+			a.NoError(err)
+
+			f := NewFakeTLS(bytes.NewReader(nil), conn)
+			buf := make([]byte, 1)
+			_, err = f.Read(buf)
+			a.Error(err)
+			a.Contains(err.Error(), tc.msg)
+		})
+	}
+}

--- a/mtproxy/faketls/record.go
+++ b/mtproxy/faketls/record.go
@@ -8,7 +8,10 @@ import (
 	"github.com/go-faster/errors"
 )
 
-const maxTLSRecordDataLength = 16384 + 24
+// maxTLSRecordDataLength is the upper bound for a single TLS record payload.
+// MTProxy FakeTLS is camouflage rather than strict TLS, so accept any payload
+// that fits into the uint16 length field carried on the wire.
+const maxTLSRecordDataLength = 1<<16 - 1
 
 type record struct {
 	Type    RecordType
@@ -41,7 +44,7 @@ func readRecord(r io.Reader) (record, error) {
 
 	length := binary.BigEndian.Uint16(buf[3:])
 	if length > maxTLSRecordDataLength {
-		return record{}, errors.New("record length is too big")
+		return record{}, errors.Errorf("record length %d is too big (max %d)", length, maxTLSRecordDataLength)
 	}
 
 	rec.Data = make([]byte, length)

--- a/mtproxy/faketls/record.go
+++ b/mtproxy/faketls/record.go
@@ -43,10 +43,6 @@ func readRecord(r io.Reader) (record, error) {
 	}
 
 	length := binary.BigEndian.Uint16(buf[3:])
-	if length > maxTLSRecordDataLength {
-		return record{}, errors.Errorf("record length %d is too big (max %d)", length, maxTLSRecordDataLength)
-	}
-
 	rec.Data = make([]byte, length)
 	if _, err := io.ReadFull(r, rec.Data); err != nil {
 		return record{}, err

--- a/mtproxy/faketls/record_test.go
+++ b/mtproxy/faketls/record_test.go
@@ -2,6 +2,7 @@ package faketls
 
 import (
 	"bytes"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -18,6 +19,25 @@ func TestRecord(t *testing.T) {
 
 	_, err := writeRecord(buf, r)
 	a.NoError(err)
+	r2, err := readRecord(buf)
+	a.NoError(err)
+	a.Equal(r, r2)
+}
+
+func TestRecord_AllowsLargeApplicationPayload(t *testing.T) {
+	a := require.New(t)
+
+	payload := []byte(strings.Repeat("a", 20_000))
+	r := record{
+		Type:    RecordTypeApplication,
+		Version: Version12Bytes,
+		Data:    payload,
+	}
+	buf := bytes.NewBuffer(nil)
+
+	_, err := writeRecord(buf, r)
+	a.NoError(err)
+
 	r2, err := readRecord(buf)
 	a.NoError(err)
 	a.Equal(r, r2)

--- a/mtproxy/faketls/server_hello.go
+++ b/mtproxy/faketls/server_hello.go
@@ -9,6 +9,8 @@ import (
 	"github.com/go-faster/errors"
 )
 
+// Sanity limit for the number of extra handshake records before
+// ChangeCipherSpec.
 const maxHandshakeRecords = 16
 
 // readServerHello reads faketls ServerHello.
@@ -16,25 +18,28 @@ func readServerHello(r io.Reader, clientRandom [32]byte, secret []byte) error {
 	packetBuf := bytes.NewBuffer(nil)
 	r = io.TeeReader(r, packetBuf)
 
-	firstRec, err := readRecord(r)
+	handshake, err := readRecord(r)
 	if err != nil {
-		return errors.Wrap(err, "first handshake record")
+		return errors.Wrap(err, "handshake record")
 	}
-	if firstRec.Type != RecordTypeHandshake {
-		return errors.Errorf("expected Handshake record first, got type 0x%02x", firstRec.Type)
+	if handshake.Type != RecordTypeHandshake {
+		return errors.New("unexpected record type")
 	}
 
+	// `$record_header = type 1 byte + version 2 bytes + payload_length 2 bytes = 5 bytes`
+	// `$server_hello_header = type 1 bytes + version 2 bytes + length 3 bytes = 6 bytes`
+	// `$offset = $record_header + $server_hello_header = 11 bytes`
 	const serverRandomOffset = 11
 	const serverRandomEnd = serverRandomOffset + 32
 	if packetBuf.Len() < serverRandomEnd {
-		return errors.Errorf("first Handshake record too short: %d bytes, need at least %d", packetBuf.Len(), serverRandomEnd)
+		return errors.New("handshake record is too short")
 	}
 
 	changeCipherFound := false
-	for i := 1; i <= maxHandshakeRecords; i++ {
+	for i := 0; i < maxHandshakeRecords; i++ {
 		rec, err := readRecord(r)
 		if err != nil {
-			return errors.Wrapf(err, "record[%d]", i)
+			return errors.Wrap(err, "change cipher record")
 		}
 
 		switch rec.Type {
@@ -43,39 +48,37 @@ func readServerHello(r io.Reader, clientRandom [32]byte, secret []byte) error {
 		case RecordTypeChangeCipherSpec:
 			changeCipherFound = true
 		default:
-			return errors.Errorf("unexpected record type 0x%02x before ChangeCipherSpec", rec.Type)
+			return errors.New("unexpected record type")
 		}
 
-		if changeCipherFound {
-			break
-		}
+		break
 	}
 
 	if !changeCipherFound {
-		return errors.Errorf("ChangeCipherSpec not found within %d records", maxHandshakeRecords)
+		return errors.New("unexpected record type")
 	}
 
-	appRec, err := readRecord(r)
+	cert, err := readRecord(r)
 	if err != nil {
-		return errors.Wrap(err, "application record after ChangeCipherSpec")
+		return errors.Wrap(err, "cert record")
 	}
-	if appRec.Type != RecordTypeApplication {
-		return errors.Errorf("expected Application record after ChangeCipherSpec, got type 0x%02x", appRec.Type)
+	if cert.Type != RecordTypeApplication {
+		return errors.New("unexpected record type")
 	}
 
 	packet := packetBuf.Bytes()
 	var originalDigest [32]byte
 	copy(originalDigest[:], packet[serverRandomOffset:serverRandomEnd])
-
+	// Fill original digest by zeros.
 	var zeros [32]byte
 	copy(packet[serverRandomOffset:serverRandomEnd], zeros[:])
 
 	mac := hmac.New(sha256.New, secret)
 	if _, err := mac.Write(clientRandom[:]); err != nil {
-		return errors.Wrap(err, "hmac write clientRandom")
+		return errors.Wrap(err, "hmac write")
 	}
 	if _, err := mac.Write(packet); err != nil {
-		return errors.Wrap(err, "hmac write packet")
+		return errors.Wrap(err, "hmac write")
 	}
 	if !bytes.Equal(mac.Sum(nil), originalDigest[:]) {
 		return errors.New("hmac digest mismatch")

--- a/mtproxy/faketls/server_hello.go
+++ b/mtproxy/faketls/server_hello.go
@@ -9,53 +9,73 @@ import (
 	"github.com/go-faster/errors"
 )
 
+const maxHandshakeRecords = 16
+
 // readServerHello reads faketls ServerHello.
 func readServerHello(r io.Reader, clientRandom [32]byte, secret []byte) error {
 	packetBuf := bytes.NewBuffer(nil)
 	r = io.TeeReader(r, packetBuf)
 
-	handshake, err := readRecord(r)
+	firstRec, err := readRecord(r)
 	if err != nil {
-		return errors.Wrap(err, "handshake record")
+		return errors.Wrap(err, "first handshake record")
 	}
-	if handshake.Type != RecordTypeHandshake {
-		return errors.Wrap(err, "unexpected record type")
+	if firstRec.Type != RecordTypeHandshake {
+		return errors.Errorf("expected Handshake record first, got type 0x%02x", firstRec.Type)
 	}
 
-	changeCipher, err := readRecord(r)
-	if err != nil {
-		return errors.Wrap(err, "change cipher record")
-	}
-	if changeCipher.Type != RecordTypeChangeCipherSpec {
-		return errors.Wrap(err, "unexpected record type")
-	}
-
-	cert, err := readRecord(r)
-	if err != nil {
-		return errors.Wrap(err, "cert record")
-	}
-	if cert.Type != RecordTypeApplication {
-		return errors.Wrap(err, "unexpected record type")
-	}
-
-	// `$record_header = type 1 byte + version 2 bytes + payload_length 2 bytes = 5 bytes`
-	// `$server_hello_header = type 1 bytes + version 2 bytes + length 3 bytes = 6 bytes`
-	// `$offset = $record_header + $server_hello_header = 11 bytes`
 	const serverRandomOffset = 11
+	const serverRandomEnd = serverRandomOffset + 32
+	if packetBuf.Len() < serverRandomEnd {
+		return errors.Errorf("first Handshake record too short: %d bytes, need at least %d", packetBuf.Len(), serverRandomEnd)
+	}
+
+	changeCipherFound := false
+	for i := 1; i <= maxHandshakeRecords; i++ {
+		rec, err := readRecord(r)
+		if err != nil {
+			return errors.Wrapf(err, "record[%d]", i)
+		}
+
+		switch rec.Type {
+		case RecordTypeHandshake:
+			continue
+		case RecordTypeChangeCipherSpec:
+			changeCipherFound = true
+		default:
+			return errors.Errorf("unexpected record type 0x%02x before ChangeCipherSpec", rec.Type)
+		}
+
+		if changeCipherFound {
+			break
+		}
+	}
+
+	if !changeCipherFound {
+		return errors.Errorf("ChangeCipherSpec not found within %d records", maxHandshakeRecords)
+	}
+
+	appRec, err := readRecord(r)
+	if err != nil {
+		return errors.Wrap(err, "application record after ChangeCipherSpec")
+	}
+	if appRec.Type != RecordTypeApplication {
+		return errors.Errorf("expected Application record after ChangeCipherSpec, got type 0x%02x", appRec.Type)
+	}
+
 	packet := packetBuf.Bytes()
-	// Copy original digest.
 	var originalDigest [32]byte
-	copy(originalDigest[:], packet[serverRandomOffset:serverRandomOffset+32])
-	// Fill original digest by zeros.
+	copy(originalDigest[:], packet[serverRandomOffset:serverRandomEnd])
+
 	var zeros [32]byte
-	copy(packet[serverRandomOffset:serverRandomOffset+32], zeros[:])
+	copy(packet[serverRandomOffset:serverRandomEnd], zeros[:])
 
 	mac := hmac.New(sha256.New, secret)
 	if _, err := mac.Write(clientRandom[:]); err != nil {
-		return errors.Wrap(err, "hmac write")
+		return errors.Wrap(err, "hmac write clientRandom")
 	}
 	if _, err := mac.Write(packet); err != nil {
-		return errors.Wrap(err, "hmac write")
+		return errors.Wrap(err, "hmac write packet")
 	}
 	if !bytes.Equal(mac.Sum(nil), originalDigest[:]) {
 		return errors.New("hmac digest mismatch")

--- a/mtproxy/faketls/server_hello_test.go
+++ b/mtproxy/faketls/server_hello_test.go
@@ -115,3 +115,75 @@ func Test_readServerHello_AllowsAdditionalHandshakeRecords(t *testing.T) {
 
 	a.NoError(readServerHello(bytes.NewReader(raw), clientRandom, secret))
 }
+
+func Test_readServerHello_ErrorPaths(t *testing.T) {
+	clientRandom := [32]byte{}
+	secret := []byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+
+	for _, tc := range []struct {
+		name string
+		buf  func(t *testing.T) []byte
+		msg  string
+	}{
+		{
+			name: "first record is not handshake",
+			buf: func(t *testing.T) []byte {
+				t.Helper()
+				b := bytes.NewBuffer(nil)
+				_, err := writeRecord(b, record{Type: RecordTypeApplication, Version: Version12Bytes, Data: []byte{0x01}})
+				require.NoError(t, err)
+				return b.Bytes()
+			},
+			msg: "expected Handshake record first",
+		},
+		{
+			name: "first handshake too short",
+			buf: func(t *testing.T) []byte {
+				t.Helper()
+				b := bytes.NewBuffer(nil)
+				_, err := writeRecord(b, record{Type: RecordTypeHandshake, Version: Version12Bytes, Data: []byte{0x01}})
+				require.NoError(t, err)
+				return b.Bytes()
+			},
+			msg: "first Handshake record too short",
+		},
+		{
+			name: "unexpected record before change cipher",
+			buf: func(t *testing.T) []byte {
+				t.Helper()
+				b := bytes.NewBuffer(nil)
+				_, err := writeRecord(b, record{Type: RecordTypeHandshake, Version: Version12Bytes, Data: make([]byte, 38)})
+				require.NoError(t, err)
+				_, err = writeRecord(b, record{Type: RecordTypeApplication, Version: Version12Bytes, Data: []byte{0x01}})
+				require.NoError(t, err)
+				return b.Bytes()
+			},
+			msg: "unexpected record type",
+		},
+		{
+			name: "application after change cipher is missing",
+			buf: func(t *testing.T) []byte {
+				t.Helper()
+				b := bytes.NewBuffer(nil)
+				_, err := writeRecord(b, record{Type: RecordTypeHandshake, Version: Version12Bytes, Data: make([]byte, 38)})
+				require.NoError(t, err)
+				_, err = writeRecord(b, record{Type: RecordTypeChangeCipherSpec, Version: Version12Bytes, Data: []byte{0x01}})
+				require.NoError(t, err)
+				_, err = writeRecord(b, record{Type: RecordTypeHandshake, Version: Version12Bytes, Data: []byte{0x01}})
+				require.NoError(t, err)
+				return b.Bytes()
+			},
+			msg: "expected Application record after ChangeCipherSpec",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			a := require.New(t)
+			err := readServerHello(bytes.NewReader(tc.buf(t)), clientRandom, secret)
+			a.Error(err)
+			a.Contains(err.Error(), tc.msg)
+		})
+	}
+}

--- a/mtproxy/faketls/server_hello_test.go
+++ b/mtproxy/faketls/server_hello_test.go
@@ -137,7 +137,7 @@ func Test_readServerHello_ErrorPaths(t *testing.T) {
 				require.NoError(t, err)
 				return b.Bytes()
 			},
-			msg: "expected Handshake record first",
+			msg: "unexpected record type",
 		},
 		{
 			name: "first handshake too short",
@@ -148,7 +148,7 @@ func Test_readServerHello_ErrorPaths(t *testing.T) {
 				require.NoError(t, err)
 				return b.Bytes()
 			},
-			msg: "first Handshake record too short",
+			msg: "handshake record is too short",
 		},
 		{
 			name: "unexpected record before change cipher",
@@ -176,7 +176,7 @@ func Test_readServerHello_ErrorPaths(t *testing.T) {
 				require.NoError(t, err)
 				return b.Bytes()
 			},
-			msg: "expected Application record after ChangeCipherSpec",
+			msg: "unexpected record type",
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/mtproxy/faketls/server_hello_test.go
+++ b/mtproxy/faketls/server_hello_test.go
@@ -2,6 +2,8 @@ package faketls
 
 import (
 	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
 	"encoding/hex"
 	"os"
 	"path/filepath"
@@ -54,4 +56,62 @@ func Test_readServerHello(t *testing.T) {
 			a.Zero(r.Len(), "should read all data")
 		})
 	}
+}
+
+func Test_readServerHello_AllowsAdditionalHandshakeRecords(t *testing.T) {
+	a := require.New(t)
+
+	clientRandom := [32]byte{
+		0xa1, 0x32, 0xe3, 0x91, 0x60, 0x83, 0xb3, 0x14, 0xc1, 0xb9, 0x74, 0xd0, 0x57, 0x85, 0xe8, 0xee,
+		0x70, 0x45, 0x6e, 0x5f, 0x86, 0x6d, 0x96, 0x57, 0xd5, 0x0a, 0x5c, 0x08, 0xea, 0x38, 0x31, 0x8e,
+	}
+	secret := []byte{
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+		0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01,
+	}
+
+	packet := bytes.NewBuffer(nil)
+	_, err := writeRecord(packet, record{
+		Type:    RecordTypeHandshake,
+		Version: Version12Bytes,
+		Data:    make([]byte, 38),
+	})
+	a.NoError(err)
+	_, err = writeRecord(packet, record{
+		Type:    RecordTypeHandshake,
+		Version: Version12Bytes,
+		Data:    []byte{0x0b, 0x00, 0x00, 0x00},
+	})
+	a.NoError(err)
+	_, err = writeRecord(packet, record{
+		Type:    RecordTypeHandshake,
+		Version: Version12Bytes,
+		Data:    []byte{0x0c, 0x00, 0x00, 0x00},
+	})
+	a.NoError(err)
+	_, err = writeRecord(packet, record{
+		Type:    RecordTypeChangeCipherSpec,
+		Version: Version12Bytes,
+		Data:    []byte{0x01},
+	})
+	a.NoError(err)
+	_, err = writeRecord(packet, record{
+		Type:    RecordTypeApplication,
+		Version: Version12Bytes,
+		Data:    []byte{0x14, 0x00, 0x00, 0x00},
+	})
+	a.NoError(err)
+
+	raw := packet.Bytes()
+	const serverRandomOffset = 11
+	const serverRandomEnd = serverRandomOffset + 32
+
+	mac := hmac.New(sha256.New, secret)
+	_, err = mac.Write(clientRandom[:])
+	a.NoError(err)
+	_, err = mac.Write(raw)
+	a.NoError(err)
+	copy(raw[serverRandomOffset:serverRandomEnd], mac.Sum(nil))
+
+	a.NoError(readServerHello(bytes.NewReader(raw), clientRandom, secret))
 }


### PR DESCRIPTION
 ## Summary

  Fix three FakeTLS interoperability issues seen with real MTProxy servers:

  - allow extra TLS Handshake records before `ChangeCipherSpec` in
  `readServerHello`
  - allow FakeTLS record payloads larger than 16 KB
  - skip `ChangeCipherSpec` records during the data phase so they do not corrupt
  the `obfuscated2` stream

  ## Why

  The current FakeTLS implementation is stricter than what some MTProxy servers
  send in practice.

  `readServerHello` expects an exact record sequence:

  `Handshake -> ChangeCipherSpec -> Application`

  In practice, some servers send additional Handshake records before
  `ChangeCipherSpec`.

  Also, FakeTLS is used as traffic camouflage rather than strict TLS, and some
  servers return Application Data records larger than 16 KB.

  Finally, passing the `ChangeCipherSpec` payload through the data phase injects
  the `0x01` byte into the decrypted stream and breaks `obfuscated2`.

  ## Changes

  - update `readServerHello` to consume additional Handshake records before
  `ChangeCipherSpec`
  - raise the accepted FakeTLS record length limit to the full `uint16` wire
  limit
  - ignore `ChangeCipherSpec` while reading application data

  ## Tests

  Added regression coverage for:

  - extra Handshake records before `ChangeCipherSpec`
  - Application Data records larger than 16 KB
  - skipping `ChangeCipherSpec` during the data phase

  Validated with:

  - `go test ./mtproxy/...`
  - `go test ./telegram/...`