### PR TITLE
feat(updates): add state-load failure callbacks

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -17,7 +17,8 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
   (InvertMedia + WebPage link-preview builder), #884 → PR #1745 (GetMediaGroup helper),
   #615 → password recovery helpers (`RequestPasswordRecovery`/`CheckRecoveryPassword`/`RecoverPassword`
   in `telegram/auth/password.go`), #883 → NTP network clock (`clock/ntp`, isolated subpackage so
-  `beevik/ntp` stays out of the core dependency tree).
+  `beevik/ntp` stays out of the core dependency tree), #689 → updates state-load callbacks
+  (`OnLoadUserStateFailed`/`OnLoadChannelStateFailed` in `telegram/updates`).
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -124,7 +125,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 816 | uploader: compute part size automatically | open |
 | 788 | invites: support `tg.ChatInvitePublicJoinRequests` | open |
 | 755 | auth: allow safer password passing | open |
-| 689 | Callback if user/channel state fails to load | open |
+| 689 | Callback if user/channel state fails to load | **done — load callbacks added** |
 | 615 | auth: helpers for (re)setting/updating/recovering password | **done — recovery helpers added** |
 | 597 | bot: fix inspection of service messages | open (lives in `gotd/bot`) |
 | 392 | mtproto: containerize small messages | open |

--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -33,6 +33,20 @@ type Config struct {
 	// Callback called if manager cannot recover
 	// common state gap, i.e. on updates.differenceTooLong (optional).
 	OnTooLong func()
+	// Callback called when the manager fails to load the locally stored user
+	// state during Run with forget=false (no state found), so the state is
+	// fetched from the server and a full resynchronization is performed.
+	//
+	// Useful to detect that updates missed while offline may need to be fetched
+	// manually, e.g. via messages.getHistory (optional).
+	OnLoadUserStateFailed func()
+	// Callback called when the manager fails to load the locally stored state of
+	// a channel during Run with forget=false (its access hash is missing), so
+	// the channel is skipped.
+	//
+	// Useful to detect that the channel may need to be resynchronized manually
+	// (optional).
+	OnLoadChannelStateFailed func(channelID int64)
 	// State storage.
 	// In-mem used if not provided.
 	Storage StateStorage
@@ -81,6 +95,17 @@ func (cfg *Config) setDefaults() {
 	if cfg.OnTooLong == nil {
 		cfg.OnTooLong = func() {
 			cfg.Logger.Error("Difference too long")
+		}
+	}
+	if cfg.OnLoadUserStateFailed == nil {
+		cfg.OnLoadUserStateFailed = func() {
+			cfg.Logger.Warn("Failed to load user state, fetching from server")
+		}
+	}
+	if cfg.OnLoadChannelStateFailed == nil {
+		cfg.OnLoadChannelStateFailed = func(channelID int64) {
+			cfg.Logger.Warn("Failed to load channel state, skipping channel",
+				zap.Int64("channel_id", channelID))
 		}
 	}
 }

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -104,27 +104,9 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 		if err != nil {
 			return errors.Wrap(err, "load internalState")
 		}
-		channels := make(map[int64]struct {
-			Pts        int
-			AccessHash int64
-		})
-		if err := m.cfg.Storage.ForEachChannels(ctx, userID, func(ctx context.Context, channelID int64, pts int) error {
-			hash, found, err := m.cfg.AccessHasher.GetChannelAccessHash(ctx, userID, channelID)
-			if err != nil {
-				return errors.Wrap(err, "get channel access hash")
-			}
-
-			if !found {
-				return nil
-			}
-
-			channels[channelID] = struct {
-				Pts        int
-				AccessHash int64
-			}{Pts: pts, AccessHash: hash}
-			return nil
-		}); err != nil {
-			return errors.Wrap(err, "iterate channels")
+		channels, err := m.loadChannels(ctx, userID)
+		if err != nil {
+			return errors.Wrap(err, "load channels")
 		}
 
 		diffLim := diffLimitUser
@@ -164,6 +146,40 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 	return wg.Wait()
 }
 
+// loadChannels loads the locally stored state of the user's channels.
+//
+// Channels with a missing access hash are skipped and reported via
+// Config.OnLoadChannelStateFailed.
+func (m *Manager) loadChannels(ctx context.Context, userID int64) (map[int64]struct {
+	Pts        int
+	AccessHash int64
+}, error) {
+	channels := make(map[int64]struct {
+		Pts        int
+		AccessHash int64
+	})
+	if err := m.cfg.Storage.ForEachChannels(ctx, userID, func(ctx context.Context, channelID int64, pts int) error {
+		hash, found, err := m.cfg.AccessHasher.GetChannelAccessHash(ctx, userID, channelID)
+		if err != nil {
+			return errors.Wrap(err, "get channel access hash")
+		}
+
+		if !found {
+			m.cfg.OnLoadChannelStateFailed(channelID)
+			return nil
+		}
+
+		channels[channelID] = struct {
+			Pts        int
+			AccessHash int64
+		}{Pts: pts, AccessHash: hash}
+		return nil
+	}); err != nil {
+		return nil, errors.Wrap(err, "iterate channels")
+	}
+	return channels, nil
+}
+
 func (m *Manager) loadState(ctx context.Context, api API, userID int64, forget bool) (State, error) {
 onNotFound:
 	var state State
@@ -187,6 +203,7 @@ onNotFound:
 	}
 
 	if !found {
+		m.cfg.OnLoadUserStateFailed()
 		forget = true
 		goto onNotFound
 	}

--- a/telegram/updates/manager_test.go
+++ b/telegram/updates/manager_test.go
@@ -1,0 +1,127 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+func newTestManager(t *testing.T, cfg Config) *Manager {
+	cfg.Handler = telegram.UpdateHandlerFunc(func(context.Context, tg.UpdatesClass) error { return nil })
+	cfg.Logger = zaptest.NewLogger(t)
+	return New(cfg)
+}
+
+func TestManager_loadState(t *testing.T) {
+	ctx := context.Background()
+	const userID = 1
+
+	t.Run("Found", func(t *testing.T) {
+		a := require.New(t)
+		called := false
+		storage := newMemStorage()
+		a.NoError(storage.SetState(ctx, userID, State{Pts: 42}))
+
+		m := newTestManager(t, Config{
+			Storage:               storage,
+			OnLoadUserStateFailed: func() { called = true },
+		})
+
+		state, err := m.loadState(ctx, &diffAPI{}, userID, false)
+		a.NoError(err)
+		a.Equal(42, state.Pts)
+		a.False(called, "callback must not fire when state is found")
+	})
+
+	t.Run("NotFound", func(t *testing.T) {
+		a := require.New(t)
+		called := false
+
+		m := newTestManager(t, Config{
+			Storage:               newMemStorage(),
+			OnLoadUserStateFailed: func() { called = true },
+		})
+
+		// No stored state: falls back to remote (forget) and reports failure.
+		_, err := m.loadState(ctx, &diffAPI{}, userID, false)
+		a.NoError(err)
+		a.True(called, "callback must fire when state is not found")
+	})
+
+	t.Run("Forget", func(t *testing.T) {
+		a := require.New(t)
+		called := false
+
+		m := newTestManager(t, Config{
+			Storage:               newMemStorage(),
+			OnLoadUserStateFailed: func() { called = true },
+		})
+
+		// Explicit forget must not report a load failure.
+		_, err := m.loadState(ctx, &diffAPI{}, userID, true)
+		a.NoError(err)
+		a.False(called, "callback must not fire on explicit forget")
+	})
+}
+
+func TestManager_loadChannels(t *testing.T) {
+	ctx := context.Background()
+	const userID = 1
+
+	t.Run("MissingAccessHash", func(t *testing.T) {
+		a := require.New(t)
+		var failed []int64
+
+		storage := newMemStorage()
+		a.NoError(storage.SetState(ctx, userID, State{}))
+		a.NoError(storage.SetChannelPts(ctx, userID, 10, 1))
+		a.NoError(storage.SetChannelPts(ctx, userID, 20, 2))
+
+		hasher := newMemAccessHasher()
+		// Only channel 10 has a known access hash.
+		a.NoError(hasher.SetChannelAccessHash(ctx, userID, 10, 0xabc))
+
+		m := newTestManager(t, Config{
+			Storage:      storage,
+			AccessHasher: hasher,
+			OnLoadChannelStateFailed: func(channelID int64) {
+				failed = append(failed, channelID)
+			},
+		})
+
+		channels, err := m.loadChannels(ctx, userID)
+		a.NoError(err)
+		a.Len(channels, 1)
+		a.Contains(channels, int64(10))
+		a.Equal(int64(0xabc), channels[10].AccessHash)
+		a.Equal([]int64{20}, failed)
+	})
+
+	t.Run("AllPresent", func(t *testing.T) {
+		a := require.New(t)
+		called := false
+
+		storage := newMemStorage()
+		a.NoError(storage.SetState(ctx, userID, State{}))
+		a.NoError(storage.SetChannelPts(ctx, userID, 10, 1))
+
+		hasher := newMemAccessHasher()
+		a.NoError(hasher.SetChannelAccessHash(ctx, userID, 10, 0xabc))
+
+		m := newTestManager(t, Config{
+			Storage:                  storage,
+			AccessHasher:             hasher,
+			OnLoadChannelStateFailed: func(int64) { called = true },
+		})
+
+		channels, err := m.loadChannels(ctx, userID)
+		a.NoError(err)
+		a.Len(channels, 1)
+		a.False(called, "callback must not fire when all access hashes are present")
+	})
+}


### PR DESCRIPTION
## Summary

Implements #689: lets callers detect when the updates manager fails to restore locally stored state during `Run` (with `forget=false`), so they know a manual synchronization may be needed.

Two new optional callbacks on `updates.Config`, mirroring the existing `OnChannelTooLong`/`OnChannelInaccessible` hooks:

- **`OnLoadUserStateFailed func()`** — fires when no local user state is stored, so the manager falls back to fetching state from the server (full resync). Does **not** fire on an explicit `forget=true`.
- **`OnLoadChannelStateFailed func(channelID int64)`** — fires when a stored channel is skipped because its access hash is missing.

Both have default implementations that log a warning (so behavior is unchanged for existing users).

## Implementation notes

- The user-state hook is invoked in `loadState` on the not-found path (before the fallback to remote).
- The inline channel-loading loop in `Run` was extracted into a `loadChannels` method, which is where the channel hook fires and which makes the path unit-testable without starting the full update loop.

## Tests

New `manager_test.go` (white-box, offline) covers:
- `loadState`: found (no callback), not-found (callback fires), explicit forget (no callback).
- `loadChannels`: missing access hash (channel skipped + callback with the right ID), all present (no callback).

`go test ./telegram/updates/...`, `go vet`, and `gofmt -l` all clean.

Closes #689

🤖 Generated with [Claude Code](https://claude.com/claude-code)