### PR TITLE
fix(calls): drain ICE notifier goroutines on Conn.Close

### DIFF
--- a/telegram/calls/connection.go
+++ b/telegram/calls/connection.go
@@ -528,6 +528,11 @@ func (c *Conn) fireDisconnected() {
 }
 
 // Close tears down the transport.
+//
+// It uses pion's graceful shutdown variants, which block until the ICE agent's
+// asynchronous state-change notifier goroutines have drained. Otherwise the
+// queued "closed" callback could fire (and log) after the caller — e.g. a test
+// — has already returned.
 func (c *Conn) Close() error {
 	c.mu.Lock()
 	dtls, ice, gatherer := c.dtls, c.ice, c.gatherer
@@ -536,10 +541,10 @@ func (c *Conn) Close() error {
 		_ = dtls.Stop()
 	}
 	if ice != nil {
-		_ = ice.Stop()
+		_ = ice.GracefulStop()
 	}
 	if gatherer != nil {
-		_ = gatherer.Close()
+		_ = gatherer.GracefulClose()
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`TestConnLoopback` could panic with:

```
panic: Log in goroutine after TestConnLoopback has completed: ... DEBUG ICE state {"state": "closed"}
```

`Conn.Close` used pion's non-graceful `ice.Stop()` / `gatherer.Close()`. Those tear the ICE agent down but leave the queued `"closed"` connection-state callback to fire on a separate notifier goroutine (`handlerNotifier`). In the test that goroutine ran *after* the test function returned, so its `c.log.Debug("ICE state", ...)` wrote to the `zaptest` logger bound to `t` and panicked.

pion's `handlerNotifier.Close(graceful)` only waits on its notifier `WaitGroup` when closed gracefully, and `Stop()`/`Close()` pass `graceful=false`.

## Fix

Use the graceful variants `ice.GracefulStop()` / `gatherer.GracefulClose()`, which block until the agent's notifier goroutines drain. The `"closed"` callback now completes before `Close` returns, so no state-change callback (or its logging) fires afterward. DTLS keeps `Stop()` — pion exposes no `GracefulStop` for it and it was not the leaked goroutine.

## Testing

- `go test -race -run TestConnLoopback -count=10 ./telegram/calls/` — green
- `go test -race ./telegram/calls/` — green

🤖 Generated with [Claude Code](https://claude.com/claude-code)