### PR TITLE
fix(message): correct error wrap message in forward path

### DIFF
--- a/telegram/message/forward.go
+++ b/telegram/message/forward.go
@@ -49,7 +49,7 @@ func (b *ForwardBuilder) Send(ctx context.Context) (tg.UpdatesClass, error) {
 	b.builder.applyProtectedOptions(req)
 	upd, err := b.builder.sender.forwardMessages(ctx, req)
 	if err != nil {
-		return nil, errors.Wrap(err, "send inline bot result")
+		return nil, errors.Wrap(err, "forward messages")
 	}
 
 	return upd, nil


### PR DESCRIPTION
## Summary

The forward send path (`ForwardBuilder.Send`) wrapped its error with `"send inline bot result"` due to a copy-paste, obscuring the actual operation. Replace it with `"forward messages"`.

This was noted during review of #1733 (point #1) as a pre-existing issue in the touched file.

## Tests

- `go build ./telegram/message/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)