### PR TITLE
feat(query): add GetMessages by-id helper

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -23,7 +23,9 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
   acknowledged) are transparently retried on the new connection (`rpc` close cause,
   `telegram.Client.invokeConn` wait-for-reconnect, `pool.DC.Invoke` re-acquire), #1308 →
   primary connection state hook (`Options.OnConnectionState` with
-  connecting/ready/disconnected `ConnectionState`).
+  connecting/ready/disconnected `ConnectionState`), #217 → get-messages-by-ID helper
+  (`messages.QueryBuilder.GetMessages`, channel-aware; users/channels already covered by
+  `telegram/peers`).
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -137,7 +139,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 376 | gen: derive mappings with parameters | open |
 | 283 | query: generate resolve helpers when query needs peer parameter | open |
 | 263 | client: improve FLOOD_WAIT handling | open |
-| 217 | client: get-by-id helpers | open |
+| 217 | client: get-by-id helpers | **done — see Progress** |
 | 214 | message: Markdown styling for text messages | **already implemented** (`telegram/message/markdown`) |
 | 189 | message: sticker helpers | **already implemented** (`telegram/query/cached`) |
 | 188 | client: admin helpers | open |
@@ -167,7 +169,7 @@ implemented (#214, #189) and one was closed (#824); they are excluded here.
 
 | # | Title | Note |
 |---|---|---|
-| 217 | get-by-id helpers | Needs ETag-style hashing + batching; new query helpers. |
+| 217 | get-by-id helpers | **done** — `messages.QueryBuilder.GetMessages` (by-ID, channel-aware). Optional hash-based caching left out as a "nice to have". |
 | 788 | `ChatInvitePublicJoinRequests` | Requires loosening the `InviteLink` type, currently hardwired to `ChatInviteExported`. |
 | 1308 | connection-state updates | `OnSession` exists; add a connect/disconnect hook (no TDLib-style state machine). |
 | 755 | safer password passing | Callback-based password hashing in `telegram/auth`. |

--- a/telegram/query/messages/get_messages.go
+++ b/telegram/query/messages/get_messages.go
@@ -1,0 +1,42 @@
+package messages
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// GetMessages fetches messages by their IDs in the given peer.
+//
+// It automatically uses channels.getMessages for channel peers and
+// messages.getMessages otherwise, so the caller does not need to special-case
+// channels (passing channel message IDs to messages.getMessages returns
+// unrelated messages).
+//
+// The returned slice preserves the contents of the server response, which may
+// include tg.MessageEmpty for IDs that do not exist or are inaccessible.
+//
+// See https://core.telegram.org/method/messages.getMessages
+// and https://core.telegram.org/method/channels.getMessages.
+func (q *QueryBuilder) GetMessages(
+	ctx context.Context,
+	peer tg.InputPeerClass,
+	ids ...int,
+) ([]tg.MessageClass, error) {
+	if len(ids) == 0 {
+		return nil, errors.New("no message ids given")
+	}
+
+	input := make([]tg.InputMessageClass, 0, len(ids))
+	for _, id := range ids {
+		input = append(input, &tg.InputMessageID{ID: id})
+	}
+
+	raw, err := q.getMessages(ctx, peer, input)
+	if err != nil {
+		return nil, errors.Wrap(err, "get messages")
+	}
+	return raw, nil
+}

--- a/telegram/query/messages/get_messages_test.go
+++ b/telegram/query/messages/get_messages_test.go
@@ -1,0 +1,67 @@
+package messages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgmock"
+)
+
+func TestGetMessages(t *testing.T) {
+	ctx := context.Background()
+
+	peerID := &tg.PeerUser{UserID: 1}
+	result := []tg.MessageClass{
+		&tg.Message{ID: 10, PeerID: peerID},
+		&tg.MessageEmpty{ID: 11},
+		&tg.Message{ID: 12, PeerID: peerID},
+	}
+
+	t.Run("User", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		mock.ExpectFunc(func(b bin.Encoder) {
+			req, ok := b.(*tg.MessagesGetMessagesRequest)
+			require.True(t, ok)
+			require.Equal(t, []tg.InputMessageClass{
+				&tg.InputMessageID{ID: 10},
+				&tg.InputMessageID{ID: 11},
+				&tg.InputMessageID{ID: 12},
+			}, req.ID)
+		}).ThenResult(&tg.MessagesMessages{Messages: result})
+
+		msgs, err := NewQueryBuilder(raw).GetMessages(ctx, &tg.InputPeerUser{UserID: 1}, 10, 11, 12)
+		require.NoError(t, err)
+		require.Equal(t, result, msgs)
+	})
+
+	t.Run("Channel", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		mock.ExpectFunc(func(b bin.Encoder) {
+			req, ok := b.(*tg.ChannelsGetMessagesRequest)
+			require.True(t, ok)
+			require.Equal(t, &tg.InputChannel{ChannelID: 10, AccessHash: 20}, req.Channel)
+			require.Equal(t, []tg.InputMessageClass{&tg.InputMessageID{ID: 42}}, req.ID)
+		}).ThenResult(&tg.MessagesChannelMessages{Messages: []tg.MessageClass{
+			&tg.Message{ID: 42, PeerID: &tg.PeerChannel{ChannelID: 10}},
+		}})
+
+		msgs, err := NewQueryBuilder(raw).GetMessages(ctx,
+			&tg.InputPeerChannel{ChannelID: 10, AccessHash: 20}, 42)
+		require.NoError(t, err)
+		require.Len(t, msgs, 1)
+		require.Equal(t, 42, msgs[0].(*tg.Message).ID)
+	})
+
+	t.Run("NoIDs", func(t *testing.T) {
+		mock := tgmock.NewRequire(t)
+		raw := tg.NewClient(mock)
+		_, err := NewQueryBuilder(raw).GetMessages(ctx, &tg.InputPeerUser{UserID: 1})
+		require.Error(t, err)
+	})
+}


### PR DESCRIPTION
## What

Adds `messages.QueryBuilder.GetMessages(ctx, peer, ids...)` — a helper to fetch messages by their IDs, addressing the get-by-id helpers request in #217.

```go
msgs, err := messages.NewQueryBuilder(raw).GetMessages(ctx, peer, 10, 11, 12)
```

It automatically routes to `channels.getMessages` for channel peers and `messages.getMessages` otherwise. This spares callers a well-known footgun: passing channel message IDs to `messages.getMessages` silently returns unrelated messages instead of the requested ones. The returned `[]tg.MessageClass` preserves the raw server response, including `tg.MessageEmpty` for IDs that don't exist or are inaccessible.

The helper reuses the existing channel-aware private `getMessages` (added alongside `GetMediaGroup`), so routing logic stays in one place.

## Scope

#217 also mentions optional ETag/hash-based caching as a "nice to have" — that is intentionally left out here, and user/channel get-by-id is already served by `telegram/peers`. This PR fills the missing messages-by-id helper.

## Tests

`TestGetMessages` (tgmock): user path asserts `messages.getMessages` with the expected `InputMessageID` list; channel path asserts `channels.getMessages` with the resolved `InputChannel` access hash; empty-ids returns an error.

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)