### PR TITLE
feat(updates): add OnTooLong hook for updates.differenceTooLong

### DIFF
--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -25,6 +25,9 @@ type Config struct {
 	// Callback called if manager cannot
 	// recover channel gap (optional).
 	OnChannelTooLong func(channelID int64)
+	// Callback called if manager cannot recover
+	// common state gap, i.e. on updates.differenceTooLong (optional).
+	OnTooLong func()
 	// State storage.
 	// In-mem used if not provided.
 	Storage StateStorage
@@ -56,6 +59,11 @@ func (cfg *Config) setDefaults() {
 	if cfg.OnChannelTooLong == nil {
 		cfg.OnChannelTooLong = func(channelID int64) {
 			cfg.Logger.Error("Difference too long", zap.Int64("channel_id", channelID))
+		}
+	}
+	if cfg.OnTooLong == nil {
+		cfg.OnTooLong = func() {
+			cfg.Logger.Error("Difference too long")
 		}
 	}
 }

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -140,6 +140,7 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 			Logger:           m.cfg.Logger,
 			Handler:          m.cfg.Handler,
 			OnChannelTooLong: m.cfg.OnChannelTooLong,
+			OnTooLong:        m.cfg.OnTooLong,
 			Storage:          m.cfg.Storage,
 			Hasher:           m.cfg.AccessHasher,
 			SelfID:           userID,

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -47,16 +47,17 @@ type internalState struct {
 	channels map[int64]*channelState
 
 	// Immutable fields.
-	client    API
-	log       *zap.Logger
-	handler   telegram.UpdateHandler
-	onTooLong func(channelID int64)
-	storage   StateStorage
-	hasher    ChannelAccessHasher
-	selfID    int64
-	diffLim   int
-	wg        *errgroup.Group
-	tracer    trace.Tracer
+	client          API
+	log             *zap.Logger
+	handler         telegram.UpdateHandler
+	onTooLong       func(channelID int64)
+	onCommonTooLong func()
+	storage         StateStorage
+	hasher          ChannelAccessHasher
+	selfID          int64
+	diffLim         int
+	wg              *errgroup.Group
+	tracer          trace.Tracer
 }
 
 type stateConfig struct {
@@ -70,6 +71,7 @@ type stateConfig struct {
 	Tracer           trace.Tracer
 	Handler          telegram.UpdateHandler
 	OnChannelTooLong func(channelID int64)
+	OnTooLong        func()
 	Storage          StateStorage
 	Hasher           ChannelAccessHasher
 	SelfID           int64
@@ -87,16 +89,17 @@ func newState(ctx context.Context, cfg stateConfig) *internalState {
 
 		channels: make(map[int64]*channelState),
 
-		client:    cfg.RawClient,
-		log:       cfg.Logger,
-		handler:   cfg.Handler,
-		onTooLong: cfg.OnChannelTooLong,
-		storage:   cfg.Storage,
-		hasher:    cfg.Hasher,
-		selfID:    cfg.SelfID,
-		diffLim:   cfg.DiffLimit,
-		wg:        cfg.WorkGroup,
-		tracer:    cfg.Tracer,
+		client:          cfg.RawClient,
+		log:             cfg.Logger,
+		handler:         cfg.Handler,
+		onTooLong:       cfg.OnChannelTooLong,
+		onCommonTooLong: cfg.OnTooLong,
+		storage:         cfg.Storage,
+		hasher:          cfg.Hasher,
+		selfID:          cfg.SelfID,
+		diffLim:         cfg.DiffLimit,
+		wg:              cfg.WorkGroup,
+		tracer:          cfg.Tracer,
 	}
 	s.pts = newSequenceBox(sequenceConfig{
 		InitialState: cfg.State.Pts,
@@ -479,6 +482,7 @@ func (s *internalState) getDifference(ctx context.Context) error {
 			s.log.Error("SetPts error", zap.Error(err))
 		}
 		s.pts.SetState(diff.Pts, "updates.differenceTooLong")
+		s.onCommonTooLong()
 		return s.getDifference(ctx)
 
 	default:

--- a/telegram/updates/state_test.go
+++ b/telegram/updates/state_test.go
@@ -1,0 +1,78 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// diffAPI is a stub API that returns the configured differences in order,
+// repeating the last one once exhausted.
+type diffAPI struct {
+	diffs []tg.UpdatesDifferenceClass
+	calls int
+}
+
+func (a *diffAPI) UpdatesGetState(ctx context.Context) (*tg.UpdatesState, error) {
+	return &tg.UpdatesState{}, nil
+}
+
+func (a *diffAPI) UpdatesGetDifference(
+	ctx context.Context, request *tg.UpdatesGetDifferenceRequest,
+) (tg.UpdatesDifferenceClass, error) {
+	diff := a.diffs[a.calls]
+	if a.calls < len(a.diffs)-1 {
+		a.calls++
+	}
+	return diff, nil
+}
+
+func (a *diffAPI) UpdatesGetChannelDifference(
+	ctx context.Context, request *tg.UpdatesGetChannelDifferenceRequest,
+) (tg.UpdatesChannelDifferenceClass, error) {
+	return &tg.UpdatesChannelDifferenceEmpty{}, nil
+}
+
+// TestStateOnTooLong ensures the OnTooLong hook is invoked when the manager
+// receives updates.differenceTooLong and cannot recover the common state gap.
+func TestStateOnTooLong(t *testing.T) {
+	ctx := context.Background()
+
+	const selfID = 123
+	storage := newMemStorage()
+	require.NoError(t, storage.SetState(ctx, selfID, State{}))
+
+	api := &diffAPI{diffs: []tg.UpdatesDifferenceClass{
+		&tg.UpdatesDifferenceTooLong{Pts: 100},
+		// Stops the recursive getDifference loop.
+		&tg.UpdatesDifferenceEmpty{},
+	}}
+
+	var tooLong int
+	s := newState(ctx, stateConfig{
+		RawClient: api,
+		Logger:    zaptest.NewLogger(t),
+		Tracer:    noop.NewTracerProvider().Tracer(""),
+		Handler: telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+			return nil
+		}),
+		OnChannelTooLong: func(int64) {},
+		OnTooLong:        func() { tooLong++ },
+		Storage:          storage,
+		Hasher:           newMemAccessHasher(),
+		SelfID:           selfID,
+		DiffLimit:        diffLimitUser,
+		WorkGroup:        &errgroup.Group{},
+	})
+
+	require.NoError(t, s.getDifference(ctx))
+	require.Equal(t, 1, tooLong, "OnTooLong must be called once")
+	require.Equal(t, 100, s.pts.State(), "pts must be advanced to the value from differenceTooLong")
+}


### PR DESCRIPTION
## Summary

Adds an `OnTooLong` callback to the gap update manager (`telegram/updates`), invoked when the manager hits an unrecoverable **common state** gap, i.e. `updates.differenceTooLong`. This mirrors the existing `OnChannelTooLong` hook that covers per-channel gaps.

## Changes

- **`config.go`** — new `Config.OnTooLong func()` field with a default that logs `"Difference too long"`.
- **`manager.go`** — wires `m.cfg.OnTooLong` into the state config.
- **`state.go`** — threads `OnTooLong` through `stateConfig` → `internalState.onCommonTooLong`, invoked in the `*tg.UpdatesDifferenceTooLong` branch (after advancing pts, before refetching the difference).
- **`state_test.go`** — `TestStateOnTooLong` stubs the API to return `differenceTooLong` then `differenceEmpty`, and asserts the hook fires exactly once and pts is advanced.

## Test plan

- `go test ./telegram/updates/` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)