### PR TITLE
feat(peers): add channel recommendations helper

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -40,6 +40,12 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
   (`ChannelMembers.Promote`/`Demote`/`Ban`/`Unban`). Builds on the already-existing title/description/
   reactions/slow-mode/signatures/sticker-set/discussion-group helpers; creator transfer
   (`channels.editCreator`, SRP-gated) intentionally left out.
+- **Done:** #1267 → channel recommendations helper
+  (`Channel.RecommendedChannels` / `Manager.RecommendedChannels` in `telegram/peers`):
+  the raw `channels.getChannelRecommendations` has no offset/hash, so true pagination
+  isn't an API feature — instead the helper surfaces the total `Count` from
+  `messages.chatsSlice` (Premium gets the full list; others a capped subset) so callers
+  can detect that more recommendations exist.
 - **Closed as already-addressed:** #824 (`tgerr.Error` already extracts `Type`/`Argument`).
 - **Found already implemented** (should be closed, not built): #214 Markdown styling
   (`telegram/message/markdown`), #189 sticker helpers (`telegram/query/cached` generates all 8).
@@ -139,7 +145,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 1406 | Update FakeTLS ClientHello to match modern clients | open |
 | 1362 | Phone call function | **in progress — `telegram/calls` (1:1 VoIP, tgcalls v2)** |
 | 1308 | Handling `UpdateConnectionState` | **done — see Progress** |
-| 1267 | Channel recommendations pagination | open |
+| 1267 | Channel recommendations pagination | **done — `Channel.RecommendedChannels` (+ total Count)** |
 | 884 | helper: support messages/GetMediaGroup | **done — PR #1745** |
 | 883 | clock: support network clock | **done — `clock/ntp`** |
 | 824 | feat: errors with placeholders like `%d` | **closed — already addressed** |
@@ -187,7 +193,7 @@ implemented (#214, #189) and one was closed (#824); they are excluded here.
 | 788 | `ChatInvitePublicJoinRequests` | Requires loosening the `InviteLink` type, currently hardwired to `ChatInviteExported`. |
 | 1308 | connection-state updates | `OnSession` exists; add a connect/disconnect hook (no TDLib-style state machine). |
 | 755 | safer password passing | Callback-based password hashing in `telegram/auth`. |
-| 1267 | recommendations pagination | Raw method exists, no helper; needs limit/more investigation. |
+| 1267 | recommendations pagination | **done** — helper added (`telegram/peers`). No offset/hash on the raw method, so not truly paginable; helper exposes the total `Count` (Premium-gated full list). |
 
 **Tier 3 — hard** (cross-cutting, breaking, or deep):
 

--- a/telegram/peers/recommendations.go
+++ b/telegram/peers/recommendations.go
@@ -1,0 +1,77 @@
+package peers
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// RecommendedChannels is the result of a channel recommendations query.
+//
+// channels.getChannelRecommendations has no offset or hash parameter, so it
+// can't be paginated: the server returns the available recommendations in a
+// single response. Non-Premium accounts receive a server-capped subset of the
+// recommendations, while Count still reports the full total — so a caller can
+// detect that more recommendations exist (e.g. to prompt for Premium) by
+// comparing len(Channels) with Count.
+//
+// See https://core.telegram.org/method/channels.getChannelRecommendations.
+type RecommendedChannels struct {
+	// Channels is the list of recommended channels returned by the server.
+	Channels []Channel
+	// Count is the total number of recommendations available, which may be
+	// greater than len(Channels) for non-Premium accounts.
+	Count int
+}
+
+// RecommendedChannels returns public channels recommended based on similarities
+// in the subscriber bases of this channel and others.
+func (c Channel) RecommendedChannels(ctx context.Context) (RecommendedChannels, error) {
+	req := &tg.ChannelsGetChannelRecommendationsRequest{}
+	req.SetChannel(c.InputChannel())
+	return c.m.recommendedChannels(ctx, req)
+}
+
+// RecommendedChannels returns channels recommended for the current user, based
+// on the channels the user has joined.
+func (m *Manager) RecommendedChannels(ctx context.Context) (RecommendedChannels, error) {
+	return m.recommendedChannels(ctx, &tg.ChannelsGetChannelRecommendationsRequest{})
+}
+
+func (m *Manager) recommendedChannels(
+	ctx context.Context,
+	req *tg.ChannelsGetChannelRecommendationsRequest,
+) (RecommendedChannels, error) {
+	res, err := m.api.ChannelsGetChannelRecommendations(ctx, req)
+	if err != nil {
+		return RecommendedChannels{}, errors.Wrap(err, "get channel recommendations")
+	}
+
+	chats := res.GetChats()
+	if err := m.applyChats(ctx, chats...); err != nil {
+		return RecommendedChannels{}, errors.Wrap(err, "apply chats")
+	}
+
+	result := RecommendedChannels{
+		Channels: make([]Channel, 0, len(chats)),
+	}
+	for _, chat := range chats {
+		ch, ok := chat.(*tg.Channel)
+		if !ok {
+			continue
+		}
+		result.Channels = append(result.Channels, m.Channel(ch))
+	}
+
+	// messages.chatsSlice carries the total count; messages.chats does not, in
+	// which case the full set was returned and the count equals its length.
+	if slice, ok := res.(*tg.MessagesChatsSlice); ok {
+		result.Count = slice.Count
+	} else {
+		result.Count = len(result.Channels)
+	}
+
+	return result, nil
+}

--- a/telegram/peers/recommendations_example_test.go
+++ b/telegram/peers/recommendations_example_test.go
@@ -1,0 +1,57 @@
+package peers_test
+
+import (
+	"context"
+	"fmt"
+
+	"go.uber.org/zap"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/telegram/peers"
+)
+
+func ExampleChannel_RecommendedChannels() {
+	logger := zap.NewExample()
+
+	client, err := telegram.ClientFromEnvironment(telegram.Options{
+		Logger: logger.Named("client"),
+	})
+	if err != nil {
+		panic(err)
+	}
+	peerManager := peers.Options{Logger: logger}.Build(client.API())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := client.Run(ctx, func(ctx context.Context) error {
+		if err := peerManager.Init(ctx); err != nil {
+			return err
+		}
+
+		p, err := peerManager.Resolve(ctx, "telegram")
+		if err != nil {
+			return err
+		}
+		ch, ok := p.(peers.Channel)
+		if !ok {
+			return fmt.Errorf("%q is not a channel", "telegram")
+		}
+
+		rec, err := ch.RecommendedChannels(ctx)
+		if err != nil {
+			return err
+		}
+
+		// rec.Count is the total number of recommendations available.
+		// For non-Premium accounts the server returns only a subset, so
+		// len(rec.Channels) may be smaller than rec.Count.
+		fmt.Printf("got %d of %d recommended channels\n", len(rec.Channels), rec.Count)
+		for _, c := range rec.Channels {
+			fmt.Println(c.VisibleName())
+		}
+		return nil
+	}); err != nil {
+		panic(err)
+	}
+}

--- a/telegram/peers/recommendations_test.go
+++ b/telegram/peers/recommendations_test.go
@@ -1,0 +1,85 @@
+package peers
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func getTestRecommendedChannel() *tg.Channel {
+	u := &tg.Channel{
+		Broadcast:  true,
+		ID:         12,
+		AccessHash: 12,
+		Title:      "Recommended",
+		Username:   "recommended",
+		Photo:      &tg.ChatPhotoEmpty{},
+	}
+	u.SetFlags()
+	return u
+}
+
+func TestChannel_RecommendedChannels(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	mock, m := testManager(t)
+
+	ch := m.Channel(getTestChannel())
+	rec := getTestRecommendedChannel()
+
+	req := &tg.ChannelsGetChannelRecommendationsRequest{}
+	req.SetChannel(ch.InputChannel())
+
+	// Error path.
+	mock.ExpectCall(req).ThenRPCErr(getTestError())
+	_, err := ch.RecommendedChannels(ctx)
+	a.Error(err)
+
+	// messages.chats: full set, Count equals number of returned channels.
+	mock.ExpectCall(req).ThenResult(&tg.MessagesChats{
+		Chats: []tg.ChatClass{rec},
+	})
+	got, err := ch.RecommendedChannels(ctx)
+	a.NoError(err)
+	a.Len(got.Channels, 1)
+	a.Equal(1, got.Count)
+	a.Equal(rec.ID, got.Channels[0].ID())
+	username, ok := got.Channels[0].Username()
+	a.True(ok)
+	a.Equal("recommended", username)
+
+	// messages.chatsSlice: capped subset, Count reports the true total.
+	mock.ExpectCall(req).ThenResult(&tg.MessagesChatsSlice{
+		Count: 82,
+		Chats: []tg.ChatClass{rec},
+	})
+	got, err = ch.RecommendedChannels(ctx)
+	a.NoError(err)
+	a.Len(got.Channels, 1)
+	a.Equal(82, got.Count, "Count must report the total, not the returned length")
+}
+
+func TestManager_RecommendedChannels(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	mock, m := testManager(t)
+
+	rec := getTestRecommendedChannel()
+
+	// No channel set: recommendations for the current user.
+	req := &tg.ChannelsGetChannelRecommendationsRequest{}
+
+	mock.ExpectCall(req).ThenResult(&tg.MessagesChatsSlice{
+		Count: 5,
+		Chats: []tg.ChatClass{rec, &tg.ChatEmpty{ID: 999}},
+	})
+	got, err := m.RecommendedChannels(ctx)
+	a.NoError(err)
+	// Non-channel chats are skipped, but the total Count is preserved.
+	a.Len(got.Channels, 1)
+	a.Equal(5, got.Count)
+	a.Equal(rec.ID, got.Channels[0].ID())
+}


### PR DESCRIPTION
## Summary

Adds a helper for channel recommendations (#1267).

`channels.getChannelRecommendations` (layer 227) has **no offset or hash parameter**, so the result genuinely can't be paginated through — the original issue's premise (paging to fetch all ~82 recommendations) isn't achievable via the API. What the server actually does, and what tdlib relies on, is:

- return the **full** list to Premium accounts;
- return a **capped subset** to non-Premium accounts, but as `messages.chatsSlice` whose `count` reports the **true total**.

So this helper returns the recommended channels together with that total `Count`, letting callers detect that more recommendations exist (e.g. to prompt for Premium):

```go
type RecommendedChannels struct {
    Channels []peers.Channel
    Count    int // total available; may exceed len(Channels) for non-Premium
}

func (c Channel) RecommendedChannels(ctx) (RecommendedChannels, error)   // related to a channel
func (m *Manager) RecommendedChannels(ctx) (RecommendedChannels, error)  // for the current user
```

It applies the returned chats to the `peers.Manager` cache (consistent with the existing resolve helpers) and skips any non-channel chats while preserving the reported total.

## Testing

Offline `tgmock`-based unit tests cover the error path, the `messages.chats` case (Count == len), the `messages.chatsSlice` case (Count reports the true total, e.g. 82), non-channel filtering, and the manager-level (no-channel) variant. Added a runnable compile-checked example. `gofmt`, `go build ./...`, `go vet ./telegram/peers/`, and `go test -race ./telegram/peers/` all pass. No generated code changed; no network access.

Closes #1267

🤖 Generated with [Claude Code](https://claude.com/claude-code)