### PR TITLE
feat(message): add sticker source helpers to send stickers

### DIFF
--- a/telegram/message/sticker_set.go
+++ b/telegram/message/sticker_set.go
@@ -1,0 +1,195 @@
+package message
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// StickerSource resolves a list of stickers (documents) to pick from.
+//
+// Use one of the built-in sources: FavedStickers, RecentStickers,
+// AttachedRecentStickers or StickerSet.
+type StickerSource interface {
+	// Stickers returns stickers (documents) of the source.
+	Stickers(ctx context.Context, raw *tg.Client) ([]tg.DocumentClass, error)
+}
+
+type favedStickerSource struct{}
+
+func (favedStickerSource) Stickers(ctx context.Context, raw *tg.Client) ([]tg.DocumentClass, error) {
+	r, err := raw.MessagesGetFavedStickers(ctx, 0)
+	if err != nil {
+		return nil, errors.Wrap(err, "get faved stickers")
+	}
+
+	m, ok := r.AsModified()
+	if !ok {
+		return nil, errors.Errorf("unexpected type %T", r)
+	}
+	return m.Stickers, nil
+}
+
+// FavedStickers returns a StickerSource using the user's favorite stickers.
+//
+// See https://core.telegram.org/method/messages.getFavedStickers.
+func FavedStickers() StickerSource {
+	return favedStickerSource{}
+}
+
+type recentStickerSource struct {
+	attached bool
+}
+
+func (s recentStickerSource) Stickers(ctx context.Context, raw *tg.Client) ([]tg.DocumentClass, error) {
+	r, err := raw.MessagesGetRecentStickers(ctx, &tg.MessagesGetRecentStickersRequest{
+		Attached: s.attached,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "get recent stickers")
+	}
+
+	m, ok := r.AsModified()
+	if !ok {
+		return nil, errors.Errorf("unexpected type %T", r)
+	}
+	return m.Stickers, nil
+}
+
+// RecentStickers returns a StickerSource using the user's recently used stickers.
+//
+// See https://core.telegram.org/method/messages.getRecentStickers.
+func RecentStickers() StickerSource {
+	return recentStickerSource{}
+}
+
+// AttachedRecentStickers returns a StickerSource using stickers recently
+// attached to photo or video files.
+//
+// See https://core.telegram.org/method/messages.getRecentStickers.
+func AttachedRecentStickers() StickerSource {
+	return recentStickerSource{attached: true}
+}
+
+type stickerSetSource struct {
+	set tg.InputStickerSetClass
+}
+
+func (s stickerSetSource) Stickers(ctx context.Context, raw *tg.Client) ([]tg.DocumentClass, error) {
+	r, err := raw.MessagesGetStickerSet(ctx, &tg.MessagesGetStickerSetRequest{
+		Stickerset: s.set,
+	})
+	if err != nil {
+		return nil, errors.Wrap(err, "get sticker set")
+	}
+
+	m, ok := r.AsModified()
+	if !ok {
+		return nil, errors.Errorf("unexpected type %T", r)
+	}
+	return m.Documents, nil
+}
+
+// StickerSet returns a StickerSource using stickers of the given set.
+//
+// See https://core.telegram.org/method/messages.getStickerSet.
+func StickerSet(set tg.InputStickerSetClass) StickerSource {
+	return stickerSetSource{set: set}
+}
+
+// StickerSetName returns a StickerSource using stickers of the set with given
+// short name.
+//
+// See https://core.telegram.org/method/messages.getStickerSet.
+func StickerSetName(shortName string) StickerSource {
+	return StickerSet(&tg.InputStickerSetShortName{ShortName: shortName})
+}
+
+// StickerSetBuilder selects and sends a sticker from a StickerSource.
+//
+// It is created using the Builder.Sticker method.
+type StickerSetBuilder struct {
+	builder *Builder
+	source  StickerSource
+}
+
+// Sticker creates a StickerSetBuilder to pick and send a sticker from the
+// given source.
+//
+//	sender.Self().Sticker(message.FavedStickers()).ByIndex(ctx, 0)
+//	sender.Self().Sticker(message.RecentStickers()).ByEmoji(ctx, "😎")
+func (b *Builder) Sticker(source StickerSource) *StickerSetBuilder {
+	return &StickerSetBuilder{
+		builder: b,
+		source:  source,
+	}
+}
+
+// Stickers returns all stickers (documents) of the source.
+func (s *StickerSetBuilder) Stickers(ctx context.Context) ([]tg.DocumentClass, error) {
+	return s.source.Stickers(ctx, s.builder.sender.raw)
+}
+
+func (s *StickerSetBuilder) send(
+	ctx context.Context,
+	doc tg.DocumentClass, caption []StyledTextOption,
+) (tg.UpdatesClass, error) {
+	d, ok := doc.AsNotEmpty()
+	if !ok {
+		return nil, errors.New("sticker document is empty")
+	}
+	return s.builder.Media(ctx, Document(d, caption...))
+}
+
+// ByIndex sends the sticker at the given index in the source.
+func (s *StickerSetBuilder) ByIndex(
+	ctx context.Context,
+	index int, caption ...StyledTextOption,
+) (tg.UpdatesClass, error) {
+	stickers, err := s.Stickers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	if index < 0 || index >= len(stickers) {
+		return nil, errors.Errorf("sticker index %d out of range [0, %d)", index, len(stickers))
+	}
+	return s.send(ctx, stickers[index], caption)
+}
+
+// ByEmoji sends the first sticker of the source whose alternative emoji
+// representation matches the given emoji.
+func (s *StickerSetBuilder) ByEmoji(
+	ctx context.Context,
+	emoji string, caption ...StyledTextOption,
+) (tg.UpdatesClass, error) {
+	stickers, err := s.Stickers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, sticker := range stickers {
+		doc, ok := sticker.AsNotEmpty()
+		if !ok {
+			continue
+		}
+		for _, attr := range doc.Attributes {
+			attr, ok := attr.(*tg.DocumentAttributeSticker)
+			if ok && attr.Alt == emoji {
+				return s.send(ctx, sticker, caption)
+			}
+		}
+	}
+
+	return nil, errors.Errorf("no sticker with emoji %q found", emoji)
+}
+
+// First sends the first sticker of the source.
+func (s *StickerSetBuilder) First(
+	ctx context.Context,
+	caption ...StyledTextOption,
+) (tg.UpdatesClass, error) {
+	return s.ByIndex(ctx, 0, caption...)
+}

--- a/telegram/message/sticker_set_example_test.go
+++ b/telegram/message/sticker_set_example_test.go
@@ -1,0 +1,56 @@
+package message_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/signal"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/telegram/message"
+	"github.com/gotd/td/tg"
+)
+
+func sendSticker(ctx context.Context) error {
+	client, err := telegram.ClientFromEnvironment(telegram.Options{})
+	if err != nil {
+		return err
+	}
+
+	return client.Run(ctx, func(ctx context.Context) error {
+		sender := message.NewSender(tg.NewClient(client))
+
+		// Sends the first favorite sticker to the @durovschat.
+		if _, err := sender.Resolve("https://t.me/durovschat").
+			Sticker(message.FavedStickers()).
+			First(ctx); err != nil {
+			return err
+		}
+
+		// Sends a recently used sticker by its emoji to your Saved Messages.
+		if _, err := sender.Self().
+			Sticker(message.RecentStickers()).
+			ByEmoji(ctx, "😎"); err != nil {
+			return err
+		}
+
+		// Sends the sticker at index 0 of a sticker set by its short name.
+		if _, err := sender.Self().
+			Sticker(message.StickerSetName("AnimatedEmojies")).
+			ByIndex(ctx, 0); err != nil {
+			return err
+		}
+
+		return nil
+	})
+}
+
+func ExampleStickerSetBuilder() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	if err := sendSticker(ctx); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "%+v\n", err)
+		os.Exit(2)
+	}
+}

--- a/telegram/message/sticker_set_test.go
+++ b/telegram/message/sticker_set_test.go
@@ -1,0 +1,120 @@
+package message
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func testStickers() []tg.DocumentClass {
+	return []tg.DocumentClass{
+		&tg.DocumentEmpty{ID: 1},
+		&tg.Document{
+			ID:            10,
+			AccessHash:    20,
+			FileReference: []byte{1, 2, 3},
+			Attributes: []tg.DocumentAttributeClass{
+				&tg.DocumentAttributeSticker{Alt: "😎", Stickerset: &tg.InputStickerSetEmpty{}},
+			},
+		},
+		&tg.Document{
+			ID:            11,
+			AccessHash:    21,
+			FileReference: []byte{4, 5, 6},
+			Attributes: []tg.DocumentAttributeClass{
+				&tg.DocumentAttributeSticker{Alt: "😢", Stickerset: &tg.InputStickerSetEmpty{}},
+			},
+		},
+	}
+}
+
+func TestStickerByIndex(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetRecentStickersRequest{}).ThenResult(&tg.MessagesRecentStickers{
+		Stickers: testStickers(),
+	})
+	expectSendMedia(t, &tg.InputMediaDocument{ID: &tg.InputDocument{
+		ID:            10,
+		AccessHash:    20,
+		FileReference: []byte{1, 2, 3},
+	}}, mock)
+
+	_, err := sender.Self().Sticker(RecentStickers()).ByIndex(ctx, 1)
+	require.NoError(t, err)
+}
+
+func TestStickerByIndexOutOfRange(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetFavedStickersRequest{}).ThenResult(&tg.MessagesFavedStickers{
+		Stickers: testStickers(),
+	})
+
+	_, err := sender.Self().Sticker(FavedStickers()).ByIndex(ctx, 10)
+	require.Error(t, err)
+}
+
+func TestStickerByEmoji(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetFavedStickersRequest{}).ThenResult(&tg.MessagesFavedStickers{
+		Stickers: testStickers(),
+	})
+	expectSendMedia(t, &tg.InputMediaDocument{ID: &tg.InputDocument{
+		ID:            11,
+		AccessHash:    21,
+		FileReference: []byte{4, 5, 6},
+	}}, mock)
+
+	_, err := sender.Self().Sticker(FavedStickers()).ByEmoji(ctx, "😢")
+	require.NoError(t, err)
+}
+
+func TestStickerByEmojiNotFound(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetFavedStickersRequest{}).ThenResult(&tg.MessagesFavedStickers{
+		Stickers: testStickers(),
+	})
+
+	_, err := sender.Self().Sticker(FavedStickers()).ByEmoji(ctx, "🤡")
+	require.Error(t, err)
+}
+
+func TestStickerSetFirst(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetStickerSetRequest{
+		Stickerset: &tg.InputStickerSetShortName{ShortName: "gotd"},
+	}).ThenResult(&tg.MessagesStickerSet{
+		Documents: testStickers()[1:],
+	})
+	expectSendMedia(t, &tg.InputMediaDocument{ID: &tg.InputDocument{
+		ID:            10,
+		AccessHash:    20,
+		FileReference: []byte{1, 2, 3},
+	}}, mock)
+
+	_, err := sender.Self().Sticker(StickerSetName("gotd")).First(ctx)
+	require.NoError(t, err)
+}
+
+func TestStickerNotModified(t *testing.T) {
+	ctx := context.Background()
+	sender, mock := testSender(t)
+
+	mock.ExpectCall(&tg.MessagesGetFavedStickersRequest{}).
+		ThenResult(&tg.MessagesFavedStickersNotModified{})
+
+	_, err := sender.Self().Sticker(FavedStickers()).First(ctx)
+	require.Error(t, err)
+}


### PR DESCRIPTION
Closes #189.

Adds fluent helpers to `telegram/message` for picking and sending stickers from the various sticker sources, matching the API sketched in the issue.

## API

```go
sender.Self().Sticker(message.FavedStickers()).First(ctx)
sender.Self().Sticker(message.RecentStickers()).ByEmoji(ctx, "😎")
sender.Self().Sticker(message.StickerSetName("AnimatedEmojies")).ByIndex(ctx, 0)
```

### Sources (`StickerSource`)
Each is backed by the corresponding `messages.*` RPC:
- `FavedStickers()` — `messages.getFavedStickers`
- `RecentStickers()` / `AttachedRecentStickers()` — `messages.getRecentStickers`
- `StickerSet(set)` / `StickerSetName(shortName)` — `messages.getStickerSet`

### Selection (`*StickerSetBuilder`, via `Builder.Sticker(source)`)
- `ByIndex(ctx, i, caption...)`
- `ByEmoji(ctx, emoji, caption...)` — matches `DocumentAttributeSticker.Alt`
- `First(ctx, caption...)`
- `Stickers(ctx)` — exposes the resolved documents

Sending reuses the existing `Document(...)` media path (a sticker is just an `InputMediaDocument`); `*NotModified`/empty results surface clear errors.

## Notes
- `ISSUES.md` lists #189 as already implemented via `telegram/query/cached`, but that only covers the fetch/cache side — the send-side helpers the issue asked for didn't exist. This fills that gap.

## Tests
Offline via `tgmock`: index/emoji selection, out-of-range, emoji-not-found, set-by-name, and the `NotModified` error path. Plus a usage example. `go test ./telegram/message/ -race` and `go build ./...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)