### PR TITLE
feat(query): add GetMediaGroup helper for albums

### DIFF
--- a/telegram/query/messages/media_group.go
+++ b/telegram/query/messages/media_group.go
@@ -1,0 +1,100 @@
+package messages
+
+import (
+	"context"
+	"sort"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// maxMediaGroupSize is the maximum number of messages in a media group (album).
+const maxMediaGroupSize = 10
+
+// GetMediaGroup fetches all messages belonging to the same media group (album)
+// as the message with the given id in peer, ordered by message ID.
+//
+// Album messages are consecutive and the anchor may be anywhere within the
+// group, so a window of messages around msgID is fetched and filtered by the
+// shared grouped_id.
+//
+// Returns an error if the message is not found or is not part of a media group.
+//
+// See https://core.telegram.org/api/files#albums-grouped-media.
+func (q *QueryBuilder) GetMediaGroup(
+	ctx context.Context,
+	peer tg.InputPeerClass,
+	msgID int,
+) ([]*tg.Message, error) {
+	ids := make([]tg.InputMessageClass, 0, 2*maxMediaGroupSize-1)
+	for id := msgID - (maxMediaGroupSize - 1); id <= msgID+(maxMediaGroupSize-1); id++ {
+		if id <= 0 {
+			continue
+		}
+		ids = append(ids, &tg.InputMessageID{ID: id})
+	}
+
+	raw, err := q.getMessages(ctx, peer, ids)
+	if err != nil {
+		return nil, errors.Wrap(err, "get messages")
+	}
+
+	byID := make(map[int]*tg.Message, len(raw))
+	for _, m := range raw {
+		if msg, ok := m.(*tg.Message); ok {
+			byID[msg.ID] = msg
+		}
+	}
+
+	anchor, ok := byID[msgID]
+	if !ok {
+		return nil, errors.Errorf("message %d not found", msgID)
+	}
+	groupedID, ok := anchor.GetGroupedID()
+	if !ok {
+		return nil, errors.Errorf("message %d is not part of a media group", msgID)
+	}
+
+	var group []*tg.Message
+	for _, msg := range byID {
+		if id, ok := msg.GetGroupedID(); ok && id == groupedID {
+			group = append(group, msg)
+		}
+	}
+	sort.Slice(group, func(i, j int) bool {
+		return group[i].ID < group[j].ID
+	})
+
+	return group, nil
+}
+
+func (q *QueryBuilder) getMessages(
+	ctx context.Context,
+	peer tg.InputPeerClass,
+	ids []tg.InputMessageClass,
+) ([]tg.MessageClass, error) {
+	var (
+		res tg.MessagesMessagesClass
+		err error
+	)
+	if ch, ok := peer.(*tg.InputPeerChannel); ok {
+		res, err = q.raw.ChannelsGetMessages(ctx, &tg.ChannelsGetMessagesRequest{
+			Channel: &tg.InputChannel{
+				ChannelID:  ch.ChannelID,
+				AccessHash: ch.AccessHash,
+			},
+			ID: ids,
+		})
+	} else {
+		res, err = q.raw.MessagesGetMessages(ctx, ids)
+	}
+	if err != nil {
+		return nil, err
+	}
+	modified, ok := res.AsModified()
+	if !ok {
+		return nil, errors.Errorf("unexpected response %T", res)
+	}
+	return modified.GetMessages(), nil
+}

--- a/telegram/query/messages/media_group_test.go
+++ b/telegram/query/messages/media_group_test.go
@@ -1,0 +1,70 @@
+package messages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgmock"
+)
+
+func TestGetMediaGroup(t *testing.T) {
+	ctx := context.Background()
+
+	// Album with grouped_id 100 spans messages 5, 6, 7; message 8 belongs to a
+	// different album, message 4 is a standalone message.
+	const groupedID int64 = 100
+	peerID := &tg.PeerUser{UserID: 1}
+	album := []tg.MessageClass{
+		&tg.Message{ID: 4, PeerID: peerID},
+		&tg.Message{ID: 5, PeerID: peerID, GroupedID: groupedID},
+		&tg.Message{ID: 6, PeerID: peerID, GroupedID: groupedID},
+		&tg.Message{ID: 7, PeerID: peerID, GroupedID: groupedID},
+		&tg.Message{ID: 8, PeerID: peerID, GroupedID: 200},
+		&tg.MessageEmpty{ID: 9},
+	}
+
+	t.Run("User", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		mock.ExpectFunc(func(b bin.Encoder) {
+			_, ok := b.(*tg.MessagesGetMessagesRequest)
+			require.True(t, ok)
+		}).ThenResult(&tg.MessagesMessages{Messages: album})
+
+		group, err := NewQueryBuilder(raw).GetMediaGroup(ctx, &tg.InputPeerUser{UserID: 1}, 6)
+		require.NoError(t, err)
+		require.Len(t, group, 3)
+		require.Equal(t, 5, group[0].ID)
+		require.Equal(t, 6, group[1].ID)
+		require.Equal(t, 7, group[2].ID)
+	})
+
+	t.Run("Channel", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		mock.ExpectFunc(func(b bin.Encoder) {
+			req, ok := b.(*tg.ChannelsGetMessagesRequest)
+			require.True(t, ok)
+			require.Equal(t, &tg.InputChannel{ChannelID: 10, AccessHash: 20}, req.Channel)
+		}).ThenResult(&tg.MessagesChannelMessages{Messages: album})
+
+		group, err := NewQueryBuilder(raw).GetMediaGroup(ctx,
+			&tg.InputPeerChannel{ChannelID: 10, AccessHash: 20}, 6)
+		require.NoError(t, err)
+		require.Len(t, group, 3)
+	})
+
+	t.Run("NotInGroup", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		mock.ExpectFunc(func(b bin.Encoder) {}).
+			ThenResult(&tg.MessagesMessages{Messages: album})
+
+		_, err := NewQueryBuilder(raw).GetMediaGroup(ctx, &tg.InputPeerUser{UserID: 1}, 4)
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Summary

Adds `messages.QueryBuilder.GetMediaGroup(ctx, peer, msgID)` to fetch every message belonging to the same media group (album) as a given message — the gotd equivalent of pyrogram's `get_media_group`.

Implementation:
- Fetches a window of messages around the anchor (`msgID ± (10-1)`, the max album span), via `channels.getMessages` for channel peers and `messages.getMessages` otherwise.
- Reads the anchor's `grouped_id` and returns all fetched messages sharing it, sorted by ID.
- Returns an error if the message is not found or is not part of a media group.

Usage:

```go
group, err := query.NewQuery(api).Messages().GetMediaGroup(ctx, peer, msgID)
```

## Test

`TestGetMediaGroup` covers the user-peer path, the channel-peer path (asserting `InputChannel` construction), and the not-in-a-group error case, using `tgmock`.

Fixes #884

🤖 Generated with [Claude Code](https://claude.com/claude-code)