### PR TITLE
fix(telegram): retry requests on new connection after connection loss

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -18,7 +18,10 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
   #615 → password recovery helpers (`RequestPasswordRecovery`/`CheckRecoveryPassword`/`RecoverPassword`
   in `telegram/auth/password.go`), #883 → NTP network clock (`clock/ntp`, isolated subpackage so
   `beevik/ntp` stays out of the core dependency tree), #689 → updates state-load callbacks
-  (`OnLoadUserStateFailed`/`OnLoadChannelStateFailed` in `telegram/updates`).
+  (`OnLoadUserStateFailed`/`OnLoadChannelStateFailed` in `telegram/updates`), #1030/#1021 →
+  connection-loss recovery: requests not processed by the server (not sent, or sent but not
+  acknowledged) are transparently retried on the new connection (`rpc` close cause,
+  `telegram.Client.invokeConn` wait-for-reconnect, `pool.DC.Invoke` re-acquire).
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -106,7 +109,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 1572 | `rpc_result`/`msg_container` decoded as gzip when not compressed | open |
 | 1382 | Update postponed and handled only with next update | open |
 | 1322 | Repeated errors in Updates Recovery for channels becoming private | open |
-| 1030 | client can't recover from connection loss (help wanted) | open |
+| 1030 | client can't recover from connection loss (help wanted) | **done — see Progress** |
 
 ### Enhancements / helpers
 

--- a/pool/pool.go
+++ b/pool/pool.go
@@ -253,6 +253,19 @@ func (c *DC) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder) 
 
 		c.log.Debug("DC Invoke")
 		err = conn.Invoke(ctx, input, output)
+		if err != nil && errRetryableOnNewConn(err) && ctx.Err() == nil {
+			// Connection died before the request was processed by the
+			// server, so it is safe to retry it on another connection.
+			//
+			// Mark connection as dead instead of releasing, so it is not
+			// re-acquired and waiters are unblocked to create a new one.
+			c.dead(conn, err)
+			c.log.Debug("DC Invoke failed on dead connection, retrying",
+				zap.Int64("conn_id", conn.id),
+				zap.Error(err),
+			)
+			continue
+		}
 		c.release(conn)
 		if err != nil {
 			c.log.Debug("DC Invoke failed", zap.Error(err))

--- a/pool/pool_conn.go
+++ b/pool/pool_conn.go
@@ -7,11 +7,20 @@ import (
 	"go.uber.org/atomic"
 
 	"github.com/gotd/td/bin"
+	"github.com/gotd/td/rpc"
 	"github.com/gotd/td/tdsync"
 )
 
 // ErrConnDead means that connection is closed and can't be used anymore.
 var ErrConnDead = errors.New("connection dead")
+
+// errRetryableOnNewConn reports whether request failed because connection
+// died before the request was processed by the server (request was not sent,
+// or sent but not acknowledged), so it is safe to retry the request on a new
+// connection.
+func errRetryableOnNewConn(err error) bool {
+	return errors.Is(err, ErrConnDead) || errors.Is(err, rpc.ErrEngineClosed)
+}
 
 // Conn represents Telegram MTProto connection.
 type Conn interface {

--- a/pool/pool_test.go
+++ b/pool/pool_test.go
@@ -45,6 +45,66 @@ func (m mockConn) Ready() <-chan struct{} {
 	return m.ready.Ready()
 }
 
+type invokeErrConn struct {
+	mockConn
+	err error
+}
+
+func (m invokeErrConn) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+	return m.err
+}
+
+func TestDC_InvokeRetryOnDeadConn(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	created := 0
+	p := NewDC(ctx, 2, func() Conn {
+		created++
+		if created == 1 {
+			// First connection dies before request is sent.
+			return invokeErrConn{
+				mockConn: newMockConn(true),
+				err:      errors.Wrap(ErrConnDead, "waitSession"),
+			}
+		}
+		return newMockConn(true)
+	}, DCOptions{
+		MaxOpenConnections: 1,
+	})
+	defer func() {
+		a.NoError(p.Close())
+	}()
+
+	// Request must be transparently retried on a new connection.
+	a.NoError(p.Invoke(ctx, nil, nil))
+	a.Equal(2, created, "Pool must create new connection to retry invoke")
+}
+
+func TestDC_InvokeNotRetryable(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	testErr := errors.New("some rpc error")
+
+	created := 0
+	p := NewDC(ctx, 2, func() Conn {
+		created++
+		return invokeErrConn{
+			mockConn: newMockConn(true),
+			err:      testErr,
+		}
+	}, DCOptions{
+		MaxOpenConnections: 1,
+	})
+	defer func() {
+		a.NoError(p.Close())
+	}()
+
+	// Non connection-related errors must be returned as-is.
+	a.ErrorIs(p.Invoke(ctx, nil, nil), testErr)
+	a.Equal(1, created, "Pool must not retry on non-retryable error")
+}
+
 func TestDC_acquire(t *testing.T) {
 	t.Run("AcquireRelease", func(t *testing.T) {
 		a := require.New(t)

--- a/rpc/engine.go
+++ b/rpc/engine.go
@@ -29,7 +29,7 @@ type Engine struct {
 
 	// Canceling pending requests in ForceClose.
 	reqCtx    context.Context
-	reqCancel context.CancelFunc
+	reqCancel context.CancelCauseFunc
 
 	wg     sync.WaitGroup
 	closed uint32
@@ -44,7 +44,7 @@ func New(send Send, cfg Options) *Engine {
 		zap.Int("max_retries", cfg.MaxRetries),
 	)
 
-	reqCtx, reqCancel := context.WithCancel(context.Background())
+	reqCtx, reqCancel := context.WithCancelCause(context.Background())
 	return &Engine{
 		rpc: map[int64]func(*bin.Buffer, error) error{},
 		ack: map[int64]chan struct{}{},
@@ -165,6 +165,16 @@ func (e *Engine) Do(ctx context.Context, req Request) error {
 		log.Debug("Request dropped")
 		return ctx.Err()
 	case <-e.reqCtx.Done():
+		select {
+		case <-done:
+			// Result arrived concurrently with close, prefer it.
+			return resultErr
+		default:
+		}
+		// Request was acknowledged by the server, but the response was not
+		// received before close: the server may have already processed it,
+		// so resending is not safe. Report plain context error, callers
+		// should not retry transparently.
 		return errors.Wrap(e.reqCtx.Err(), "engine forcibly closed")
 	case <-done:
 		return resultErr
@@ -201,7 +211,17 @@ func (e *Engine) retryUntilAck(ctx context.Context, req Request) (sent bool, err
 			case <-ctx.Done():
 				return ctx.Err()
 			case <-e.reqCtx.Done():
-				return errors.Wrap(e.reqCtx.Err(), "engine forcibly closed")
+				select {
+				case <-ackChan:
+					// Acknowledge arrived concurrently with close, prefer it.
+					log.Debug("Acknowledged")
+					return nil
+				default:
+				}
+				// Request was sent, but not yet acknowledged: per MTProto it is
+				// safe to resend it on a new connection, so report ErrEngineClosed
+				// (the cancellation cause) to let callers retry.
+				return errors.Wrap(context.Cause(e.reqCtx), "engine forcibly closed")
 			case <-ackChan:
 				log.Debug("Acknowledged")
 				return nil
@@ -276,6 +296,6 @@ func (e *Engine) Close() {
 // All pending requests will be canceled.
 // All Do method calls of closed engine will return ErrEngineClosed error.
 func (e *Engine) ForceClose() {
-	e.reqCancel()
+	e.reqCancel(ErrEngineClosed)
 	e.Close()
 }

--- a/rpc/engine_test.go
+++ b/rpc/engine_test.go
@@ -420,6 +420,85 @@ func TestDropRPC(t *testing.T) {
 	}, server, client)
 }
 
+func TestEngineForceCloseNotAcked(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	gotRequest := make(chan struct{})
+	result := make(chan error, 1)
+
+	server := func(t *testing.T, e *Engine, incoming <-chan request) error {
+		// Server receives the request, but never acknowledges it.
+		<-incoming
+		close(gotRequest)
+		return nil
+	}
+
+	client := func(t *testing.T, e *Engine) error {
+		go func() {
+			result <- e.Do(context.TODO(), Request{
+				MsgID:  msgID,
+				SeqNo:  seqNo,
+				Input:  &mt.PingRequest{PingID: pingID},
+				Output: &mt.Pong{},
+			})
+		}()
+		<-gotRequest
+		e.ForceClose()
+
+		// Sent but not acknowledged request is safe to resend, so the error
+		// must be retryable (ErrEngineClosed) and not a plain cancellation.
+		err := <-result
+		require.ErrorIs(t, err, ErrEngineClosed)
+		require.NotErrorIs(t, err, context.Canceled)
+		return nil
+	}
+
+	runTest(t, Options{
+		RetryInterval: time.Minute,
+		MaxRetries:    2,
+		Logger:        log.Named("rpc"),
+	}, server, client)
+}
+
+func TestEngineForceCloseAcked(t *testing.T) {
+	log := zaptest.NewLogger(t)
+	acked := make(chan struct{})
+	result := make(chan error, 1)
+
+	server := func(t *testing.T, e *Engine, incoming <-chan request) error {
+		// Server acknowledges the request, but never responds.
+		req := <-incoming
+		e.NotifyAcks([]int64{req.MsgID})
+		close(acked)
+		return nil
+	}
+
+	client := func(t *testing.T, e *Engine) error {
+		go func() {
+			result <- e.Do(context.TODO(), Request{
+				MsgID:  msgID,
+				SeqNo:  seqNo,
+				Input:  &mt.PingRequest{PingID: pingID},
+				Output: &mt.Pong{},
+			})
+		}()
+		<-acked
+		e.ForceClose()
+
+		// Acknowledged request may be already processed by server, so
+		// transparent resend is not safe: plain cancellation is expected.
+		err := <-result
+		require.ErrorIs(t, err, context.Canceled)
+		require.NotErrorIs(t, err, ErrEngineClosed)
+		return nil
+	}
+
+	runTest(t, Options{
+		RetryInterval: time.Minute,
+		MaxRetries:    2,
+		Logger:        log.Named("rpc"),
+	}, server, client)
+}
+
 func runTest(
 	t *testing.T,
 	cfg Options,

--- a/telegram/client.go
+++ b/telegram/client.go
@@ -91,9 +91,12 @@ type Client struct {
 	testDC bool // immutable
 
 	// Connection state. Guarded by connMux.
-	session     *pool.SyncSession
-	cfg         *manager.AtomicConfig
-	conn        clientConn
+	session *pool.SyncSession
+	cfg     *manager.AtomicConfig
+	conn    clientConn
+	// connChanged is closed and re-created on every primary connection
+	// replacement, letting invokeConn wait for reconnect and retry.
+	connChanged chan struct{}
 	connBackoff atomic.Pointer[backoff.BackOff]
 	connMux     sync.Mutex
 
@@ -238,6 +241,16 @@ func NewClient(appID int, appHash string, opt Options) *Client {
 	return client
 }
 
+// replaceConn replaces primary connection and notifies invokers waiting for
+// reconnection (see invokeConn).
+//
+// Caller must hold connMux.
+func (c *Client) replaceConn(conn clientConn) {
+	c.conn = conn
+	close(c.connChanged)
+	c.connChanged = make(chan struct{})
+}
+
 // init sets fields which needs explicit initialization, like maps or channels.
 func (c *Client) init() {
 	if c.domains == nil {
@@ -247,6 +260,7 @@ func (c *Client) init() {
 		c.cfg = manager.NewAtomicConfig(tg.Config{})
 	}
 	c.ready = tdsync.NewResetReady()
+	c.connChanged = make(chan struct{})
 	c.restart = make(chan struct{})
 	c.migration = make(chan struct{}, 1)
 	c.sessions = map[int]*pool.SyncSession{}

--- a/telegram/client_e2e_test.go
+++ b/telegram/client_e2e_test.go
@@ -3,6 +3,7 @@ package telegram_test
 import (
 	"bytes"
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -227,6 +228,54 @@ func testMigrate(p dcs.Protocol) func(t *testing.T) {
 
 func TestMigrate(t *testing.T) {
 	t.Run("Intermediate", testMigrate(transport.Intermediate))
+}
+
+func testConnectionRecovery(p dcs.Protocol) func(t *testing.T) {
+	return testCluster(p, false, func(s clusterSetup) {
+		c := s.Cluster
+		c.Common().Vector(tg.UsersGetUsersRequestTypeID, user)
+
+		var once sync.Once
+		c.Dispatch(2, "server").HandleFunc(tg.MessagesSendMessageRequestTypeID,
+			func(server *tgtest.Server, req *tgtest.Request) error {
+				m := &tg.MessagesSendMessageRequest{}
+				if err := m.Decode(req.Buf); err != nil {
+					return err
+				}
+
+				first := false
+				once.Do(func() {
+					first = true
+				})
+				if first {
+					// Simulate sudden connection loss before the request is
+					// acknowledged, see https://github.com/gotd/td/issues/1030.
+					server.ForceDisconnect(req.Session)
+					return nil
+				}
+				return server.SendGZIP(req, &tg.Updates{})
+			},
+		)
+	}, func(ctx context.Context, c clientSetup) error {
+		client := telegram.NewClient(1, "hash", c.Options)
+		return client.Run(ctx, func(ctx context.Context) error {
+			// Request observes connection loss, but must be transparently
+			// retried on the new connection after reconnect.
+			if err := client.SendMessage(ctx, &tg.MessagesSendMessageRequest{
+				Peer:    &tg.InputPeerUser{},
+				Message: "abc",
+			}); err != nil {
+				return errors.Wrap(err, "send")
+			}
+
+			c.Complete()
+			return nil
+		})
+	})
+}
+
+func TestConnectionRecovery(t *testing.T) {
+	t.Run("Intermediate", testConnectionRecovery(transport.Intermediate))
 }
 
 func testFiles(p dcs.Protocol) func(t *testing.T) {

--- a/telegram/connect.go
+++ b/telegram/connect.go
@@ -99,7 +99,7 @@ func (c *Client) reconnectUntilClosed(ctx context.Context) error {
 		c.connMux.Lock()
 		// Some PFS errors require dropping persisted keys before recreating conn.
 		c.handlePrimaryConnDead(err)
-		c.conn = c.createPrimaryConn(nil)
+		c.replaceConn(c.createPrimaryConn(nil))
 		c.connMux.Unlock()
 	})
 }

--- a/telegram/invoke.go
+++ b/telegram/invoke.go
@@ -109,10 +109,10 @@ func (c *Client) invokeConn(ctx context.Context, input bin.Encoder, output bin.D
 		)
 		select {
 		case <-ctx.Done():
-			return err
+			return errors.Wrap(ctx.Err(), "wait for reconnect")
 		case <-clientDone:
 			// Client is closed, no reconnection will happen.
-			return err
+			return errors.Wrap(c.ctx.Err(), "client closed")
 		case <-connChanged:
 		}
 	}

--- a/telegram/invoke.go
+++ b/telegram/invoke.go
@@ -5,11 +5,14 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/go-faster/errors"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 
 	"github.com/gotd/td/bin"
+	"github.com/gotd/td/pool"
+	"github.com/gotd/td/rpc"
 	"github.com/gotd/td/tg"
 	"github.com/gotd/td/tgerr"
 )
@@ -81,10 +84,44 @@ func (c *Client) invokeDirect(ctx context.Context, input bin.Encoder, output bin
 
 // invokeConn directly invokes RPC call on primary connection without any
 // additional handling.
+//
+// If the connection dies before the request is processed by the server,
+// invokeConn waits until the reconnection loop replaces the connection and
+// retries the request on it, see https://github.com/gotd/td/issues/1030.
 func (c *Client) invokeConn(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
-	c.connMux.Lock()
-	conn := c.conn
-	c.connMux.Unlock()
+	for {
+		c.connMux.Lock()
+		conn := c.conn
+		connChanged := c.connChanged
+		c.connMux.Unlock()
 
-	return conn.Invoke(ctx, input, output)
+		err := conn.Invoke(ctx, input, output)
+		if err == nil || !errRetryableOnNewConn(err) {
+			return err
+		}
+
+		var clientDone <-chan struct{}
+		if c.ctx != nil {
+			clientDone = c.ctx.Done()
+		}
+		c.log.Debug("Primary connection is dead, waiting for new connection to retry",
+			zap.Error(err),
+		)
+		select {
+		case <-ctx.Done():
+			return err
+		case <-clientDone:
+			// Client is closed, no reconnection will happen.
+			return err
+		case <-connChanged:
+		}
+	}
+}
+
+// errRetryableOnNewConn reports whether request failed because connection
+// died before the request was processed by the server (request was not sent,
+// or sent but not acknowledged), so it is safe to retry the request on a new
+// connection.
+func errRetryableOnNewConn(err error) bool {
+	return errors.Is(err, pool.ErrConnDead) || errors.Is(err, rpc.ErrEngineClosed)
 }

--- a/telegram/invoke_test.go
+++ b/telegram/invoke_test.go
@@ -1,0 +1,120 @@
+package telegram
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/pool"
+	"github.com/gotd/td/rpc"
+)
+
+// notifyInvokeConn is a fake connection which always fails Invoke with given
+// error, signaling about every Invoke call via channel.
+type notifyInvokeConn struct {
+	err     error
+	once    sync.Once
+	invoked chan struct{}
+}
+
+func newNotifyInvokeConn(err error) *notifyInvokeConn {
+	return &notifyInvokeConn{
+		err:     err,
+		invoked: make(chan struct{}),
+	}
+}
+
+func (c *notifyInvokeConn) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (c *notifyInvokeConn) Invoke(context.Context, bin.Encoder, bin.Decoder) error {
+	c.once.Do(func() { close(c.invoked) })
+	return c.err
+}
+
+func (c *notifyInvokeConn) Ping(context.Context) error { return nil }
+
+type okInvokeConn struct{}
+
+func (okInvokeConn) Run(ctx context.Context) error {
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func (okInvokeConn) Invoke(context.Context, bin.Encoder, bin.Decoder) error { return nil }
+
+func (okInvokeConn) Ping(context.Context) error { return nil }
+
+func TestClient_invokeConnRetriesOnNewConn(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		err  error
+	}{
+		{"ConnDead", errors.Wrap(pool.ErrConnDead, "waitSession")},
+		{"EngineClosed", errors.Wrap(rpc.ErrEngineClosed, "engine forcibly closed")},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			client := Client{log: zap.NewNop()}
+			client.init()
+
+			dead := newNotifyInvokeConn(tt.err)
+			client.conn = dead
+
+			// Replace dead connection like reconnection loop does, but only
+			// after invokeConn observed the dead connection.
+			go func() {
+				<-dead.invoked
+				client.connMux.Lock()
+				client.replaceConn(okInvokeConn{})
+				client.connMux.Unlock()
+			}()
+
+			// Request must be transparently retried on the new connection.
+			require.NoError(t, client.invokeConn(context.Background(), nil, nil))
+		})
+	}
+}
+
+func TestClient_invokeConnContextCancel(t *testing.T) {
+	client := Client{log: zap.NewNop()}
+	client.init()
+	client.conn = newNotifyInvokeConn(pool.ErrConnDead)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	// No reconnection happens, so canceled context must stop waiting,
+	// reporting original invoke error.
+	require.ErrorIs(t, client.invokeConn(ctx, nil, nil), pool.ErrConnDead)
+}
+
+func TestClient_invokeConnClientClose(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	client := Client{log: zap.NewNop(), ctx: ctx}
+	client.init()
+	client.conn = newNotifyInvokeConn(pool.ErrConnDead)
+
+	// Closed client never reconnects, so waiting must stop immediately.
+	require.ErrorIs(t, client.invokeConn(context.Background(), nil, nil), pool.ErrConnDead)
+}
+
+func TestClient_invokeConnNotRetryable(t *testing.T) {
+	testErr := errors.New("some rpc error")
+
+	client := Client{log: zap.NewNop()}
+	client.init()
+	client.conn = newNotifyInvokeConn(testErr)
+
+	// Non connection-related errors must be returned as-is without waiting
+	// for reconnect.
+	require.ErrorIs(t, client.invokeConn(context.Background(), nil, nil), testErr)
+}

--- a/telegram/invoke_test.go
+++ b/telegram/invoke_test.go
@@ -91,8 +91,10 @@ func TestClient_invokeConnContextCancel(t *testing.T) {
 	cancel()
 
 	// No reconnection happens, so canceled context must stop waiting,
-	// reporting original invoke error.
-	require.ErrorIs(t, client.invokeConn(ctx, nil, nil), pool.ErrConnDead)
+	// reporting context error to keep standard context semantics.
+	err := client.invokeConn(ctx, nil, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, pool.ErrConnDead)
 }
 
 func TestClient_invokeConnClientClose(t *testing.T) {
@@ -103,8 +105,11 @@ func TestClient_invokeConnClientClose(t *testing.T) {
 	client.init()
 	client.conn = newNotifyInvokeConn(pool.ErrConnDead)
 
-	// Closed client never reconnects, so waiting must stop immediately.
-	require.ErrorIs(t, client.invokeConn(context.Background(), nil, nil), pool.ErrConnDead)
+	// Closed client never reconnects, so waiting must stop immediately,
+	// reporting client context error.
+	err := client.invokeConn(context.Background(), nil, nil)
+	require.ErrorIs(t, err, context.Canceled)
+	require.NotErrorIs(t, err, pool.ErrConnDead)
 }
 
 func TestClient_invokeConnNotRetryable(t *testing.T) {

--- a/telegram/session.go
+++ b/telegram/session.go
@@ -54,7 +54,7 @@ func (c *Client) restoreConnection(ctx context.Context) error {
 		AuthKey: key,
 		Salt:    data.Salt,
 	})
-	c.conn = c.createPrimaryConn(nil)
+	c.replaceConn(c.createPrimaryConn(nil))
 	c.connMux.Unlock()
 
 	return nil


### PR DESCRIPTION
## Problem

Analysis of the debug logs from #1030 (and #1021) shows three failure modes when a connection dies:

1. **In-flight requests** are killed with `engine forcibly closed: context canceled` — indistinguishable from user cancellation, so nothing can retry them (#1021's upload part failures).
2. **Requests issued during the reconnect window** fail instantly with `waitSession: connection dead` instead of waiting for the replacement connection — the error storm in the #1030 reproducer. This is also why the updates (gaps) engine "can't recover": its internal `getDifference` calls share the same invoke path, fail with the same error, and shut down its errgroup.
3. **`pool.DC.Invoke`** handles `ErrConnDead` only at acquire time; a connection dying between acquire and invoke leaks the error to the caller instead of retrying on another connection.

## Fix

Requests that were **not processed by the server** are now transparently retried on the new connection:

- **rpc**: `ForceClose` cancels pending requests with `ErrEngineClosed` as cancellation cause. A request that was *sent but not acknowledged* now reports a retryable error (per MTProto it is safe to resend such a message). A request that was *acknowledged* still reports plain cancellation — the server may have already processed it, so transparent resend is not safe. Close paths prefer a concurrently arrived ack/result over the close error, making classification deterministic.
- **telegram**: `Client.invokeConn` waits for the reconnection loop to replace the dead connection (via a `connChanged` notification guarded by `connMux`) and retries the request on it, bounded by the request context and client lifetime.
- **pool**: `DC.Invoke` marks the dead connection (unblocking capacity and waiters) and retries the request on another connection.

## Tests

- `rpc`: force-close of a sent-but-unacked request yields `ErrEngineClosed` (retryable); force-close after ack yields `context.Canceled` (not retryable).
- `telegram`: `invokeConn` retries on connection replacement for both `pool.ErrConnDead` and `rpc.ErrEngineClosed`; stops waiting on request cancel / client close; passes other errors through.
- `pool`: `DC.Invoke` retries on a fresh connection when the acquired one is dead; non-retryable errors are returned as-is.
- **e2e** (`TestConnectionRecovery`, tgtest cluster): server force-disconnects the client on the first `messages.sendMessage` without replying; the call must transparently succeed after reconnect — the exact #1030 scenario.

Closes #1030
Closes #1021

🤖 Generated with [Claude Code](https://claude.com/claude-code)