### PR TITLE
feat(updates): force getDifference for updates referencing peers with unknown access hash

### DIFF
--- a/telegram/updates/access_hash_feeder.go
+++ b/telegram/updates/access_hash_feeder.go
@@ -45,6 +45,32 @@ func (s *internalState) saveChannelHashes(ctx context.Context, chats []tg.ChatCl
 	}
 }
 
+// saveUserHashes records user IDs that carry a full (non-min, non-zero) access
+// hash into the UserAccessHasher. A min user or a user with a zero access hash is
+// NOT recorded: per TDLib / Telegram-Android, such an entity does not count as a
+// known peer. Runs on the internalState goroutine.
+func (s *internalState) saveUserHashes(ctx context.Context, users []tg.UserClass) {
+	ctx, span := s.tracer.Start(ctx, "updates.saveUserHashes")
+	defer span.End()
+
+	for _, u := range users {
+		u, ok := u.(*tg.User)
+		if !ok {
+			continue
+		}
+		if u.Min || u.AccessHash == 0 {
+			continue
+		}
+		if _, found, err := s.userHasher.GetUserAccessHash(ctx, s.selfID, u.ID); err == nil && found {
+			continue
+		}
+		s.log.Debug("New user access hash", zap.Int64("user_id", u.ID))
+		if err := s.userHasher.SetUserAccessHash(ctx, s.selfID, u.ID, u.AccessHash); err != nil {
+			s.log.Error("SetUserAccessHash error", zap.Error(err))
+		}
+	}
+}
+
 func (s *internalState) restoreAccessHash(ctx context.Context, channelID int64, date int) (accessHash int64, ok bool) {
 	ctx, span := s.tracer.Start(ctx, "updates.restoreAccessHash")
 	defer span.End()

--- a/telegram/updates/access_hash_feeder_user_test.go
+++ b/telegram/updates/access_hash_feeder_user_test.go
@@ -1,0 +1,46 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+func TestSaveUserHashes(t *testing.T) {
+	ctx := context.Background()
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		return nil
+	})
+	s := newShortTestState(t, &countDiffAPI{}, handler)
+
+	// Pre-seed a known user to exercise the "already known, skip" branch.
+	require.NoError(t, s.userHasher.SetUserAccessHash(ctx, s.selfID, 111, 1111))
+
+	s.saveUserHashes(ctx, []tg.UserClass{
+		&tg.User{ID: 111, AccessHash: 9999},     // already known: must not be overwritten
+		&tg.User{ID: 222, AccessHash: 2222},     // full: recorded
+		&tg.User{ID: 333, Min: true, AccessHash: 3333}, // min: skipped
+		&tg.User{ID: 444, AccessHash: 0},        // zero hash: skipped
+		&tg.UserEmpty{ID: 555},                  // not *tg.User: skipped
+	})
+
+	assertHash := func(id, want int64, wantFound bool) {
+		t.Helper()
+		hash, found, err := s.userHasher.GetUserAccessHash(ctx, s.selfID, id)
+		require.NoError(t, err)
+		require.Equal(t, wantFound, found)
+		if wantFound {
+			require.Equal(t, want, hash)
+		}
+	}
+
+	assertHash(111, 1111, true) // unchanged
+	assertHash(222, 2222, true) // newly recorded
+	assertHash(333, 0, false)   // min skipped
+	assertHash(444, 0, false)   // zero hash skipped
+	assertHash(555, 0, false)   // wrong type skipped
+}

--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -39,6 +39,9 @@ type Config struct {
 	// Channel access hash storage.
 	// In-mem used if not provided.
 	AccessHasher ChannelAccessHasher
+	// User access hash storage.
+	// In-mem used if not provided.
+	UserAccessHasher UserAccessHasher
 	// Logger (optional).
 	Logger *zap.Logger
 	// TracerProvider (optional).
@@ -51,6 +54,9 @@ func (cfg *Config) setDefaults() {
 	}
 	if cfg.AccessHasher == nil {
 		cfg.AccessHasher = newMemAccessHasher()
+	}
+	if cfg.UserAccessHasher == nil {
+		cfg.UserAccessHasher = newMemUserAccessHasher()
 	}
 	if cfg.Logger == nil {
 		cfg.Logger = zap.NewNop()

--- a/telegram/updates/config_user_hasher_test.go
+++ b/telegram/updates/config_user_hasher_test.go
@@ -1,0 +1,31 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+func TestConfigDefaultsUserAccessHasher(t *testing.T) {
+	cfg := Config{Handler: telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		return nil
+	})}
+	cfg.setDefaults()
+	require.NotNil(t, cfg.UserAccessHasher, "setDefaults must supply an in-mem UserAccessHasher")
+}
+
+func TestConfigPreservesUserAccessHasher(t *testing.T) {
+	custom := newMemUserAccessHasher()
+	cfg := Config{
+		Handler: telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+			return nil
+		}),
+		UserAccessHasher: custom,
+	}
+	cfg.setDefaults()
+	require.Same(t, custom, cfg.UserAccessHasher, "a provided UserAccessHasher must be preserved")
+}

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -144,6 +144,7 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 			OnTooLong:             m.cfg.OnTooLong,
 			Storage:               m.cfg.Storage,
 			Hasher:                m.cfg.AccessHasher,
+			UserHasher:            m.cfg.UserAccessHasher,
 			SelfID:                userID,
 			DiffLimit:             diffLim,
 			WorkGroup:             wg,

--- a/telegram/updates/message_getdiff_test.go
+++ b/telegram/updates/message_getdiff_test.go
@@ -1,0 +1,114 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// A realtime incoming message can arrive as a full *tg.UpdateNewMessage inside
+// *tg.Updates / *tg.UpdatesCombined / *tg.UpdateShort whose sender is absent (or
+// only min) in the envelope users[]. Like the short forms, such an update must
+// force getDifference so the sender access hash is recovered before dispatch.
+// Mirrors TDLib is_acceptable_update for the non-channel get_difference branch.
+
+func newMessageUpdate(senderID int64) *tg.UpdateNewMessage {
+	return &tg.UpdateNewMessage{
+		Message: &tg.Message{
+			ID:      1,
+			PeerID:  &tg.PeerUser{UserID: senderID},
+			FromID:  &tg.PeerUser{UserID: senderID},
+			Message: "hi",
+		},
+		Pts:      1,
+		PtsCount: 1,
+	}
+}
+
+func TestNewMessageUnknownSenderForcesDifference(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	err := s.handleUpdates(ctx, &tg.Updates{
+		Updates: []tg.UpdateClass{newMessageUpdate(555)},
+		// sender NOT supplied inline
+	})
+	require.NoError(t, err)
+	require.Equal(t, 1, api.diffCalls, "full new message from unknown sender must force getDifference")
+	require.Equal(t, 0, dispatched, "message must not be dispatched directly")
+}
+
+func TestUpdateShortWrappedNewMessageUnknownSenderForcesDifference(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	// The exact reproduced shape: updateShort wrapping a pts updateNewMessage,
+	// no inline users[].
+	err := s.handleUpdates(ctx, &tg.UpdateShort{Update: newMessageUpdate(555)})
+	require.NoError(t, err)
+	require.Equal(t, 1, api.diffCalls, "updateShort-wrapped new message from unknown sender must force getDifference")
+	require.Equal(t, 0, dispatched, "message must not be dispatched directly")
+}
+
+func TestNewMessageKnownSenderAppliesDirectly(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	// Sender supplied full (non-min, non-zero hash) inline: it becomes known
+	// via saveUserHashes before the acceptability check, so the message applies
+	// directly without a getDifference.
+	err := s.handleUpdates(ctx, &tg.Updates{
+		Updates: []tg.UpdateClass{newMessageUpdate(555)},
+		Users:   []tg.UserClass{&tg.User{ID: 555, AccessHash: 7777}},
+	})
+	require.NoError(t, err)
+	require.Equal(t, 0, api.diffCalls, "no difference when the sender is supplied full inline")
+	require.Equal(t, 1, dispatched, "message with known sender must be dispatched directly")
+}
+
+// TestMessageUpdatesPeersKnownSkipsChannelMessages locks the performance
+// boundary: a channel (megagroup) message with a min/unknown sender is excluded
+// from the non-channel acceptability check, so it never forces a global
+// getDifference. Min senders are routine in megagroups; the channel-difference
+// machinery owns that recovery path. (Tested at the function level to isolate it
+// from gotd's pre-existing unknown-channel access-hash recovery.)
+func TestMessageUpdatesPeersKnownSkipsChannelMessages(t *testing.T) {
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		return nil
+	})
+	s := newShortTestState(t, &countDiffAPI{}, handler)
+
+	known := s.messageUpdatesPeersKnown(context.Background(), []tg.UpdateClass{&tg.UpdateNewChannelMessage{
+		Message: &tg.Message{
+			ID:      1,
+			PeerID:  &tg.PeerChannel{ChannelID: 42},
+			FromID:  &tg.PeerUser{UserID: 555},
+			Message: "hi",
+		},
+		Pts:      1,
+		PtsCount: 1,
+	}})
+	require.True(t, known, "channel messages are excluded from the global-getDifference acceptability check")
+}

--- a/telegram/updates/message_peer.go
+++ b/telegram/updates/message_peer.go
@@ -1,0 +1,83 @@
+package updates
+
+import (
+	"context"
+
+	"github.com/gotd/td/tg"
+)
+
+// messageUserIDs returns the user IDs a full (non-channel) message refers to
+// whose access hash must be known before the message can be resolved: the
+// dialog peer (when a user), the sender, the forward origin and its saved-from
+// peer (when users), the inline bot, and mention-name entities. selfID and zero
+// IDs are never returned. Mirrors referencedUserIDs for *tg.Message.
+func messageUserIDs(selfID int64, msg *tg.Message) []int64 {
+	ids := make([]int64, 0, 4)
+	add := func(id int64) {
+		if id != 0 && id != selfID {
+			ids = append(ids, id)
+		}
+	}
+	addPeer := func(p tg.PeerClass) {
+		if u, ok := p.(*tg.PeerUser); ok {
+			add(u.UserID)
+		}
+	}
+
+	addPeer(msg.PeerID)
+	if msg.FromID != nil {
+		addPeer(msg.FromID)
+	}
+	if fwd, ok := msg.GetFwdFrom(); ok {
+		if from, ok := fwd.GetFromID(); ok {
+			addPeer(from)
+		}
+		if saved, ok := fwd.GetSavedFromPeer(); ok {
+			addPeer(saved)
+		}
+	}
+	if via, ok := msg.GetViaBotID(); ok {
+		add(via)
+	}
+	if ents, ok := msg.GetEntities(); ok {
+		for _, e := range ents {
+			if m, ok := e.(*tg.MessageEntityMentionName); ok {
+				add(m.UserID)
+			}
+		}
+	}
+
+	return ids
+}
+
+// messageUpdatesPeersKnown reports whether every non-channel message-bearing
+// update in the batch references only user peers with a known access hash.
+//
+// It covers *tg.UpdateNewMessage and *tg.UpdateEditMessage (private/basic-group
+// messages). Channel message updates (*tg.UpdateNewChannelMessage and friends)
+// are intentionally excluded: their senders are routinely min in megagroups, so
+// recovering them via a global getDifference would be prohibitively expensive;
+// the channel-difference machinery owns that path. This mirrors TDLib
+// is_acceptable_update restricted to the non-channel get_difference branch (see
+// docs/research/telegram-min-updates-discipline.md §9).
+func (s *internalState) messageUpdatesPeersKnown(ctx context.Context, updates []tg.UpdateClass) bool {
+	for _, u := range updates {
+		var msg tg.MessageClass
+		switch upd := u.(type) {
+		case *tg.UpdateNewMessage:
+			msg = upd.Message
+		case *tg.UpdateEditMessage:
+			msg = upd.Message
+		default:
+			continue
+		}
+		m, ok := msg.(*tg.Message)
+		if !ok {
+			continue
+		}
+		if !s.userPeersKnown(ctx, messageUserIDs(s.selfID, m)) {
+			return false
+		}
+	}
+	return true
+}

--- a/telegram/updates/message_peer_test.go
+++ b/telegram/updates/message_peer_test.go
@@ -1,0 +1,115 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+func TestMessageUserIDs(t *testing.T) {
+	const selfID = 999
+
+	full := func() *tg.Message {
+		m := &tg.Message{
+			ID:     1,
+			PeerID: &tg.PeerUser{UserID: 111},
+			FromID: &tg.PeerUser{UserID: 222},
+		}
+		var fwd tg.MessageFwdHeader
+		fwd.SetFromID(&tg.PeerUser{UserID: 333})
+		fwd.SetSavedFromPeer(&tg.PeerUser{UserID: 444})
+		m.SetFwdFrom(fwd)
+		m.SetViaBotID(555)
+		m.SetEntities([]tg.MessageEntityClass{
+			&tg.MessageEntityMentionName{UserID: 666},
+			&tg.MessageEntityBold{},
+		})
+		return m
+	}
+
+	tests := []struct {
+		name string
+		msg  *tg.Message
+		want []int64
+	}{
+		{
+			name: "sender only",
+			msg:  &tg.Message{PeerID: &tg.PeerUser{UserID: 111}},
+			want: []int64{111},
+		},
+		{
+			name: "self and zero excluded",
+			msg:  &tg.Message{PeerID: &tg.PeerUser{UserID: selfID}, FromID: &tg.PeerUser{UserID: 0}},
+			want: []int64{},
+		},
+		{
+			name: "non-user peers ignored",
+			msg:  &tg.Message{PeerID: &tg.PeerChannel{ChannelID: 42}, FromID: &tg.PeerChat{ChatID: 7}},
+			want: []int64{},
+		},
+		{
+			name: "peer + sender + fwd + saved-from + via_bot + mention",
+			msg:  full(),
+			want: []int64{111, 222, 333, 444, 555, 666},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, messageUserIDs(selfID, tt.msg))
+		})
+	}
+}
+
+func TestMessageUpdatesPeersKnown(t *testing.T) {
+	ctx := context.Background()
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		return nil
+	})
+	s := newShortTestState(t, &countDiffAPI{}, handler)
+	require.NoError(t, s.userHasher.SetUserAccessHash(ctx, s.selfID, 111, 7777))
+
+	knownMsg := func(senderID int64) *tg.Message {
+		return &tg.Message{ID: 1, PeerID: &tg.PeerUser{UserID: senderID}}
+	}
+
+	tests := []struct {
+		name    string
+		updates []tg.UpdateClass
+		want    bool
+	}{
+		{
+			name:    "non-message update is ignored",
+			updates: []tg.UpdateClass{&tg.UpdateUserName{UserID: 222}},
+			want:    true,
+		},
+		{
+			name:    "non-*tg.Message body is ignored",
+			updates: []tg.UpdateClass{&tg.UpdateNewMessage{Message: &tg.MessageService{ID: 1, PeerID: &tg.PeerUser{UserID: 222}}}},
+			want:    true,
+		},
+		{
+			name:    "new message with known sender",
+			updates: []tg.UpdateClass{&tg.UpdateNewMessage{Message: knownMsg(111)}},
+			want:    true,
+		},
+		{
+			name:    "new message with unknown sender",
+			updates: []tg.UpdateClass{&tg.UpdateNewMessage{Message: knownMsg(222)}},
+			want:    false,
+		},
+		{
+			name:    "edit message with unknown sender",
+			updates: []tg.UpdateClass{&tg.UpdateEditMessage{Message: knownMsg(222)}},
+			want:    false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, s.messageUpdatesPeersKnown(ctx, tt.updates))
+		})
+	}
+}

--- a/telegram/updates/short_getdiff_test.go
+++ b/telegram/updates/short_getdiff_test.go
@@ -1,0 +1,220 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// countDiffAPI counts UpdatesGetDifference calls and always returns an empty
+// difference, so no messages are dispatched through the difference path.
+type countDiffAPI struct {
+	diffCalls int
+}
+
+func (a *countDiffAPI) UpdatesGetState(ctx context.Context) (*tg.UpdatesState, error) {
+	return &tg.UpdatesState{}, nil
+}
+
+func (a *countDiffAPI) UpdatesGetDifference(
+	ctx context.Context, request *tg.UpdatesGetDifferenceRequest,
+) (tg.UpdatesDifferenceClass, error) {
+	a.diffCalls++
+	return &tg.UpdatesDifferenceEmpty{}, nil
+}
+
+func (a *countDiffAPI) UpdatesGetChannelDifference(
+	ctx context.Context, request *tg.UpdatesGetChannelDifferenceRequest,
+) (tg.UpdatesChannelDifferenceClass, error) {
+	return &tg.UpdatesChannelDifferenceEmpty{}, nil
+}
+
+func newShortTestState(t *testing.T, api API, handler telegram.UpdateHandler) *internalState {
+	t.Helper()
+	ctx := context.Background()
+	const selfID = 123
+	storage := newMemStorage()
+	require.NoError(t, storage.SetState(ctx, selfID, State{}))
+	return newState(ctx, stateConfig{
+		RawClient:        api,
+		Logger:           zaptest.NewLogger(t),
+		Tracer:           noop.NewTracerProvider().Tracer(""),
+		Handler:          handler,
+		OnChannelTooLong: func(int64) {},
+		OnTooLong:        func() {},
+		Storage:          storage,
+		Hasher:           newMemAccessHasher(),
+		UserHasher:       newMemUserAccessHasher(),
+		SelfID:           selfID,
+		DiffLimit:        diffLimitUser,
+		WorkGroup:        &errgroup.Group{},
+	})
+}
+
+func TestShortMessageUnknownPeerForcesDifference(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	err := s.handleUpdates(ctx, &tg.UpdateShortMessage{UserID: 555, ID: 1, Pts: 1, PtsCount: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, api.diffCalls, "getDifference must be forced for unknown peer")
+	require.Equal(t, 0, dispatched, "short message must not be dispatched directly")
+}
+
+func TestShortMessageKnownPeerAppliesDirectly(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	// Seed the sender as known through the normal apply path: a prior *tg.Updates
+	// carrying the full (non-min, non-zero hash) user marks it known.
+	require.NoError(t, s.handleUpdates(ctx, &tg.Updates{
+		Users: []tg.UserClass{&tg.User{ID: 555, AccessHash: 7777}},
+	}))
+
+	err := s.handleUpdates(ctx, &tg.UpdateShortMessage{UserID: 555, ID: 1, Pts: 1, PtsCount: 1})
+	require.NoError(t, err)
+	require.Equal(t, 0, api.diffCalls, "no difference for known peer")
+	require.Equal(t, 1, dispatched, "short message must be dispatched directly")
+}
+
+// TestShortMessageMinUserNotKnown encodes the min rule: a user observed ONLY as
+// min (or with a zero access hash) does NOT count as known, so a short message
+// from it still forces getDifference.
+func TestShortMessageMinUserNotKnown(t *testing.T) {
+	ctx := context.Background()
+
+	for _, tt := range []struct {
+		name string
+		user *tg.User
+	}{
+		{"min user", &tg.User{ID: 555, Min: true, AccessHash: 7777}},
+		{"zero access hash", &tg.User{ID: 555, AccessHash: 0}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			api := &countDiffAPI{}
+			var dispatched int
+			handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+				dispatched++
+				return nil
+			})
+			s := newShortTestState(t, api, handler)
+
+			// Feed the min/zero-hash user through the normal apply path. It must
+			// NOT be recorded as known.
+			require.NoError(t, s.handleUpdates(ctx, &tg.Updates{
+				Users: []tg.UserClass{tt.user},
+			}))
+			_, known, _ := s.userHasher.GetUserAccessHash(ctx, s.selfID, 555)
+			require.False(t, known, "min/zero-hash user must not be recorded as known")
+
+			err := s.handleUpdates(ctx, &tg.UpdateShortMessage{UserID: 555, ID: 1, Pts: 1, PtsCount: 1})
+			require.NoError(t, err)
+			require.Equal(t, 1, api.diffCalls, "min/zero-hash sender must still force getDifference")
+			require.Equal(t, 0, dispatched, "short message must not be dispatched directly")
+		})
+	}
+}
+
+func TestShortChatMessageUnknownPeerForcesDifference(t *testing.T) {
+	ctx := context.Background()
+	api := &countDiffAPI{}
+	var dispatched int
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		dispatched++
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	err := s.handleUpdates(ctx, &tg.UpdateShortChatMessage{FromID: 555, ChatID: 42, ID: 1, Pts: 1, PtsCount: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, api.diffCalls, "getDifference must be forced for unknown sender of a chat message")
+	require.Equal(t, 0, dispatched, "short chat message must not be dispatched directly")
+}
+
+// oneDiffAPI returns a single configured difference for every getDifference call.
+type oneDiffAPI struct {
+	diff  tg.UpdatesDifferenceClass
+	calls int
+}
+
+func (a *oneDiffAPI) UpdatesGetState(ctx context.Context) (*tg.UpdatesState, error) {
+	return &tg.UpdatesState{}, nil
+}
+
+func (a *oneDiffAPI) UpdatesGetDifference(
+	ctx context.Context, request *tg.UpdatesGetDifferenceRequest,
+) (tg.UpdatesDifferenceClass, error) {
+	a.calls++
+	return a.diff, nil
+}
+
+func (a *oneDiffAPI) UpdatesGetChannelDifference(
+	ctx context.Context, request *tg.UpdatesGetChannelDifferenceRequest,
+) (tg.UpdatesChannelDifferenceClass, error) {
+	return &tg.UpdatesChannelDifferenceEmpty{}, nil
+}
+
+// TestShortMessageRecoveredDifferenceCarriesSender locks the end-to-end invariant:
+// forcing getDifference for an unknown sender re-delivers the message together with
+// the sender entity (access hash) in the SAME envelope, so a downstream
+// entity-ingesting handler learns the access hash before the message is processed.
+// Afterwards, that peer is recorded as known.
+func TestShortMessageRecoveredDifferenceCarriesSender(t *testing.T) {
+	ctx := context.Background()
+	user := &tg.User{ID: 555, AccessHash: 7777}
+	msg := &tg.Message{
+		ID:      10,
+		PeerID:  &tg.PeerUser{UserID: 555},
+		FromID:  &tg.PeerUser{UserID: 555},
+		Message: "hi",
+	}
+	api := &oneDiffAPI{diff: &tg.UpdatesDifference{
+		NewMessages: []tg.MessageClass{msg},
+		Users:       []tg.UserClass{user},
+		State:       tg.UpdatesState{Pts: 1, Date: 1},
+	}}
+
+	var got *tg.Updates
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		if up, ok := u.(*tg.Updates); ok && len(up.Updates) > 0 {
+			got = up
+		}
+		return nil
+	})
+	s := newShortTestState(t, api, handler)
+
+	err := s.handleUpdates(ctx, &tg.UpdateShortMessage{UserID: 555, ID: 10, Pts: 1, PtsCount: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, api.calls, "getDifference must be forced once for the unknown sender")
+	require.NotNil(t, got, "recovered message must be dispatched")
+
+	require.Len(t, got.Users, 1, "recovered envelope must carry the sender entity")
+	gotUser, ok := got.Users[0].(*tg.User)
+	require.True(t, ok)
+	require.Equal(t, int64(555), gotUser.ID)
+	require.Equal(t, int64(7777), gotUser.AccessHash, "sender access hash present before message dispatch")
+
+	// The recovered sender is now known: a subsequent short message from it
+	// applies directly without another getDifference.
+	_, known, _ := s.userHasher.GetUserAccessHash(ctx, s.selfID, 555)
+	require.True(t, known, "recovered sender must be recorded as known")
+}

--- a/telegram/updates/short_peer.go
+++ b/telegram/updates/short_peer.go
@@ -1,0 +1,91 @@
+package updates
+
+import (
+	"context"
+
+	"github.com/gotd/td/tg"
+)
+
+// shortMessageOptional is implemented by both *tg.UpdateShortMessage and
+// *tg.UpdateShortChatMessage; it exposes the optional fields that may reference
+// additional user peers (forward origin, inline bot, mention entities).
+type shortMessageOptional interface {
+	GetFwdFrom() (tg.MessageFwdHeader, bool)
+	GetViaBotID() (int64, bool)
+	GetEntities() ([]tg.MessageEntityClass, bool)
+}
+
+// referencedUserIDs returns the user IDs a short message refers to whose access
+// hash must be known before the message can be resolved: the primary
+// peer/sender, the forward origin and its saved-from peer (when users), the
+// inline bot, and mention-name entities. selfID and zero IDs are never returned.
+//
+// The primary is the counterpart user for UpdateShortMessage (u.UserID) and the
+// sender for UpdateShortChatMessage (u.FromID); for an outgoing chat message the
+// sender is selfID and is therefore excluded. The basic-group chat and channel
+// peers carry no user access hash and are not checked here; the reply-to peer is
+// likewise deliberately omitted (rare cross-thread case).
+func referencedUserIDs(selfID, primary int64, opt shortMessageOptional) []int64 {
+	ids := make([]int64, 0, 4)
+	add := func(id int64) {
+		if id != 0 && id != selfID {
+			ids = append(ids, id)
+		}
+	}
+
+	add(primary)
+
+	if fwd, ok := opt.GetFwdFrom(); ok {
+		if from, ok := fwd.GetFromID(); ok {
+			if u, ok := from.(*tg.PeerUser); ok {
+				add(u.UserID)
+			}
+		}
+		if saved, ok := fwd.GetSavedFromPeer(); ok {
+			if u, ok := saved.(*tg.PeerUser); ok {
+				add(u.UserID)
+			}
+		}
+	}
+	if via, ok := opt.GetViaBotID(); ok {
+		add(via)
+	}
+	if ents, ok := opt.GetEntities(); ok {
+		for _, e := range ents {
+			if m, ok := e.(*tg.MessageEntityMentionName); ok {
+				add(m.UserID)
+			}
+		}
+	}
+
+	return ids
+}
+
+// shortMessagePeersKnown reports whether every user peer referenced by a private
+// short message already has a known access hash.
+func (s *internalState) shortMessagePeersKnown(ctx context.Context, u *tg.UpdateShortMessage) bool {
+	return s.userPeersKnown(ctx, referencedUserIDs(s.selfID, u.UserID, u))
+}
+
+// shortChatMessagePeersKnown reports whether every user peer referenced by a
+// basic-group short message already has a known access hash. The basic-group
+// chat itself has no access hash and is intentionally not checked.
+func (s *internalState) shortChatMessagePeersKnown(ctx context.Context, u *tg.UpdateShortChatMessage) bool {
+	return s.userPeersKnown(ctx, referencedUserIDs(s.selfID, u.FromID, u))
+}
+
+// userPeersKnown reports whether every referenced user ID is known: a user is
+// known iff it is selfID or a full (non-min, non-zero) access hash has been seen
+// for it (see saveUserHashes). A hasher error is treated as "not known", so the
+// caller falls back to getDifference.
+func (s *internalState) userPeersKnown(ctx context.Context, ids []int64) bool {
+	for _, id := range ids {
+		if id == s.selfID {
+			continue
+		}
+		if _, found, err := s.userHasher.GetUserAccessHash(ctx, s.selfID, id); err != nil || !found {
+			return false
+		}
+	}
+	return true
+}

--- a/telegram/updates/short_peer_test.go
+++ b/telegram/updates/short_peer_test.go
@@ -58,3 +58,19 @@ func TestShortMessagePeersKnown(t *testing.T) {
 	// selfID is always known without being seeded.
 	require.True(t, s.shortMessagePeersKnown(ctx, &tg.UpdateShortMessage{UserID: selfID}))
 }
+
+func TestUserPeersKnown(t *testing.T) {
+	ctx := context.Background()
+	const selfID = 999
+	hasher := newMemUserAccessHasher()
+	require.NoError(t, hasher.SetUserAccessHash(ctx, selfID, 111, 7777))
+	s := &internalState{
+		selfID:     selfID,
+		userHasher: hasher,
+	}
+
+	require.True(t, s.userPeersKnown(ctx, nil), "no peers are trivially known")
+	// selfID is skipped before the hasher lookup, so it counts as known.
+	require.True(t, s.userPeersKnown(ctx, []int64{selfID, 111}))
+	require.False(t, s.userPeersKnown(ctx, []int64{111, 222}), "an unknown peer makes the batch unknown")
+}

--- a/telegram/updates/short_peer_test.go
+++ b/telegram/updates/short_peer_test.go
@@ -1,0 +1,60 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestReferencedUserIDs(t *testing.T) {
+	const selfID = 999
+
+	withOptional := func() shortMessageOptional {
+		u := &tg.UpdateShortMessage{UserID: 111}
+		var fwd tg.MessageFwdHeader
+		fwd.SetFromID(&tg.PeerUser{UserID: 222})
+		fwd.SetSavedFromPeer(&tg.PeerUser{UserID: 666})
+		u.SetFwdFrom(fwd)
+		u.SetViaBotID(333)
+		u.SetEntities([]tg.MessageEntityClass{
+			&tg.MessageEntityMentionName{UserID: 444},
+			&tg.MessageEntityBold{},
+		})
+		return u
+	}
+
+	tests := []struct {
+		name    string
+		primary int64
+		opt     shortMessageOptional
+		want    []int64
+	}{
+		{"sender only", 111, &tg.UpdateShortMessage{UserID: 111}, []int64{111}},
+		{"self excluded", selfID, &tg.UpdateShortMessage{UserID: selfID}, []int64{}},
+		{"fwd + saved-from + via_bot + mention", 111, withOptional(), []int64{111, 222, 666, 333, 444}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, referencedUserIDs(selfID, tt.primary, tt.opt))
+		})
+	}
+}
+
+func TestShortMessagePeersKnown(t *testing.T) {
+	ctx := context.Background()
+	const selfID = 999
+	hasher := newMemUserAccessHasher()
+	require.NoError(t, hasher.SetUserAccessHash(ctx, selfID, 111, 7777))
+	s := &internalState{
+		selfID:     selfID,
+		userHasher: hasher,
+	}
+
+	require.True(t, s.shortMessagePeersKnown(ctx, &tg.UpdateShortMessage{UserID: 111}))
+	require.False(t, s.shortMessagePeersKnown(ctx, &tg.UpdateShortMessage{UserID: 222}))
+	// selfID is always known without being seeded.
+	require.True(t, s.shortMessagePeersKnown(ctx, &tg.UpdateShortMessage{UserID: selfID}))
+}

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -59,6 +59,7 @@ type internalState struct {
 	onCommonTooLong       func()
 	storage               StateStorage
 	hasher                ChannelAccessHasher
+	userHasher            UserAccessHasher
 	selfID                int64
 	diffLim               int
 	wg                    *errgroup.Group
@@ -80,6 +81,7 @@ type stateConfig struct {
 	OnTooLong             func()
 	Storage               StateStorage
 	Hasher                ChannelAccessHasher
+	UserHasher            UserAccessHasher
 	SelfID                int64
 	DiffLimit             int
 	WorkGroup             *errgroup.Group
@@ -104,6 +106,7 @@ func newState(ctx context.Context, cfg stateConfig) *internalState {
 		onCommonTooLong:       cfg.OnTooLong,
 		storage:               cfg.Storage,
 		hasher:                cfg.Hasher,
+		userHasher:            cfg.UserHasher,
 		selfID:                cfg.SelfID,
 		diffLim:               cfg.DiffLimit,
 		wg:                    cfg.WorkGroup,
@@ -240,6 +243,10 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 	switch u := u.(type) {
 	case *tg.Updates:
 		s.saveChannelHashes(ctx, u.Chats)
+		s.saveUserHashes(ctx, u.Users)
+		if !s.messageUpdatesPeersKnown(ctx, u.Updates) {
+			return s.getDifference(ctx)
+		}
 		return s.handleSeq(ctx, &tg.UpdatesCombined{
 			Updates:  u.Updates,
 			Users:    u.Users,
@@ -250,6 +257,10 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 		})
 	case *tg.UpdatesCombined:
 		s.saveChannelHashes(ctx, u.Chats)
+		s.saveUserHashes(ctx, u.Users)
+		if !s.messageUpdatesPeersKnown(ctx, u.Updates) {
+			return s.getDifference(ctx)
+		}
 		return s.handleSeq(ctx, u)
 	case *tg.UpdateShort:
 		return s.handleUpdates(ctx, &tg.UpdatesCombined{
@@ -257,8 +268,14 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 			Date:    u.Date,
 		})
 	case *tg.UpdateShortMessage:
+		if !s.shortMessagePeersKnown(ctx, u) {
+			return s.getDifference(ctx)
+		}
 		return s.handleUpdates(ctx, s.convertShortMessage(u))
 	case *tg.UpdateShortChatMessage:
+		if !s.shortChatMessagePeersKnown(ctx, u) {
+			return s.getDifference(ctx)
+		}
 		return s.handleUpdates(ctx, s.convertShortChatMessage(u))
 	case *tg.UpdateShortSentMessage:
 		return s.handleUpdates(ctx, s.convertShortSentMessage(u))
@@ -436,6 +453,11 @@ func (s *internalState) getDifference(ctx context.Context) error {
 
 	switch diff := diff.(type) {
 	case *tg.UpdatesDifference:
+		// Record recovered senders as known before dispatching, so a user
+		// recovered via getDifference does not re-trigger getDifference for the
+		// next short message from the same sender.
+		s.saveUserHashes(ctx, diff.Users)
+
 		if len(diff.OtherUpdates) > 0 {
 			if err := s.handleUpdates(ctx, &tg.UpdatesCombined{
 				Updates: diff.OtherUpdates,
@@ -474,6 +496,11 @@ func (s *internalState) getDifference(ctx context.Context) error {
 
 	// Incomplete list of occurred events.
 	case *tg.UpdatesDifferenceSlice:
+		// Record recovered senders as known before dispatching, so a user
+		// recovered via getDifference does not re-trigger getDifference for the
+		// next short message from the same sender.
+		s.saveUserHashes(ctx, diff.Users)
+
 		if len(diff.OtherUpdates) > 0 {
 			if err := s.handleUpdates(ctx, &tg.UpdatesCombined{
 				Updates: diff.OtherUpdates,

--- a/telegram/updates/storage.go
+++ b/telegram/updates/storage.go
@@ -43,3 +43,11 @@ type ChannelAccessHasher interface {
 	SetChannelAccessHash(ctx context.Context, userID, channelID, accessHash int64) error
 	GetChannelAccessHash(ctx context.Context, userID, channelID int64) (accessHash int64, found bool, err error)
 }
+
+// UserAccessHasher stores user access hashes observed by the updates manager so
+// it can decide whether an incoming update references a user it already knows.
+// Mirrors ChannelAccessHasher. In-mem used if not provided to Config.
+type UserAccessHasher interface {
+	SetUserAccessHash(ctx context.Context, userID, targetUserID, accessHash int64) error
+	GetUserAccessHash(ctx context.Context, userID, targetUserID int64) (accessHash int64, found bool, err error)
+}

--- a/telegram/updates/storage_mem.go
+++ b/telegram/updates/storage_mem.go
@@ -193,3 +193,43 @@ func (m *memAccessHasher) SetChannelAccessHash(ctx context.Context, userID, chan
 	userHashes[channelID] = accessHash
 	return nil
 }
+
+var _ UserAccessHasher = (*memUserAccessHasher)(nil)
+
+type memUserAccessHasher struct {
+	hashes map[int64]map[int64]int64
+	mux    sync.Mutex
+}
+
+func newMemUserAccessHasher() *memUserAccessHasher {
+	return &memUserAccessHasher{
+		hashes: map[int64]map[int64]int64{},
+	}
+}
+
+func (m *memUserAccessHasher) GetUserAccessHash(ctx context.Context, userID, targetUserID int64) (accessHash int64, found bool, err error) {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	userHashes, ok := m.hashes[userID]
+	if !ok {
+		return 0, false, nil
+	}
+
+	accessHash, found = userHashes[targetUserID]
+	return
+}
+
+func (m *memUserAccessHasher) SetUserAccessHash(ctx context.Context, userID, targetUserID, accessHash int64) error {
+	m.mux.Lock()
+	defer m.mux.Unlock()
+
+	userHashes, ok := m.hashes[userID]
+	if !ok {
+		userHashes = map[int64]int64{}
+		m.hashes[userID] = userHashes
+	}
+
+	userHashes[targetUserID] = accessHash
+	return nil
+}

--- a/telegram/updates/storage_mem_user_test.go
+++ b/telegram/updates/storage_mem_user_test.go
@@ -1,0 +1,29 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMemUserAccessHasher(t *testing.T) {
+	ctx := context.Background()
+	h := newMemUserAccessHasher()
+
+	_, found, err := h.GetUserAccessHash(ctx, 1, 555)
+	require.NoError(t, err)
+	require.False(t, found, "unset user must report not found")
+
+	require.NoError(t, h.SetUserAccessHash(ctx, 1, 555, 7777))
+
+	hash, found, err := h.GetUserAccessHash(ctx, 1, 555)
+	require.NoError(t, err)
+	require.True(t, found)
+	require.Equal(t, int64(7777), hash)
+
+	// Scoped per self user id.
+	_, found, err = h.GetUserAccessHash(ctx, 2, 555)
+	require.NoError(t, err)
+	require.False(t, found, "hash is scoped to the owning self user id")
+}


### PR DESCRIPTION
## Problem

The updates manager forwards the entity arrays (`users[]`, `chats[]`) to the handler but does not, on its own, guarantee that a usable access hash is learned for every peer an update refers to. Usually that is fine because the envelope carries the referenced users. But a message-bearing update can arrive whose sender has **no full access hash available**:

- `updateShortMessage` / `updateShortChatMessage` carry the sender id but no `users[]` at all;
- a regular `updateNewMessage` / `updateEditMessage` inside `updates` / `updatesCombined` / `updateShort` whose sender is absent (or only `min`) in the envelope `users[]`.

In these cases the update is applied and dispatched, yet **no access hash is ever recorded for the sender**. So even though the client has just observed an event directly involving that user — an incoming message from them — it still has no usable access hash and cannot construct a valid `InputUser` / `InputPeer` to act on them afterwards (e.g. to reply). A `min` entity does not help here: a min access hash is only valid for `inputPeerPhotoFileLocation`, not for normal RPCs ([/api/min](https://core.telegram.org/api/min)).

This is the situation the existing TODO in `telegram/peers/apply.go` anticipates:

> `// TODO(tdakkota): call some hook to get actual user if got min (e.g. force gaps to getDifference)`

## Fix

Follow the official clients (TDLib `is_acceptable_update`, Telegram Android `needGetDiff`): before applying a message-bearing update, check that every referenced user peer is known; if not, run `updates.getDifference`, which returns the message together with the full `users[]`, then apply. The recovered sender enters the cache before the message is dispatched, so the same peer never re-triggers `getDifference`.

Covered constructors: `updateShortMessage`, `updateShortChatMessage`, and the non-channel `updateNewMessage` / `updateEditMessage`. Referenced user peers checked: dialog peer, sender (`from_id`), forward origin + saved-from, inline `via_bot`, and `messageEntityMentionName`.

For already-known peers the apply path is unchanged — `getDifference` is forced only for previously-unresolvable peers (one extra round-trip on first contact).

## New API: `UserAccessHasher`

Known users are tracked via a new optional `UserAccessHasher`, mirroring the existing `ChannelAccessHasher`:

```go
type UserAccessHasher interface {
    SetUserAccessHash(ctx context.Context, userID, targetUserID, accessHash int64) error
    GetUserAccessHash(ctx context.Context, userID, targetUserID int64) (accessHash int64, found bool, err error)
}
```

- New optional `Config.UserAccessHasher`; an in-memory implementation is used when not provided (`setDefaults`), exactly like `Config.AccessHasher`.
- Fed **min-aware** from the authoritative `users[]` of `updates`/`updatesCombined` and of `getDifference` results: a `min` user or a zero access hash does not count as known (per [/api/min](https://core.telegram.org/api/min)). Recovered senders are recorded before dispatch (loop-safety).
- Providing a persistent implementation makes known-peer decisions survive reconnects.

## Scope / non-goals

- Channel message updates (`updateNewChannelMessage` / `updateEditChannelMessage`) are intentionally **not** covered: `min` senders are routine in megagroups, so a global `getDifference` per such message would be excessive — TDLib handles those via `updateChannelTooLong` (channel difference), which is left untouched here.
- `messageService` is not covered.

## Backward compatibility

Purely additive (`telegram/updates` only). The new interface and the new optional `Config` field break nothing: existing `updates.New(Config{...})` callers keep working and get the in-memory default. Behavior changes only for previously-unresolvable peers.

## Tests

Unit/table tests cover: unknown peer → forces `getDifference`; known peer → direct apply; `min`/zero-hash not counted as known; recovered difference carries the sender; channel messages excluded; the in-mem `UserAccessHasher` and the `Config` default.
