### PR TITLE
feat(message): expose Spoiler option on media builders

### DIFF
--- a/telegram/message/document.go
+++ b/telegram/message/document.go
@@ -33,6 +33,12 @@ func (u *DocumentBuilder) Query(query string) *DocumentBuilder {
 	return u
 }
 
+// Spoiler sets flag to add spoiler animation (blurred preview) to the document.
+func (u *DocumentBuilder) Spoiler(v bool) *DocumentBuilder {
+	u.doc.Spoiler = v
+	return u
+}
+
 // apply implements MediaOption.
 func (u *DocumentBuilder) apply(ctx context.Context, b *multiMediaBuilder) error {
 	return Media(&u.doc, u.caption...).apply(ctx, b)
@@ -164,6 +170,12 @@ func (u *DocumentExternalBuilder) TTLSeconds(ttl int) *DocumentExternalBuilder {
 	return u
 }
 
+// Spoiler sets flag to add spoiler animation (blurred preview) to the document.
+func (u *DocumentExternalBuilder) Spoiler(v bool) *DocumentExternalBuilder {
+	u.doc.Spoiler = v
+	return u
+}
+
 // apply implements MediaOption.
 func (u *DocumentExternalBuilder) apply(ctx context.Context, b *multiMediaBuilder) error {
 	return Media(&u.doc, u.caption...).apply(ctx, b)
@@ -200,6 +212,12 @@ func (u *UploadedDocumentBuilder) NosoundVideo(v bool) *UploadedDocumentBuilder 
 // ForceFile sets flag to force the media file to be uploaded as document.
 func (u *UploadedDocumentBuilder) ForceFile(v bool) *UploadedDocumentBuilder {
 	u.doc.ForceFile = v
+	return u
+}
+
+// Spoiler sets flag to add spoiler animation (blurred preview) to the document.
+func (u *UploadedDocumentBuilder) Spoiler(v bool) *UploadedDocumentBuilder {
+	u.doc.Spoiler = v
 	return u
 }
 

--- a/telegram/message/photo.go
+++ b/telegram/message/photo.go
@@ -15,6 +15,12 @@ type PhotoBuilder struct {
 	caption []StyledTextOption
 }
 
+// Spoiler sets flag to add spoiler animation (blurred preview) to the photo.
+func (u *PhotoBuilder) Spoiler(v bool) *PhotoBuilder {
+	u.photo.Spoiler = v
+	return u
+}
+
 // TTL sets time to live of self-destructing photo.
 func (u *PhotoBuilder) TTL(ttl time.Duration) *PhotoBuilder {
 	return u.TTLSeconds(int(ttl.Seconds()))
@@ -63,6 +69,12 @@ type PhotoExternalBuilder struct {
 	caption []StyledTextOption
 }
 
+// Spoiler sets flag to add spoiler animation (blurred preview) to the photo.
+func (u *PhotoExternalBuilder) Spoiler(v bool) *PhotoExternalBuilder {
+	u.doc.Spoiler = v
+	return u
+}
+
 // TTL sets time to live of self-destructing document.
 func (u *PhotoExternalBuilder) TTL(ttl time.Duration) *PhotoExternalBuilder {
 	return u.TTLSeconds(int(ttl.Seconds()))
@@ -106,6 +118,12 @@ type UploadedPhotoBuilder struct {
 // Stickers adds attached mask stickers.
 func (u *UploadedPhotoBuilder) Stickers(stickers ...FileLocation) *UploadedPhotoBuilder {
 	u.photo.Stickers = append(u.photo.Stickers, inputDocuments(stickers...)...)
+	return u
+}
+
+// Spoiler sets flag to add spoiler animation (blurred preview) to the photo.
+func (u *UploadedPhotoBuilder) Spoiler(v bool) *UploadedPhotoBuilder {
+	u.photo.Spoiler = v
 	return u
 }
 

--- a/telegram/message/spoiler_test.go
+++ b/telegram/message/spoiler_test.go
@@ -1,0 +1,36 @@
+package message
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestSpoiler(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	file := &tg.InputFile{ID: 10}
+	photo := &tg.InputPhoto{ID: 10}
+	doc := &tg.InputDocument{ID: 10}
+
+	expectSendMedia(t, &tg.InputMediaUploadedPhoto{File: file, Spoiler: true}, mock)
+	expectSendMedia(t, &tg.InputMediaPhoto{ID: photo, Spoiler: true}, mock)
+	expectSendMedia(t, &tg.InputMediaPhotoExternal{URL: "https://google.com", Spoiler: true}, mock)
+	expectSendMedia(t, &tg.InputMediaDocument{ID: doc, Spoiler: true}, mock)
+	expectSendMedia(t, &tg.InputMediaDocumentExternal{URL: "https://google.com", Spoiler: true}, mock)
+
+	_, err := sender.Self().Media(ctx, UploadedPhoto(file).Spoiler(true))
+	require.NoError(t, err)
+	_, err = sender.Self().Media(ctx, Photo(photo).Spoiler(true))
+	require.NoError(t, err)
+	_, err = sender.Self().Media(ctx, PhotoExternal("https://google.com").Spoiler(true))
+	require.NoError(t, err)
+	_, err = sender.Self().Media(ctx, Document(doc).Spoiler(true))
+	require.NoError(t, err)
+	_, err = sender.Self().Media(ctx, DocumentExternal("https://google.com").Spoiler(true))
+	require.NoError(t, err)
+}

--- a/telegram/message/video.go
+++ b/telegram/message/video.go
@@ -30,6 +30,12 @@ type VideoDocumentBuilder struct {
 	attr tg.DocumentAttributeVideo
 }
 
+// Spoiler sets flag to add spoiler animation (blurred preview) to the video.
+func (u *VideoDocumentBuilder) Spoiler(v bool) *VideoDocumentBuilder {
+	u.doc.Spoiler(v)
+	return u
+}
+
 // Round sets flag to mark this video as round.
 func (u *VideoDocumentBuilder) Round() *VideoDocumentBuilder {
 	u.attr.RoundMessage = true


### PR DESCRIPTION
## Summary

Surfaces the existing `Spoiler` flag of the `InputMedia*` types on the high-level message media builders, so callers can send a blurred/spoiler preview without dropping to raw `tg` structs.

Adds `Spoiler(v bool)` to:
- `PhotoBuilder`, `PhotoExternalBuilder`, `UploadedPhotoBuilder`
- `DocumentBuilder`, `DocumentExternalBuilder`, `UploadedDocumentBuilder`
- `VideoDocumentBuilder` (delegates to the wrapped document builder)

Follows the existing builder pattern (e.g. `NosoundVideo`, `ForceFile`): the bool field is set directly and the generated `SetFlags()` handles the flag bit on encode.

## Test

Adds `TestSpoiler` asserting the spoiler flag is set on the outgoing media for photo, photo-external, document and document-external paths.

Fixes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)