### PR TITLE
feat(auth): add password recovery helpers

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -14,7 +14,9 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
 ## Progress
 
 - **Done (PR):** #1474 → PR #1743 (Spoiler on media builders), #1510 → PR #1744
-  (InvertMedia + WebPage link-preview builder), #884 → PR #1745 (GetMediaGroup helper).
+  (InvertMedia + WebPage link-preview builder), #884 → PR #1745 (GetMediaGroup helper),
+  #615 → password recovery helpers (`RequestPasswordRecovery`/`CheckRecoveryPassword`/`RecoverPassword`
+  in `telegram/auth/password.go`).
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -122,7 +124,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 788 | invites: support `tg.ChatInvitePublicJoinRequests` | open |
 | 755 | auth: allow safer password passing | open |
 | 689 | Callback if user/channel state fails to load | open |
-| 615 | auth: helpers for (re)setting/updating/recovering password | open (recoverPassword left) |
+| 615 | auth: helpers for (re)setting/updating/recovering password | **done — recovery helpers added** |
 | 597 | bot: fix inspection of service messages | open (lives in `gotd/bot`) |
 | 392 | mtproto: containerize small messages | open |
 | 376 | gen: derive mappings with parameters | open |
@@ -150,7 +152,7 @@ implemented (#214, #189) and one was closed (#824); they are excluded here.
 
 | # | Title | Why easy |
 |---|---|---|
-| 615 | `auth.recoverPassword` helper | Only remaining checklist item; raw methods (`AuthRequestPasswordRecovery`, `AuthRecoverPassword`, `AuthCheckRecoveryPassword`) exist — add wrappers to `telegram/auth/password.go` like `ResetPassword`. |
+| 615 | `auth.recoverPassword` helper | **done** — `RequestPasswordRecovery`/`CheckRecoveryPassword`/`RecoverPassword` added to `telegram/auth/password.go`. |
 | 689 | updates state-load callbacks | Add `OnLoadUserStateFailed`/`OnLoadChannelStateFailed` to `updates.Config` + invoke at load sites, mirroring the existing `OnChannelTooLong`. |
 | 883 | network clock (NTP) | `clock/` already defines the `Clock` interface; NTP impl is self-contained. Friction: adds a `beevik/ntp` dependency. |
 

--- a/telegram/auth/password.go
+++ b/telegram/auth/password.go
@@ -177,3 +177,92 @@ func (c *Client) CancelPasswordReset(ctx context.Context) error {
 	}
 	return nil
 }
+
+// RequestPasswordRecovery requests a recovery code to be sent to the recovery
+// email set up for the 2FA password and returns the pattern of that email.
+//
+// The returned code is used by RecoverPassword and CheckRecoveryPassword.
+//
+// See https://core.telegram.org/method/auth.requestPasswordRecovery.
+func (c *Client) RequestPasswordRecovery(ctx context.Context) (*tg.AuthPasswordRecovery, error) {
+	r, err := c.api.AuthRequestPasswordRecovery(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "request password recovery")
+	}
+	return r, nil
+}
+
+// CheckRecoveryPassword checks whether the recovery code sent to the recovery
+// email (see RequestPasswordRecovery) is valid, without resetting the password.
+//
+// See https://core.telegram.org/method/auth.checkRecoveryPassword.
+func (c *Client) CheckRecoveryPassword(ctx context.Context, code string) (bool, error) {
+	ok, err := c.api.AuthCheckRecoveryPassword(ctx, code)
+	if err != nil {
+		return false, errors.Wrap(err, "check recovery password")
+	}
+	return ok, nil
+}
+
+// RecoverPasswordOptions is options structure for RecoverPassword.
+type RecoverPasswordOptions struct {
+	// Code is the recovery code received via the recovery email.
+	//
+	// Use RequestPasswordRecovery to send a recovery code to the email.
+	Code string
+	// NewPassword, if not empty, sets a new 2FA password after recovery.
+	//
+	// If empty, the 2FA password is removed.
+	NewPassword string
+	// Hint is the new password hint.
+	//
+	// Used only if NewPassword is not empty.
+	Hint string
+}
+
+// RecoverPassword resets the 2FA password using the recovery code sent to the
+// recovery email (see RequestPasswordRecovery) and logs in.
+//
+// If opts.NewPassword is set, it becomes the new 2FA password, otherwise the
+// password is removed.
+//
+// See https://core.telegram.org/method/auth.recoverPassword.
+func (c *Client) RecoverPassword(ctx context.Context, opts RecoverPasswordOptions) (*tg.AuthAuthorization, error) {
+	req := &tg.AuthRecoverPasswordRequest{
+		Code: opts.Code,
+	}
+
+	if opts.NewPassword != "" {
+		p, err := c.api.AccountGetPassword(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "get SRP parameters")
+		}
+
+		algo, ok := p.NewAlgo.(*tg.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow)
+		if !ok {
+			return nil, errors.Errorf("unsupported algo: %T", p.NewAlgo)
+		}
+
+		newHash, err := NewPasswordHash([]byte(opts.NewPassword), algo)
+		if err != nil {
+			return nil, errors.Wrap(err, "compute new password hash")
+		}
+
+		req.SetNewSettings(tg.AccountPasswordInputSettings{
+			NewAlgo:         algo,
+			NewPasswordHash: newHash,
+			Hint:            opts.Hint,
+		})
+	}
+
+	auth, err := c.api.AuthRecoverPassword(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "recover password")
+	}
+
+	result, err := checkResult(auth)
+	if err != nil {
+		return nil, errors.Wrap(err, "check")
+	}
+	return result, nil
+}

--- a/telegram/auth/password_example_test.go
+++ b/telegram/auth/password_example_test.go
@@ -34,6 +34,48 @@ func ExampleClient_UpdatePassword() {
 	}
 }
 
+func ExampleClient_RecoverPassword() {
+	ctx := context.Background()
+	client := telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{})
+	if err := client.Run(ctx, func(ctx context.Context) error {
+		// Request a recovery code to be sent to the recovery email.
+		recovery, err := client.Auth().RequestPasswordRecovery(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("Recovery code was sent to %s.\n", recovery.EmailPattern)
+
+		// Code received via the recovery email.
+		code := "123456"
+
+		// Optionally check the code before resetting the password.
+		ok, err := client.Auth().CheckRecoveryPassword(ctx, code)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Println("Invalid recovery code.")
+			return nil
+		}
+
+		// Reset the 2FA password using the recovery code and set a new one.
+		//
+		// Leave NewPassword empty to remove the 2FA password instead.
+		if _, err := client.Auth().RecoverPassword(ctx, auth.RecoverPasswordOptions{
+			Code:        code,
+			NewPassword: "new_password",
+			Hint:        "new password hint",
+		}); err != nil {
+			return err
+		}
+
+		fmt.Println("Password was recovered.")
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+}
+
 func ExampleClient_ResetPassword() {
 	ctx := context.Background()
 	client := telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{})

--- a/telegram/auth/password_test.go
+++ b/telegram/auth/password_test.go
@@ -167,3 +167,90 @@ func TestClient_CancelPasswordReset(t *testing.T) {
 		a.NoError(client.CancelPasswordReset(ctx))
 	})(t)
 }
+
+func TestClient_RequestPasswordRecovery(t *testing.T) {
+	ctx := context.Background()
+	mockTest(func(a *require.Assertions, mock *tgmock.Mock, client *Client) {
+		mock.ExpectCall(&tg.AuthRequestPasswordRecoveryRequest{}).ThenErr(testutil.TestError())
+		_, err := client.RequestPasswordRecovery(ctx)
+		a.Error(err)
+
+		mock.ExpectCall(&tg.AuthRequestPasswordRecoveryRequest{}).ThenResult(&tg.AuthPasswordRecovery{
+			EmailPattern: "foo@bar.com",
+		})
+		r, err := client.RequestPasswordRecovery(ctx)
+		a.NoError(err)
+		a.Equal("foo@bar.com", r.EmailPattern)
+	})(t)
+}
+
+func TestClient_CheckRecoveryPassword(t *testing.T) {
+	ctx := context.Background()
+	mockTest(func(a *require.Assertions, mock *tgmock.Mock, client *Client) {
+		mock.ExpectCall(&tg.AuthCheckRecoveryPasswordRequest{Code: "code"}).ThenErr(testutil.TestError())
+		_, err := client.CheckRecoveryPassword(ctx, "code")
+		a.Error(err)
+
+		mock.ExpectCall(&tg.AuthCheckRecoveryPasswordRequest{Code: "code"}).ThenTrue()
+		ok, err := client.CheckRecoveryPassword(ctx, "code")
+		a.NoError(err)
+		a.True(ok)
+
+		mock.ExpectCall(&tg.AuthCheckRecoveryPasswordRequest{Code: "bad"}).ThenFalse()
+		ok, err = client.CheckRecoveryPassword(ctx, "bad")
+		a.NoError(err)
+		a.False(ok)
+	})(t)
+}
+
+func TestClient_RecoverPassword(t *testing.T) {
+	ctx := context.Background()
+	auth := &tg.AuthAuthorization{User: &tg.User{ID: 10}}
+
+	t.Run("RemovePassword", mockTest(func(a *require.Assertions, mock *tgmock.Mock, client *Client) {
+		mock.ExpectCall(&tg.AuthRecoverPasswordRequest{Code: "code"}).ThenErr(testutil.TestError())
+		_, err := client.RecoverPassword(ctx, RecoverPasswordOptions{Code: "code"})
+		a.Error(err)
+
+		mock.ExpectCall(&tg.AuthRecoverPasswordRequest{Code: "code"}).ThenResult(auth)
+		r, err := client.RecoverPassword(ctx, RecoverPasswordOptions{Code: "code"})
+		a.NoError(err)
+		a.Equal(int64(10), r.User.GetID())
+	}))
+
+	t.Run("NewPassword", mockTest(func(a *require.Assertions, mock *tgmock.Mock, client *Client) {
+		p := &tg.AccountPassword{
+			NewAlgo:       testAlgo,
+			NewSecureAlgo: &tg.SecurePasswordKdfAlgoUnknown{},
+		}
+		p.SetFlags()
+
+		mock.ExpectCall(&tg.AccountGetPasswordRequest{}).ThenResult(p).
+			ExpectFunc(func(b bin.Encoder) {
+				a.IsType(&tg.AuthRecoverPasswordRequest{}, b)
+				r := b.(*tg.AuthRecoverPasswordRequest)
+				a.Equal("code", r.Code)
+				s, ok := r.GetNewSettings()
+				a.True(ok)
+				a.NotEmpty(s.NewPasswordHash)
+				a.Equal("hint", s.Hint)
+			}).ThenResult(auth)
+
+		r, err := client.RecoverPassword(ctx, RecoverPasswordOptions{
+			Code:        "code",
+			NewPassword: "password",
+			Hint:        "hint",
+		})
+		a.NoError(err)
+		a.Equal(int64(10), r.User.GetID())
+	}))
+
+	t.Run("GetPasswordError", mockTest(func(a *require.Assertions, mock *tgmock.Mock, client *Client) {
+		mock.ExpectCall(&tg.AccountGetPasswordRequest{}).ThenErr(testutil.TestError())
+		_, err := client.RecoverPassword(ctx, RecoverPasswordOptions{
+			Code:        "code",
+			NewPassword: "password",
+		})
+		a.Error(err)
+	}))
+}


### PR DESCRIPTION
## Summary

Adds 2FA password recovery helpers to `telegram/auth`, completing the only remaining checklist item of #615 (the set/reset/update pieces were done in #682).

New methods in `telegram/auth/password.go`, mirroring the existing `ResetPassword`/`UpdatePassword` style:

- `RequestPasswordRecovery(ctx)` — sends a recovery code to the account's recovery email and returns `*tg.AuthPasswordRecovery` (the email pattern).
- `CheckRecoveryPassword(ctx, code)` — validates a recovery code without resetting, returns `bool`.
- `RecoverPassword(ctx, RecoverPasswordOptions)` — resets the 2FA password with the code and logs in, returning `*tg.AuthAuthorization`. With `NewPassword` set it computes a new SRP hash (`NewPasswordHash`) and attaches `NewSettings`; otherwise the password is removed.

## Tests

- Offline `tgmock` unit tests covering all three helpers: error paths, email-pattern result, valid/invalid code, password-removal recovery, new-password recovery (asserts the request carries code + hash + hint), and the `AccountGetPassword` error path.
- Added a runnable `ExampleClient_RecoverPassword` documenting the full flow.

`go test ./telegram/auth/`, `go vet`, and `gofmt -l` all clean.

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)