### PR TITLE
feat(auth): safer 2FA password handling via protected memory (memguard)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -136,7 +136,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 824 | feat: errors with placeholders like `%d` | **closed — already addressed** |
 | 816 | uploader: compute part size automatically | **done — see Progress** |
 | 788 | invites: support `tg.ChatInvitePublicJoinRequests` | open |
-| 755 | auth: allow safer password passing | open |
+| 755 | auth: allow safer password passing | **done — `PasswordWith` + `telegram/auth/srpguard` (memguard)** |
 | 689 | Callback if user/channel state fails to load | **done — load callbacks added** |
 | 615 | auth: helpers for (re)setting/updating/recovering password | **done — recovery helpers added** |
 | 597 | bot: fix inspection of service messages | open (lives in `gotd/bot`) |

--- a/examples/go.mod
+++ b/examples/go.mod
@@ -3,6 +3,7 @@ module github.com/gotd/td/examples
 go 1.25.0
 
 require (
+	github.com/awnumar/memguard v0.23.0
 	github.com/cockroachdb/pebble v1.1.2
 	github.com/go-faster/errors v0.7.1
 	github.com/gotd/contrib v0.21.0
@@ -21,6 +22,7 @@ require (
 
 require (
 	github.com/DataDog/zstd v1.4.5 // indirect
+	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
@@ -80,7 +82,7 @@ require (
 	golang.org/x/crypto v0.53.0 // indirect
 	golang.org/x/exp v0.0.0-20230725093048-515e97ebf090 // indirect
 	golang.org/x/mod v0.36.0 // indirect
-	golang.org/x/net v0.55.0 // indirect
+	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect
 	golang.org/x/tools v0.45.0 // indirect

--- a/examples/go.sum
+++ b/examples/go.sum
@@ -1,5 +1,9 @@
 github.com/DataDog/zstd v1.4.5 h1:EndNeuB0l9syBZhut0wns3gV1hL8zX8LIu6ZiVHWLIQ=
 github.com/DataDog/zstd v1.4.5/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
+github.com/awnumar/memcall v0.4.0 h1:B7hgZYdfH6Ot1Goaz8jGne/7i8xD4taZie/PNSFZ29g=
+github.com/awnumar/memcall v0.4.0/go.mod h1:8xOx1YbfyuCg3Fy6TO8DK0kZUua3V42/goA5Ru47E8w=
+github.com/awnumar/memguard v0.23.0 h1:sJ3a1/SWlcuKIQ7MV+R9p0Pvo9CWsMbGZvcZQtmc68A=
+github.com/awnumar/memguard v0.23.0/go.mod h1:olVofBrsPdITtJ2HgxQKrEYEMyIBAIciVG4wNnZhW9M=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
@@ -179,8 +183,8 @@ golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200226121028-0de0cce0169b/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20201021035429-f5854403a974/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
-golang.org/x/net v0.55.0 h1:bcvxaJn3e1U6InsFWt1JUq1aSjnRxLzT2rtD2KfkDF8=
-golang.org/x/net v0.55.0/go.mod h1:L5U2KuzuOe1lY7Z+aWVIKK6qEeJXnXV9yzGA+WCHJww=
+golang.org/x/net v0.56.0 h1:Rw8j/hFzGvJUZwNBXnAtf5sVDVt+65SK2C7IxCxZt5o=
+golang.org/x/net v0.56.0/go.mod h1:D3Ku6r+V6JROoZK144D2XfMHFcMq/0zSfLelVTCFKec=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=

--- a/examples/secure-password/main.go
+++ b/examples/secure-password/main.go
@@ -1,0 +1,84 @@
+// Binary secure-password logs in with phone + code and supplies the 2FA
+// password from protected memory (memguard) instead of a Go string, so the
+// plaintext is locked, never swapped to disk, and wiped after the SRP answer is
+// computed (gotd/td#755).
+//
+// Usage:
+//
+//	APP_ID=... APP_HASH=... PHONE=+1234567890 SESSION_FILE=session.json \
+//	    go run ./examples/secure-password
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/awnumar/memguard"
+	"go.uber.org/zap"
+	"golang.org/x/term"
+
+	"github.com/gotd/td/examples"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/telegram/auth"
+	"github.com/gotd/td/telegram/auth/srpguard"
+	"github.com/gotd/td/tg"
+)
+
+func main() {
+	// Wipe all protected memory if the process is interrupted.
+	memguard.CatchInterrupt()
+	defer memguard.Purge()
+
+	examples.Run(func(ctx context.Context, log *zap.Logger) error {
+		// Read the 2FA password into protected memory once, up front.
+		// NewEnclave copies the input into an encrypted enclave and wipes it.
+		fmt.Fprint(os.Stderr, "Enter 2FA password: ")
+		secret, err := term.ReadPassword(int(syscall.Stdin))
+		if err != nil {
+			return err
+		}
+		fmt.Fprintln(os.Stderr)
+		enclave := memguard.NewEnclave(secret)
+
+		client, err := telegram.ClientFromEnvironment(telegram.Options{Logger: log})
+		if err != nil {
+			return err
+		}
+
+		flow := auth.NewFlow(
+			securePassword{
+				UserAuthenticator: examples.Terminal{PhoneNumber: os.Getenv("PHONE")},
+				enclave:           enclave,
+			},
+			auth.SendCodeOptions{},
+		)
+
+		return client.Run(ctx, func(ctx context.Context) error {
+			if err := client.Auth().IfNecessary(ctx, flow); err != nil {
+				return err
+			}
+			self, err := client.Self(ctx)
+			if err != nil {
+				return err
+			}
+			log.Info("Logged in with secure 2FA password",
+				zap.String("user", self.FirstName), zap.Int64("id", self.ID))
+			return nil
+		})
+	})
+}
+
+// securePassword extends the terminal authenticator to supply the 2FA password
+// from a memguard enclave instead of a string. Because it implements
+// auth.PasswordHashProvider, auth.Flow uses PasswordHash and never calls the
+// string-based Password fallback.
+type securePassword struct {
+	auth.UserAuthenticator
+	enclave *memguard.Enclave
+}
+
+func (s securePassword) PasswordHash(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error) {
+	return srpguard.Enclave(s.enclave)(ctx, p)
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/gotd/td
 go 1.25.0
 
 require (
+	github.com/awnumar/memguard v0.23.0
 	github.com/beevik/ntp v1.5.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/coder/websocket v1.8.14
@@ -46,6 +47,7 @@ require (
 require (
 	github.com/PuerkitoBio/goquery v1.11.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
+	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/benbjohnson/clock v1.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,10 @@ github.com/PuerkitoBio/goquery v1.11.0 h1:jZ7pwMQXIITcUXNH83LLk+txlaEy6NVOfTuP43
 github.com/PuerkitoBio/goquery v1.11.0/go.mod h1:wQHgxUOU3JGuj3oD/QFfxUdlzW6xPHfqyHre6VMY4DQ=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
+github.com/awnumar/memcall v0.4.0 h1:B7hgZYdfH6Ot1Goaz8jGne/7i8xD4taZie/PNSFZ29g=
+github.com/awnumar/memcall v0.4.0/go.mod h1:8xOx1YbfyuCg3Fy6TO8DK0kZUua3V42/goA5Ru47E8w=
+github.com/awnumar/memguard v0.23.0 h1:sJ3a1/SWlcuKIQ7MV+R9p0Pvo9CWsMbGZvcZQtmc68A=
+github.com/awnumar/memguard v0.23.0/go.mod h1:olVofBrsPdITtJ2HgxQKrEYEMyIBAIciVG4wNnZhW9M=
 github.com/beevik/ntp v1.5.0 h1:y+uj/JjNwlY2JahivxYvtmv4ehfi3h74fAuABB9ZSM4=
 github.com/beevik/ntp v1.5.0/go.mod h1:mJEhBrwT76w9D+IfOEGvuzyuudiW9E52U2BaTrMOYow=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=

--- a/telegram/auth/flow.go
+++ b/telegram/auth/flow.go
@@ -72,14 +72,7 @@ func (f Flow) Run(ctx context.Context, client FlowClient) error {
 
 		_, signInErr := client.SignIn(ctx, phone, code, hash)
 		if errors.Is(signInErr, ErrPasswordAuthNeeded) {
-			password, err := f.Auth.Password(ctx)
-			if err != nil {
-				return errors.Wrap(err, "get password")
-			}
-			if _, err := client.Password(ctx, password); err != nil {
-				return errors.Wrap(err, "sign in with password")
-			}
-			return nil
+			return f.password(ctx, client)
 		}
 		var signUpRequired *SignUpRequired
 		if errors.As(signInErr, &signUpRequired) {
@@ -118,6 +111,38 @@ type FlowClient interface {
 	SendCode(ctx context.Context, phone string, options SendCodeOptions) (tg.AuthSentCodeClass, error)
 	Password(ctx context.Context, password string) (*tg.AuthAuthorization, error)
 	SignUp(ctx context.Context, s SignUp) (*tg.AuthAuthorization, error)
+}
+
+// PasswordHashProvider is an optional UserAuthenticator extension. When an
+// authenticator implements it, Flow obtains the 2FA SRP answer via PasswordHash
+// instead of Password, so the plaintext password can stay in protected memory
+// (see #755 and the telegram/auth/srpguard subpackage).
+type PasswordHashProvider interface {
+	PasswordHash(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error)
+}
+
+// password supplies the 2FA password to the client, preferring a
+// PasswordHashProvider (protected memory) over the plaintext Password callback.
+func (f Flow) password(ctx context.Context, client FlowClient) error {
+	if hp, ok := f.Auth.(PasswordHashProvider); ok {
+		if ph, ok := client.(interface {
+			PasswordWith(ctx context.Context, hash PasswordHashFunc) (*tg.AuthAuthorization, error)
+		}); ok {
+			if _, err := ph.PasswordWith(ctx, hp.PasswordHash); err != nil {
+				return errors.Wrap(err, "sign in with password hash")
+			}
+			return nil
+		}
+	}
+
+	password, err := f.Auth.Password(ctx)
+	if err != nil {
+		return errors.Wrap(err, "get password")
+	}
+	if _, err := client.Password(ctx, password); err != nil {
+		return errors.Wrap(err, "sign in with password")
+	}
+	return nil
 }
 
 // CodeAuthenticator asks user for received authentication code.

--- a/telegram/auth/password_hash_test.go
+++ b/telegram/auth/password_hash_test.go
@@ -1,0 +1,65 @@
+package auth
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+// recordingClient records which password method the flow used.
+type recordingClient struct {
+	FlowClient
+	passwordCalled     bool
+	passwordWithCalled bool
+	hashInvoked        bool
+}
+
+func (r *recordingClient) Password(context.Context, string) (*tg.AuthAuthorization, error) {
+	r.passwordCalled = true
+	return &tg.AuthAuthorization{}, nil
+}
+
+func (r *recordingClient) PasswordWith(ctx context.Context, hash PasswordHashFunc) (*tg.AuthAuthorization, error) {
+	r.passwordWithCalled = true
+	if _, err := hash(ctx, &tg.AccountPassword{}); err == nil {
+		r.hashInvoked = true
+	}
+	return &tg.AuthAuthorization{}, nil
+}
+
+// hashAuth is a UserAuthenticator that also provides the SRP answer directly.
+type hashAuth struct {
+	UserAuthenticator
+}
+
+func (hashAuth) PasswordHash(context.Context, *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error) {
+	return &tg.InputCheckPasswordSRP{}, nil
+}
+
+func noCode() CodeAuthenticator {
+	return CodeAuthenticatorFunc(func(context.Context, *tg.AuthSentCode) (string, error) { return "", nil })
+}
+
+func TestFlowPasswordPrefersHashProvider(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("HashProvider", func(t *testing.T) {
+		f := NewFlow(hashAuth{UserAuthenticator: Constant("phone", "pw", noCode())}, SendCodeOptions{})
+		client := &recordingClient{}
+		require.NoError(t, f.password(ctx, client))
+		require.True(t, client.passwordWithCalled, "should use the hash path")
+		require.True(t, client.hashInvoked, "hash callback should be invoked")
+		require.False(t, client.passwordCalled, "plaintext path must be skipped")
+	})
+
+	t.Run("StringFallback", func(t *testing.T) {
+		f := NewFlow(Constant("phone", "pw", noCode()), SendCodeOptions{})
+		client := &recordingClient{}
+		require.NoError(t, f.password(ctx, client))
+		require.True(t, client.passwordCalled, "should fall back to the string path")
+		require.False(t, client.passwordWithCalled)
+	})
+}

--- a/telegram/auth/srpguard/example_test.go
+++ b/telegram/auth/srpguard/example_test.go
@@ -1,0 +1,24 @@
+package srpguard_test
+
+import (
+	"context"
+
+	"github.com/awnumar/memguard"
+
+	"github.com/gotd/td/telegram/auth"
+	"github.com/gotd/td/telegram/auth/srpguard"
+)
+
+// This example shows how to supply a 2FA password from protected memory instead
+// of a Go string, so the plaintext is locked, never swapped to disk, and wiped
+// after the SRP answer is computed.
+func ExampleLockedBuffer() {
+	// secret is read from a prompt/keyring into a byte slice; memguard takes
+	// ownership of it and wipes the original.
+	secret := []byte("correct horse battery staple")
+	buf := memguard.NewBufferFromBytes(secret)
+
+	// client is obtained via telegramClient.Auth().
+	var client *auth.Client
+	_, _ = client.PasswordWith(context.Background(), srpguard.LockedBuffer(buf))
+}

--- a/telegram/auth/srpguard/srpguard.go
+++ b/telegram/auth/srpguard/srpguard.go
@@ -1,0 +1,62 @@
+// Package srpguard provides memguard-backed 2FA password handling for
+// telegram/auth, keeping the plaintext password in locked, swap-protected
+// memory that is wiped after the SRP answer is computed.
+//
+// It addresses gotd/td#755: a Go string cannot be reliably zeroed, so the 2FA
+// password may linger in memory longer than necessary. The helpers here return
+// an [auth.PasswordHashFunc] that reads the password from a memguard buffer and
+// destroys it before returning.
+//
+// Usage with the high-level method:
+//
+//	buf := memguard.NewBufferFromBytes(secret) // takes ownership, wipes secret
+//	_, err := client.Auth().PasswordWith(ctx, srpguard.LockedBuffer(buf))
+//
+// or with an encrypted [memguard.Enclave]:
+//
+//	_, err := client.Auth().PasswordWith(ctx, srpguard.Enclave(enclave))
+//
+// This package isolates the memguard dependency from the core auth package.
+package srpguard
+
+import (
+	"context"
+
+	"github.com/awnumar/memguard"
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/telegram/auth"
+	"github.com/gotd/td/tg"
+)
+
+// errDestroyed is returned when the provided buffer is no longer usable.
+var errDestroyed = errors.New("srpguard: password buffer already destroyed")
+
+// LockedBuffer returns an [auth.PasswordHashFunc] that computes the SRP answer
+// from a password kept in buf, destroying buf afterwards.
+//
+// buf is consumed: it is destroyed once the returned function is called (or, if
+// it is never called, the caller remains responsible for destroying it).
+func LockedBuffer(buf *memguard.LockedBuffer) auth.PasswordHashFunc {
+	return func(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error) {
+		defer buf.Destroy()
+		if !buf.IsAlive() {
+			return nil, errDestroyed
+		}
+		return auth.PasswordHash(buf.Bytes(), p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
+	}
+}
+
+// Enclave returns an [auth.PasswordHashFunc] that opens enc into a locked
+// buffer, computes the SRP answer and destroys the buffer. enc itself remains
+// valid and may be reused.
+func Enclave(enc *memguard.Enclave) auth.PasswordHashFunc {
+	return func(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error) {
+		buf, err := enc.Open()
+		if err != nil {
+			return nil, errors.Wrap(err, "open enclave")
+		}
+		defer buf.Destroy()
+		return auth.PasswordHash(buf.Bytes(), p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
+	}
+}

--- a/telegram/auth/srpguard/srpguard_test.go
+++ b/telegram/auth/srpguard/srpguard_test.go
@@ -1,0 +1,75 @@
+package srpguard_test
+
+import (
+	"context"
+	"encoding/hex"
+	"testing"
+
+	"github.com/awnumar/memguard"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram/auth/srpguard"
+	"github.com/gotd/td/tg"
+)
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	require.NoError(t, err)
+	return b
+}
+
+func testPassword(t *testing.T) *tg.AccountPassword {
+	t.Helper()
+	algo := &tg.PasswordKdfAlgoSHA256SHA256PBKDF2HMACSHA512iter100000SHA256ModPow{
+		Salt1: mustHex(t, "4D11FB6BEC38F9D2546BB0F61E4F1C99A1BC0DB8F0D5F35B1291B37B213123D7ED48F3C6794D495B"),
+		Salt2: mustHex(t, "A1B181AAFE88188680AE32860D60BB01"),
+		G:     3,
+		P: mustHex(t, "C71CAEB9C6B1C9048E6C522F70F13F73980D40238E3E21C14934D037563D930F"+
+			"48198A0AA7C14058229493D22530F4DBFA336F6E0AC925139543AED44CCE7C37"+
+			"20FD51F69458705AC68CD4FE6B6B13ABDC9746512969328454F18FAF8C595F64"+
+			"2477FE96BB2A941D5BCD1D4AC8CC49880708FA9B378E3C4F3A9060BEE67CF9A4"+
+			"A4A695811051907E162753B56B0F6B410DBA74D8A84B2A14B3144E0EF1284754"+
+			"FD17ED950D5965B4B9DD46582DB1178D169C6BC465B0D6FF9CA3928FEF5B9AE4"+
+			"E418FC15E83EBEA0F87FA9FF5EED70050DED2849F47BF959D956850CE929851F"+
+			"0D8115F635B105EE2E4E15D04B2454BF6F4FADF034B10403119CD8E3B92FCC5B"),
+	}
+	p := &tg.AccountPassword{SRPID: 1234567890}
+	p.SetCurrentAlgo(algo)
+	return p
+}
+
+func TestLockedBuffer(t *testing.T) {
+	p := testPassword(t)
+	buf := memguard.NewBufferFromBytes([]byte("correct horse battery staple"))
+
+	answer, err := srpguard.LockedBuffer(buf)(context.Background(), p)
+	require.NoError(t, err)
+	require.NotEmpty(t, answer.A)
+	require.NotEmpty(t, answer.M1)
+	require.Equal(t, p.SRPID, answer.SRPID)
+	require.False(t, buf.IsAlive(), "buffer must be destroyed after use")
+}
+
+func TestEnclave(t *testing.T) {
+	p := testPassword(t)
+	enc := memguard.NewEnclave([]byte("correct horse battery staple"))
+
+	answer, err := srpguard.Enclave(enc)(context.Background(), p)
+	require.NoError(t, err)
+	require.NotEmpty(t, answer.A)
+	require.NotEmpty(t, answer.M1)
+
+	// The enclave may be reused for a second attempt.
+	answer2, err := srpguard.Enclave(enc)(context.Background(), p)
+	require.NoError(t, err)
+	require.NotEmpty(t, answer2.A)
+}
+
+func TestLockedBufferDestroyed(t *testing.T) {
+	buf := memguard.NewBufferFromBytes([]byte("x"))
+	buf.Destroy()
+
+	_, err := srpguard.LockedBuffer(buf)(context.Background(), testPassword(t))
+	require.Error(t, err)
+}

--- a/telegram/auth/user.go
+++ b/telegram/auth/user.go
@@ -16,16 +16,46 @@ import (
 // You can use strings.TrimSpace(password) for this.
 var ErrPasswordInvalid = errors.New("invalid password")
 
+// PasswordHashFunc computes the SRP answer from the account's password
+// parameters (as returned by account.getPassword).
+//
+// It lets callers keep the plaintext password out of a Go string — which
+// cannot be reliably zeroed (see #755) — for example in locked memory, and
+// turn it into an answer on demand. See the telegram/auth/srpguard subpackage
+// for a memguard-backed implementation.
+type PasswordHashFunc func(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error)
+
+// PasswordHashFor returns a PasswordHashFunc that hashes the given password.
+//
+// It is the string-based default used by Password; prefer a secret-memory
+// implementation (e.g. telegram/auth/srpguard) when handling sensitive input.
+func PasswordHashFor(password []byte) PasswordHashFunc {
+	return func(ctx context.Context, p *tg.AccountPassword) (*tg.InputCheckPasswordSRP, error) {
+		return PasswordHash(password, p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
+	}
+}
+
 // Password performs login via secure remote password (aka 2FA).
 //
 // Method can be called after SignIn to provide password if requested.
+//
+// Note that the password is passed as a string, which cannot be reliably
+// zeroed from memory; use PasswordWith to provide it from protected memory.
 func (c *Client) Password(ctx context.Context, password string) (*tg.AuthAuthorization, error) {
+	return c.PasswordWith(ctx, PasswordHashFor([]byte(password)))
+}
+
+// PasswordWith performs login via secure remote password (aka 2FA), computing
+// the SRP answer via hash so the password never has to be passed as a string.
+//
+// Method can be called after SignIn to provide password if requested.
+func (c *Client) PasswordWith(ctx context.Context, hash PasswordHashFunc) (*tg.AuthAuthorization, error) {
 	p, err := c.api.AccountGetPassword(ctx)
 	if err != nil {
 		return nil, errors.Wrap(err, "get SRP parameters")
 	}
 
-	a, err := PasswordHash([]byte(password), p.SRPID, p.SRPB, p.SecureRandom, p.CurrentAlgo)
+	a, err := hash(ctx, p)
 	if err != nil {
 		return nil, errors.Wrap(err, "compute password hash")
 	}


### PR DESCRIPTION
Closes #755.

## Problem

The 2FA password could only be supplied to `auth.Client.Password` as a Go `string`, which [cannot be reliably zeroed](https://stackoverflow.com/questions/39968084/is-it-possible-to-zero-a-golang-strings-memory-safely). It may therefore linger in memory (and potentially swap) longer than necessary.

## Change

A string-free path, with **no breaking API changes**:

- **`auth.PasswordHashFunc`** + **`(*auth.Client).PasswordWith`** — compute the SRP answer from the account password parameters via a callback, so the plaintext never has to be a `string`. `Password(string)` now delegates to it (`PasswordHashFor`), so existing callers are unchanged.
- **`auth.PasswordHashProvider`** — an *optional* `UserAuthenticator` extension. `Flow` uses it when an authenticator implements it, and falls back to the plaintext `Password` callback otherwise (the `FlowClient`/`UserAuthenticator` interfaces are unchanged).
- **`telegram/auth/srpguard`** (new subpackage) — `LockedBuffer` and `Enclave` helpers backed by [`awnumar/memguard`](https://github.com/awnumar/memguard). The password is held in locked, swap-protected memory and **wiped after** the SRP answer is computed. memguard is isolated to this subpackage so it stays out of core `telegram/auth`.

### Usage

```go
buf := memguard.NewBufferFromBytes(secret) // takes ownership, wipes secret
_, err := client.Auth().PasswordWith(ctx, srpguard.LockedBuffer(buf))
```

## Tests

- `srpguard`: `LockedBuffer`/`Enclave` produce a valid `InputCheckPasswordSRP` and the buffer is destroyed after use (incl. the already-destroyed error path).
- `auth`: the flow prefers the hash provider when available and falls back to the string path otherwise.
- Existing `auth` tests (which exercise `Password`, now routed through `PasswordWith`) still pass.

`go test ./telegram/auth/...`, `go vet`, `gofmt`, full module build — all clean.

## Note
This adds `github.com/awnumar/memguard` (+ `awnumar/memcall`) to the module, used only by the `srpguard` subpackage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)