### PR TITLE
feat(clock): add NTP-calibrated network clock

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -16,7 +16,8 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
 - **Done (PR):** #1474 → PR #1743 (Spoiler on media builders), #1510 → PR #1744
   (InvertMedia + WebPage link-preview builder), #884 → PR #1745 (GetMediaGroup helper),
   #615 → password recovery helpers (`RequestPasswordRecovery`/`CheckRecoveryPassword`/`RecoverPassword`
-  in `telegram/auth/password.go`).
+  in `telegram/auth/password.go`), #883 → NTP network clock (`clock/ntp`, isolated subpackage so
+  `beevik/ntp` stays out of the core dependency tree).
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -118,7 +119,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 1308 | Handling `UpdateConnectionState` | open |
 | 1267 | Channel recommendations pagination | open |
 | 884 | helper: support messages/GetMediaGroup | **done — PR #1745** |
-| 883 | clock: support network clock | open |
+| 883 | clock: support network clock | **done — `clock/ntp`** |
 | 824 | feat: errors with placeholders like `%d` | **closed — already addressed** |
 | 816 | uploader: compute part size automatically | open |
 | 788 | invites: support `tg.ChatInvitePublicJoinRequests` | open |

--- a/clock/ntp/example_test.go
+++ b/clock/ntp/example_test.go
@@ -1,0 +1,30 @@
+package ntp_test
+
+import (
+	"fmt"
+
+	"github.com/gotd/td/clock"
+	"github.com/gotd/td/clock/ntp"
+	"github.com/gotd/td/telegram"
+)
+
+func ExampleNew() {
+	// Create an NTP-calibrated clock.
+	c, err := ntp.New(ntp.Options{
+		Server: ntp.DefaultServer,
+	})
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("clock offset: %s\n", c.Offset())
+
+	// Use it as the time source for the client.
+	_ = telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{
+		Clock: c,
+	})
+
+	// Re-calibrate periodically if the process runs for a long time.
+	_ = c.Sync()
+
+	var _ clock.Clock = c
+}

--- a/clock/ntp/ntp.go
+++ b/clock/ntp/ntp.go
@@ -1,0 +1,127 @@
+// Package ntp implements a clock.Clock backed by an NTP-calibrated time source.
+//
+// It periodically (or on demand) queries an NTP server to estimate the offset
+// between the local system clock and the server's clock, and reports a
+// corrected time via Now. Timer and Ticker behave the same as clock.System.
+//
+// See https://core.telegram.org/mtproto#time-synchronization.
+package ntp
+
+import (
+	"sync"
+	"time"
+
+	"github.com/beevik/ntp"
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/clock"
+)
+
+// DefaultServer is the NTP server used when Options.Server is empty.
+const DefaultServer = "pool.ntp.org"
+
+// Options configures the network Clock.
+type Options struct {
+	// Server is the NTP server address to query.
+	//
+	// Defaults to DefaultServer.
+	Server string
+	// Now is the local time source the offset is applied to.
+	//
+	// Defaults to time.Now.
+	Now func() time.Time
+
+	// query is the NTP query function, overridable in tests.
+	query func(server string) (time.Duration, error)
+}
+
+func (o *Options) setDefaults() {
+	if o.Server == "" {
+		o.Server = DefaultServer
+	}
+	if o.Now == nil {
+		o.Now = time.Now
+	}
+	if o.query == nil {
+		o.query = queryNTP
+	}
+}
+
+// queryNTP queries the NTP server and returns the estimated clock offset.
+func queryNTP(server string) (time.Duration, error) {
+	resp, err := ntp.Query(server)
+	if err != nil {
+		return 0, errors.Wrap(err, "query")
+	}
+	if err := resp.Validate(); err != nil {
+		return 0, errors.Wrap(err, "validate")
+	}
+	return resp.ClockOffset, nil
+}
+
+// Clock is a clock.Clock that corrects the local time using an offset estimated
+// from an NTP server.
+//
+// It is safe for concurrent use.
+type Clock struct {
+	server string
+	now    func() time.Time
+	query  func(server string) (time.Duration, error)
+
+	mux    sync.RWMutex
+	offset time.Duration
+}
+
+var _ clock.Clock = (*Clock)(nil)
+
+// New creates a network Clock and performs the initial synchronization.
+func New(opts Options) (*Clock, error) {
+	opts.setDefaults()
+	c := &Clock{
+		server: opts.Server,
+		now:    opts.Now,
+		query:  opts.query,
+	}
+	if err := c.Sync(); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Sync queries the NTP server and updates the recorded clock offset.
+func (c *Clock) Sync() error {
+	offset, err := c.query(c.server)
+	if err != nil {
+		return errors.Wrap(err, "sync")
+	}
+	c.mux.Lock()
+	c.offset = offset
+	c.mux.Unlock()
+	return nil
+}
+
+// Offset returns the last recorded offset between the NTP server clock and the
+// local clock.
+func (c *Clock) Offset() time.Duration {
+	c.mux.RLock()
+	defer c.mux.RUnlock()
+	return c.offset
+}
+
+// Now returns the corrected current time.
+func (c *Clock) Now() time.Time {
+	c.mux.RLock()
+	offset := c.offset
+	c.mux.RUnlock()
+	return c.now().Add(offset)
+}
+
+// Timer returns a timer, behaving the same as clock.System.
+func (c *Clock) Timer(d time.Duration) clock.Timer {
+	return clock.System.Timer(d)
+}
+
+// Ticker returns a ticker, behaving the same as clock.System.
+func (c *Clock) Ticker(d time.Duration) clock.Ticker {
+	return clock.System.Ticker(d)
+}

--- a/clock/ntp/ntp_test.go
+++ b/clock/ntp/ntp_test.go
@@ -1,0 +1,95 @@
+package ntp
+
+import (
+	"testing"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/clock"
+)
+
+func TestNew(t *testing.T) {
+	t.Run("Defaults", func(t *testing.T) {
+		a := require.New(t)
+		c, err := New(Options{
+			query: func(server string) (time.Duration, error) {
+				a.Equal(DefaultServer, server)
+				return time.Second, nil
+			},
+		})
+		a.NoError(err)
+		a.Equal(time.Second, c.Offset())
+	})
+
+	t.Run("SyncError", func(t *testing.T) {
+		a := require.New(t)
+		_, err := New(Options{
+			query: func(string) (time.Duration, error) {
+				return 0, errors.New("boom")
+			},
+		})
+		a.Error(err)
+	})
+}
+
+func TestClock_Now(t *testing.T) {
+	a := require.New(t)
+	base := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	c, err := New(Options{
+		Server: "example.com:123",
+		Now:    func() time.Time { return base },
+		query: func(server string) (time.Duration, error) {
+			a.Equal("example.com:123", server)
+			return time.Minute, nil
+		},
+	})
+	a.NoError(err)
+
+	a.Equal(time.Minute, c.Offset())
+	a.Equal(base.Add(time.Minute), c.Now())
+}
+
+func TestClock_Sync(t *testing.T) {
+	a := require.New(t)
+	offset := time.Second
+	fail := false
+	c, err := New(Options{
+		query: func(string) (time.Duration, error) {
+			if fail {
+				return 0, errors.New("boom")
+			}
+			return offset, nil
+		},
+	})
+	a.NoError(err)
+	a.Equal(time.Second, c.Offset())
+
+	// Re-sync with a new offset.
+	offset = 2 * time.Second
+	a.NoError(c.Sync())
+	a.Equal(2*time.Second, c.Offset())
+
+	// On error the previous offset is kept.
+	fail = true
+	a.Error(c.Sync())
+	a.Equal(2*time.Second, c.Offset())
+}
+
+func TestClock_Interface(t *testing.T) {
+	a := require.New(t)
+	c, err := New(Options{
+		query: func(string) (time.Duration, error) { return 0, nil },
+	})
+	a.NoError(err)
+
+	var cl clock.Clock = c
+	timer := cl.Timer(time.Hour)
+	a.NotNil(timer)
+	clock.StopTimer(timer)
+
+	ticker := cl.Ticker(time.Hour)
+	a.NotNil(ticker)
+	ticker.Stop()
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gotd/td
 go 1.25.0
 
 require (
+	github.com/beevik/ntp v1.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coder/websocket v1.8.14
 	github.com/go-faster/errors v0.7.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
+github.com/beevik/ntp v1.5.0/go.mod h1:mJEhBrwT76w9D+IfOEGvuzyuudiW9E52U2BaTrMOYow=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=


### PR DESCRIPTION
## Summary

Implements #883: a `clock.Clock` backed by an NTP-calibrated time source.

`clock/ntp.Clock` queries an NTP server to estimate the offset between the local system clock and the server's clock, then reports a corrected time via `Now()`. `Timer`/`Ticker` delegate to `clock.System`, matching the issue's request.

API:
- `ntp.New(ntp.Options{...})` — creates the clock and performs the initial sync.
- `(*Clock).Sync()` — re-queries the server and updates the offset (call periodically for long-running processes).
- `(*Clock).Offset()` — last recorded offset.
- `(*Clock).Now()` — corrected time. Safe for concurrent use.

It plugs straight into `telegram.Options{Clock: c}`.

## Dependency isolation

The new `github.com/beevik/ntp` dependency is confined to the `clock/ntp` **subpackage**, not the core `clock` package (which is imported by `mtproto`/`rpc` across 25 files). Verified `go list -deps ./mtproto` does **not** pull in `beevik/ntp`, so existing users' dependency trees are unaffected.

## Tests

- White-box unit tests with an injected query function (no network): defaults, sync error, offset application in `Now`, re-sync, offset retention on error, and `clock.Clock` interface conformance.
- Runnable `ExampleNew` showing usage with `telegram.NewClient`.

`go test ./clock/...`, `go vet`, and `gofmt -l` all clean.

Closes #883

🤖 Generated with [Claude Code](https://claude.com/claude-code)