### PR TITLE
feat(updates): stop and remove channel on CHANNEL_PRIVATE

### DIFF
--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -25,6 +25,11 @@ type Config struct {
 	// Callback called if manager cannot
 	// recover channel gap (optional).
 	OnChannelTooLong func(channelID int64)
+	// Callback called when the manager loses access to a channel, detected via
+	// CHANNEL_PRIVATE on updates.getChannelDifference (e.g. the account was
+	// kicked/banned or the channel was deleted). The channel is removed from
+	// the update manager after this call (optional).
+	OnChannelInaccessible func(channelID int64)
 	// Callback called if manager cannot recover
 	// common state gap, i.e. on updates.differenceTooLong (optional).
 	OnTooLong func()
@@ -59,6 +64,12 @@ func (cfg *Config) setDefaults() {
 	if cfg.OnChannelTooLong == nil {
 		cfg.OnChannelTooLong = func(channelID int64) {
 			cfg.Logger.Error("Difference too long", zap.Int64("channel_id", channelID))
+		}
+	}
+	if cfg.OnChannelInaccessible == nil {
+		cfg.OnChannelInaccessible = func(channelID int64) {
+			cfg.Logger.Info("Channel is inaccessible, stopping updates",
+				zap.Int64("channel_id", channelID))
 		}
 	}
 	if cfg.OnTooLong == nil {

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -133,19 +133,20 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 		}
 
 		m.state = newState(ctx, stateConfig{
-			State:            state,
-			Channels:         channels,
-			RawClient:        api,
-			Tracer:           m.tracer,
-			Logger:           m.cfg.Logger,
-			Handler:          m.cfg.Handler,
-			OnChannelTooLong: m.cfg.OnChannelTooLong,
-			OnTooLong:        m.cfg.OnTooLong,
-			Storage:          m.cfg.Storage,
-			Hasher:           m.cfg.AccessHasher,
-			SelfID:           userID,
-			DiffLimit:        diffLim,
-			WorkGroup:        wg,
+			State:                 state,
+			Channels:              channels,
+			RawClient:             api,
+			Tracer:                m.tracer,
+			Logger:                m.cfg.Logger,
+			Handler:               m.cfg.Handler,
+			OnChannelTooLong:      m.cfg.OnChannelTooLong,
+			OnChannelInaccessible: m.cfg.OnChannelInaccessible,
+			OnTooLong:             m.cfg.OnTooLong,
+			Storage:               m.cfg.Storage,
+			Hasher:                m.cfg.AccessHasher,
+			SelfID:                userID,
+			DiffLimit:             diffLim,
+			WorkGroup:             wg,
 		})
 
 		return nil

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -45,19 +45,24 @@ type internalState struct {
 
 	// Channel states.
 	channels map[int64]*channelState
+	// removeChannel receives channel IDs from channel workers that lost access
+	// (CHANNEL_PRIVATE) so they can be dropped from the channels map. Only the
+	// internalState goroutine mutates the map, so this keeps access serialized.
+	removeChannel chan int64
 
 	// Immutable fields.
-	client          API
-	log             *zap.Logger
-	handler         telegram.UpdateHandler
-	onTooLong       func(channelID int64)
-	onCommonTooLong func()
-	storage         StateStorage
-	hasher          ChannelAccessHasher
-	selfID          int64
-	diffLim         int
-	wg              *errgroup.Group
-	tracer          trace.Tracer
+	client                API
+	log                   *zap.Logger
+	handler               telegram.UpdateHandler
+	onTooLong             func(channelID int64)
+	onChannelInaccessible func(channelID int64)
+	onCommonTooLong       func()
+	storage               StateStorage
+	hasher                ChannelAccessHasher
+	selfID                int64
+	diffLim               int
+	wg                    *errgroup.Group
+	tracer                trace.Tracer
 }
 
 type stateConfig struct {
@@ -66,17 +71,18 @@ type stateConfig struct {
 		Pts        int
 		AccessHash int64
 	}
-	RawClient        API
-	Logger           *zap.Logger
-	Tracer           trace.Tracer
-	Handler          telegram.UpdateHandler
-	OnChannelTooLong func(channelID int64)
-	OnTooLong        func()
-	Storage          StateStorage
-	Hasher           ChannelAccessHasher
-	SelfID           int64
-	DiffLimit        int
-	WorkGroup        *errgroup.Group
+	RawClient             API
+	Logger                *zap.Logger
+	Tracer                trace.Tracer
+	Handler               telegram.UpdateHandler
+	OnChannelTooLong      func(channelID int64)
+	OnChannelInaccessible func(channelID int64)
+	OnTooLong             func()
+	Storage               StateStorage
+	Hasher                ChannelAccessHasher
+	SelfID                int64
+	DiffLimit             int
+	WorkGroup             *errgroup.Group
 }
 
 func newState(ctx context.Context, cfg stateConfig) *internalState {
@@ -87,19 +93,21 @@ func newState(ctx context.Context, cfg stateConfig) *internalState {
 		date:        cfg.State.Date,
 		idleTimeout: time.NewTimer(idleTimeout),
 
-		channels: make(map[int64]*channelState),
+		channels:      make(map[int64]*channelState),
+		removeChannel: make(chan int64, 10),
 
-		client:          cfg.RawClient,
-		log:             cfg.Logger,
-		handler:         cfg.Handler,
-		onTooLong:       cfg.OnChannelTooLong,
-		onCommonTooLong: cfg.OnTooLong,
-		storage:         cfg.Storage,
-		hasher:          cfg.Hasher,
-		selfID:          cfg.SelfID,
-		diffLim:         cfg.DiffLimit,
-		wg:              cfg.WorkGroup,
-		tracer:          cfg.Tracer,
+		client:                cfg.RawClient,
+		log:                   cfg.Logger,
+		handler:               cfg.Handler,
+		onTooLong:             cfg.OnChannelTooLong,
+		onChannelInaccessible: cfg.OnChannelInaccessible,
+		onCommonTooLong:       cfg.OnTooLong,
+		storage:               cfg.Storage,
+		hasher:                cfg.Hasher,
+		selfID:                cfg.SelfID,
+		diffLim:               cfg.DiffLimit,
+		wg:                    cfg.WorkGroup,
+		tracer:                cfg.Tracer,
 	}
 	s.pts = newSequenceBox(sequenceConfig{
 		InitialState: cfg.State.Pts,
@@ -204,8 +212,23 @@ func (s *internalState) Run(ctx context.Context) error {
 		case <-s.idleTimeout.C:
 			s.log.Debug("Idle timeout")
 			s.getDifferenceLogger(ctx)
+		case channelID := <-s.removeChannel:
+			s.removeChannelState(channelID)
 		}
 	}
+}
+
+// removeChannelState drops a channel from tracking after its worker stopped
+// due to lost access (CHANNEL_PRIVATE). Must be called from the internalState
+// goroutine, which is the sole mutator of the channels map.
+func (s *internalState) removeChannelState(channelID int64) {
+	if _, ok := s.channels[channelID]; !ok {
+		return
+	}
+	delete(s.channels, channelID)
+	s.log.Debug("Removed inaccessible channel from tracking",
+		zap.Int64("channel_id", channelID),
+	)
 }
 
 func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) error {
@@ -361,18 +384,20 @@ func (s *internalState) handleChannel(ctx context.Context, channelID int64, date
 
 func (s *internalState) newChannelState(channelID, accessHash int64, initialPts int) *channelState {
 	return newChannelState(channelStateConfig{
-		Out:              s.internalQueue,
-		InitialPts:       initialPts,
-		ChannelID:        channelID,
-		AccessHash:       accessHash,
-		SelfID:           s.selfID,
-		Storage:          s.storage,
-		DiffLimit:        s.diffLim,
-		RawClient:        s.client,
-		Handler:          s.handler,
-		OnChannelTooLong: s.onTooLong,
-		Logger:           s.log.Named("channel").With(zap.Int64("channel_id", channelID)),
-		Tracer:           s.tracer,
+		Out:                   s.internalQueue,
+		InitialPts:            initialPts,
+		ChannelID:             channelID,
+		AccessHash:            accessHash,
+		SelfID:                s.selfID,
+		Storage:               s.storage,
+		DiffLimit:             s.diffLim,
+		RawClient:             s.client,
+		Handler:               s.handler,
+		OnChannelTooLong:      s.onTooLong,
+		OnChannelInaccessible: s.onChannelInaccessible,
+		RemoveChannel:         s.removeChannel,
+		Logger:                s.log.Named("channel").With(zap.Int64("channel_id", channelID)),
+		Tracer:                s.tracer,
 	})
 }
 

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -10,7 +10,13 @@ import (
 
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
 )
+
+// errChannelInaccessible is a sentinel returned by getDifference when the
+// account has lost access to the channel (CHANNEL_PRIVATE). It signals the
+// Run loop to stop the worker instead of logging the error and retrying.
+var errChannelInaccessible = errors.New("channel is inaccessible")
 
 type channelUpdate struct {
 	update   tg.UpdateClass
@@ -29,32 +35,41 @@ type channelState struct {
 	idleTimeout *time.Timer
 	diffTimeout time.Time
 
+	// done is closed when Run returns, so that Push never blocks on a stopped
+	// worker (e.g. after the channel became inaccessible and is pending removal).
+	done chan struct{}
+
 	// Immutable fields.
-	channelID  int64
-	accessHash int64
-	selfID     int64
-	diffLim    int
-	client     API
-	storage    StateStorage
-	log        *zap.Logger
-	tracer     trace.Tracer
-	handler    telegram.UpdateHandler
-	onTooLong  func(channelID int64)
+	channelID      int64
+	accessHash     int64
+	selfID         int64
+	diffLim        int
+	client         API
+	storage        StateStorage
+	log            *zap.Logger
+	tracer         trace.Tracer
+	handler        telegram.UpdateHandler
+	onTooLong      func(channelID int64)
+	onInaccessible func(channelID int64)
+	// removeChannel signals *internalState to drop this channel from tracking.
+	removeChannel chan<- int64
 }
 
 type channelStateConfig struct {
-	Out              chan tracedUpdate
-	InitialPts       int
-	ChannelID        int64
-	AccessHash       int64
-	SelfID           int64
-	DiffLimit        int
-	RawClient        API
-	Storage          StateStorage
-	Handler          telegram.UpdateHandler
-	OnChannelTooLong func(channelID int64)
-	Logger           *zap.Logger
-	Tracer           trace.Tracer
+	Out                   chan tracedUpdate
+	InitialPts            int
+	ChannelID             int64
+	AccessHash            int64
+	SelfID                int64
+	DiffLimit             int
+	RawClient             API
+	Storage               StateStorage
+	Handler               telegram.UpdateHandler
+	OnChannelTooLong      func(channelID int64)
+	OnChannelInaccessible func(channelID int64)
+	RemoveChannel         chan<- int64
+	Logger                *zap.Logger
+	Tracer                trace.Tracer
 }
 
 func newChannelState(cfg channelStateConfig) *channelState {
@@ -63,17 +78,20 @@ func newChannelState(cfg channelStateConfig) *channelState {
 		out:     cfg.Out,
 
 		idleTimeout: time.NewTimer(idleTimeout),
+		done:        make(chan struct{}),
 
-		channelID:  cfg.ChannelID,
-		accessHash: cfg.AccessHash,
-		selfID:     cfg.SelfID,
-		diffLim:    cfg.DiffLimit,
-		client:     cfg.RawClient,
-		storage:    cfg.Storage,
-		log:        cfg.Logger,
-		handler:    cfg.Handler,
-		onTooLong:  cfg.OnChannelTooLong,
-		tracer:     cfg.Tracer,
+		channelID:      cfg.ChannelID,
+		accessHash:     cfg.AccessHash,
+		selfID:         cfg.SelfID,
+		diffLim:        cfg.DiffLimit,
+		client:         cfg.RawClient,
+		storage:        cfg.Storage,
+		log:            cfg.Logger,
+		handler:        cfg.Handler,
+		onTooLong:      cfg.OnChannelTooLong,
+		onInaccessible: cfg.OnChannelInaccessible,
+		removeChannel:  cfg.RemoveChannel,
+		tracer:         cfg.Tracer,
 	}
 
 	state.pts = newSequenceBox(sequenceConfig{
@@ -90,14 +108,24 @@ func (s *channelState) Push(ctx context.Context, u channelUpdate) error {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
+	case <-s.done:
+		// Worker has stopped (channel inaccessible, pending removal): drop the
+		// update instead of blocking. It is restored by a future subscribe if
+		// access is regained.
+		return nil
 	case s.updates <- u:
 		return nil
 	}
 }
 
 func (s *channelState) Run(ctx context.Context) error {
+	defer close(s.done)
+
 	// Subscribe to channel updates.
 	if err := s.getDifference(ctx); err != nil {
+		if errors.Is(err, errChannelInaccessible) {
+			return nil
+		}
 		s.log.Error("Failed to subscribe to channel updates", zap.Error(err))
 	}
 
@@ -106,11 +134,16 @@ func (s *channelState) Run(ctx context.Context) error {
 		case u := <-s.updates:
 			ctx := trace.ContextWithSpanContext(ctx, u.span)
 			if err := s.handleUpdate(ctx, u.update, u.entities); err != nil {
+				if errors.Is(err, errChannelInaccessible) {
+					return nil
+				}
 				s.log.Error("Handle update error", zap.Error(err))
 			}
 		case <-s.pts.gapTimeout.C:
 			s.log.Debug("Gap timeout")
-			s.getDifferenceLogger(ctx)
+			if s.getDifferenceLogger(ctx) {
+				return nil
+			}
 		case <-ctx.Done():
 			if len(s.pts.pending) > 0 {
 				// This will probably fail.
@@ -120,7 +153,9 @@ func (s *channelState) Run(ctx context.Context) error {
 		case <-s.idleTimeout.C:
 			s.log.Debug("Idle timeout")
 			s.resetIdleTimer()
-			s.getDifferenceLogger(ctx)
+			if s.getDifferenceLogger(ctx) {
+				return nil
+			}
 		}
 	}
 }
@@ -250,6 +285,9 @@ func (s *channelState) getDifference(ctx context.Context) error {
 		Limit:  s.diffLim,
 	})
 	if err != nil {
+		if tgerr.Is(err, "CHANNEL_PRIVATE") {
+			return s.handleInaccessible(ctx)
+		}
 		return errors.Wrap(err, "get channel difference")
 	}
 
@@ -356,10 +394,33 @@ func (s *channelState) sendOut(ctx context.Context, out tracedUpdate) error {
 	}
 }
 
-func (s *channelState) getDifferenceLogger(ctx context.Context) {
+// getDifferenceLogger calls getDifference, logging any error. It returns true
+// if the channel became inaccessible and the worker should stop.
+func (s *channelState) getDifferenceLogger(ctx context.Context) (stop bool) {
 	if err := s.getDifference(ctx); err != nil {
+		if errors.Is(err, errChannelInaccessible) {
+			return true
+		}
 		s.log.Error("get channel difference error", zap.Error(err))
 	}
+	return false
+}
+
+// handleInaccessible is called when updates.getChannelDifference reports
+// CHANNEL_PRIVATE, i.e. the account has lost access to the channel (kicked,
+// banned, or the channel was deleted).
+//
+// It notifies the inaccessible hook and signals *internalState to remove this
+// channel from tracking, then returns errChannelInaccessible so the Run loop
+// stops the worker.
+func (s *channelState) handleInaccessible(ctx context.Context) error {
+	s.log.Info("Channel is inaccessible, removing from updates manager")
+	s.onInaccessible(s.channelID)
+	select {
+	case s.removeChannel <- s.channelID:
+	case <-ctx.Done():
+	}
+	return errChannelInaccessible
 }
 
 func (s *channelState) resetIdleTimer() {

--- a/telegram/updates/state_test.go
+++ b/telegram/updates/state_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgerr"
 )
 
 // diffAPI is a stub API that returns the configured differences in order,
@@ -75,4 +76,57 @@ func TestStateOnTooLong(t *testing.T) {
 	require.NoError(t, s.getDifference(ctx))
 	require.Equal(t, 1, tooLong, "OnTooLong must be called once")
 	require.Equal(t, 100, s.pts.State(), "pts must be advanced to the value from differenceTooLong")
+}
+
+// channelPrivateAPI returns CHANNEL_PRIVATE from getChannelDifference,
+// simulating the account losing access to a channel.
+type channelPrivateAPI struct {
+	diffAPI
+}
+
+func (a *channelPrivateAPI) UpdatesGetChannelDifference(
+	ctx context.Context, request *tg.UpdatesGetChannelDifferenceRequest,
+) (tg.UpdatesChannelDifferenceClass, error) {
+	return nil, tgerr.New(400, "CHANNEL_PRIVATE")
+}
+
+// TestChannelStateInaccessible ensures that when getChannelDifference reports
+// CHANNEL_PRIVATE the worker invokes the OnChannelInaccessible hook, signals
+// removal, and stops instead of looping with error logs.
+func TestChannelStateInaccessible(t *testing.T) {
+	ctx := context.Background()
+
+	const channelID = 1750799539
+
+	removeChannel := make(chan int64, 1)
+	var inaccessible int64
+	state := newChannelState(channelStateConfig{
+		Out:        make(chan tracedUpdate, 10),
+		ChannelID:  channelID,
+		AccessHash: 42,
+		RawClient:  &channelPrivateAPI{},
+		Storage:    newMemStorage(),
+		Handler: telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+			return nil
+		}),
+		OnChannelTooLong:      func(int64) {},
+		OnChannelInaccessible: func(id int64) { inaccessible = id },
+		RemoveChannel:         removeChannel,
+		Logger:                zaptest.NewLogger(t),
+		Tracer:                noop.NewTracerProvider().Tracer(""),
+	})
+
+	// Run subscribes via getChannelDifference, hits CHANNEL_PRIVATE, and must
+	// return nil (clean stop) rather than spinning on the error.
+	require.NoError(t, state.Run(ctx))
+	require.Equal(t, int64(channelID), inaccessible, "OnChannelInaccessible must be called with channel ID")
+	select {
+	case got := <-removeChannel:
+		require.Equal(t, int64(channelID), got, "channel ID must be signaled for removal")
+	default:
+		t.Fatal("expected channel removal signal")
+	}
+
+	// done must be closed so Push no longer blocks on the stopped worker.
+	require.NoError(t, state.Push(ctx, channelUpdate{}))
 }


### PR DESCRIPTION
## Problem

`updates.getChannelDifference` returns `CHANNEL_PRIVATE` when the account loses access to a channel (kicked/banned, or the channel was deleted). Previously this was wrapped as a generic error and logged at **error** level on *every* idle/gap timeout — forever — while the worker kept issuing useless RPCs. A single lost channel produces an endless stream of error logs:

```
E updates.channel get channel difference error channel_id=... error="get channel difference: ... rpc error code 400: CHANNEL_PRIVATE"
```

## Change

`CHANNEL_PRIVATE` is now treated as terminal for the channel worker:

- `getDifference` detects it via `tgerr.Is` and routes to `handleInaccessible`, which logs at **info**, fires the new optional `Config.OnChannelInaccessible` hook, signals `internalState` to drop the channel from tracking, and returns a sentinel so `Run` stops cleanly.
- `getDifferenceLogger` returns a `stop bool`; all `Run` call sites (subscribe, gap/idle timeouts, and the `handleUpdate` path) exit on the sentinel instead of error-logging and retrying.
- A new buffered `removeChannel` signal + `removeChannelState` keep the `channels` map mutated solely by the `internalState` goroutine (no new data race — verified with `-race`).
- A `done` channel (closed when `Run` returns) keeps `Push` from blocking on a stopped worker while removal is pending.

`OnChannelInaccessible` mirrors the existing `OnChannelTooLong` hook and defaults to an info-level log.

## Behavior trade-off

A worker can't delete itself from the map, so a stale entry persists until `internalState` processes the removal signal; updates arriving in that window are dropped (via `done`). After removal, a later update could recreate the worker, which re-detects `CHANNEL_PRIVATE` and removes itself again — a bounded loop driven only by *incoming* updates (which a truly-private channel stops sending), versus the old per-idle-tick RPC + error log indefinitely.

## Tests

- Added `TestChannelStateInaccessible`: stub API returns `CHANNEL_PRIVATE`; asserts `Run` returns nil, the hook fires with the channel ID, the removal signal is sent, and `Push` no longer blocks after stop.
- Full `telegram/updates/...` suite passes with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)