### PR TITLE
feat(message): add rich message builder and parsers

### DIFF
--- a/telegram/message/rich.go
+++ b/telegram/message/rich.go
@@ -1,0 +1,51 @@
+package message
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// RichMessage sends a rich message.
+//
+// A rich message carries structured content (headings, lists, tables, media,
+// math and more) instead of a flat string. Build one with the
+// telegram/message/rich package, e.g. rich.New(...).Input(), rich.HTML(...) or
+// rich.Markdown(...).
+func (b *Builder) RichMessage(ctx context.Context, msg tg.InputRichMessageClass) (tg.UpdatesClass, error) {
+	p, err := b.peer(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "peer")
+	}
+
+	req := b.sendRequest(p, "", nil)
+	req.RichMessage = msg
+
+	upd, err := b.sender.sendMessage(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "send rich message")
+	}
+
+	return upd, nil
+}
+
+// RichMessage edits the message, replacing its content with the given rich
+// message.
+func (b *EditMessageBuilder) RichMessage(ctx context.Context, msg tg.InputRichMessageClass) (tg.UpdatesClass, error) {
+	p, err := b.builder.peer(ctx)
+	if err != nil {
+		return nil, errors.Wrap(err, "peer")
+	}
+
+	req := b.editTextRequest(p, "", nil)
+	req.RichMessage = msg
+
+	upd, err := b.builder.sender.editMessage(ctx, req)
+	if err != nil {
+		return nil, errors.Wrap(err, "edit rich message")
+	}
+
+	return upd, nil
+}

--- a/telegram/message/rich/block.go
+++ b/telegram/message/rich/block.go
@@ -1,0 +1,262 @@
+package rich
+
+import "github.com/gotd/td/tg"
+
+// Title returns a title block (pageBlockTitle).
+func Title(text tg.RichTextClass) *tg.PageBlockTitle {
+	return &tg.PageBlockTitle{Text: text}
+}
+
+// Subtitle returns a subtitle block (pageBlockSubtitle).
+func Subtitle(text tg.RichTextClass) *tg.PageBlockSubtitle {
+	return &tg.PageBlockSubtitle{Text: text}
+}
+
+// Header returns a header block (pageBlockHeader).
+func Header(text tg.RichTextClass) *tg.PageBlockHeader {
+	return &tg.PageBlockHeader{Text: text}
+}
+
+// Subheader returns a subheader block (pageBlockSubheader).
+func Subheader(text tg.RichTextClass) *tg.PageBlockSubheader {
+	return &tg.PageBlockSubheader{Text: text}
+}
+
+// Kicker returns a kicker block (pageBlockKicker).
+func Kicker(text tg.RichTextClass) *tg.PageBlockKicker {
+	return &tg.PageBlockKicker{Text: text}
+}
+
+// Footer returns a footer block (pageBlockFooter).
+func Footer(text tg.RichTextClass) *tg.PageBlockFooter {
+	return &tg.PageBlockFooter{Text: text}
+}
+
+// Paragraph returns a paragraph block (pageBlockParagraph).
+func Paragraph(text tg.RichTextClass) *tg.PageBlockParagraph {
+	return &tg.PageBlockParagraph{Text: text}
+}
+
+// AuthorDate returns an author and publication date block (pageBlockAuthorDate).
+func AuthorDate(author tg.RichTextClass, publishedDate int) *tg.PageBlockAuthorDate {
+	return &tg.PageBlockAuthorDate{Author: author, PublishedDate: publishedDate}
+}
+
+// Heading1 returns a level-1 heading block (pageBlockHeading1).
+func Heading1(text tg.RichTextClass) *tg.PageBlockHeading1 {
+	return &tg.PageBlockHeading1{Text: text}
+}
+
+// Heading2 returns a level-2 heading block (pageBlockHeading2).
+func Heading2(text tg.RichTextClass) *tg.PageBlockHeading2 {
+	return &tg.PageBlockHeading2{Text: text}
+}
+
+// Heading3 returns a level-3 heading block (pageBlockHeading3).
+func Heading3(text tg.RichTextClass) *tg.PageBlockHeading3 {
+	return &tg.PageBlockHeading3{Text: text}
+}
+
+// Heading4 returns a level-4 heading block (pageBlockHeading4).
+func Heading4(text tg.RichTextClass) *tg.PageBlockHeading4 {
+	return &tg.PageBlockHeading4{Text: text}
+}
+
+// Heading5 returns a level-5 heading block (pageBlockHeading5).
+func Heading5(text tg.RichTextClass) *tg.PageBlockHeading5 {
+	return &tg.PageBlockHeading5{Text: text}
+}
+
+// Heading6 returns a level-6 heading block (pageBlockHeading6).
+func Heading6(text tg.RichTextClass) *tg.PageBlockHeading6 {
+	return &tg.PageBlockHeading6{Text: text}
+}
+
+// Heading returns a heading block for the given level (1-6), clamped to that
+// range.
+func Heading(level int, text tg.RichTextClass) tg.PageBlockClass {
+	switch {
+	case level <= 1:
+		return Heading1(text)
+	case level == 2:
+		return Heading2(text)
+	case level == 3:
+		return Heading3(text)
+	case level == 4:
+		return Heading4(text)
+	case level == 5:
+		return Heading5(text)
+	default:
+		return Heading6(text)
+	}
+}
+
+// Preformatted returns a preformatted (code) block with optional language
+// (pageBlockPreformatted).
+func Preformatted(text tg.RichTextClass, language string) *tg.PageBlockPreformatted {
+	return &tg.PageBlockPreformatted{Text: text, Language: language}
+}
+
+// Divider returns a divider block (pageBlockDivider).
+func Divider() *tg.PageBlockDivider {
+	return &tg.PageBlockDivider{}
+}
+
+// AnchorBlock returns an anchor block with the given name (pageBlockAnchor),
+// usable as the target of an [AnchorLink].
+func AnchorBlock(name string) *tg.PageBlockAnchor {
+	return &tg.PageBlockAnchor{Name: name}
+}
+
+// MathBlock returns a block-level mathematical expression with the given LaTeX
+// source (pageBlockMath).
+func MathBlock(source string) *tg.PageBlockMath {
+	return &tg.PageBlockMath{Source: source}
+}
+
+// Thinking returns a thinking block (pageBlockThinking), used to show an AI
+// model's reasoning.
+func Thinking(text tg.RichTextClass) *tg.PageBlockThinking {
+	return &tg.PageBlockThinking{Text: text}
+}
+
+// Blockquote returns a block quotation with an optional caption
+// (pageBlockBlockquote). Use [BlockquoteBlocks] to quote multiple blocks.
+func Blockquote(text, caption tg.RichTextClass) *tg.PageBlockBlockquote {
+	return &tg.PageBlockBlockquote{Text: text, Caption: caption}
+}
+
+// BlockquoteBlocks returns a block quotation of multiple blocks with an
+// optional caption (pageBlockBlockquoteBlocks).
+func BlockquoteBlocks(caption tg.RichTextClass, blocks ...tg.PageBlockClass) *tg.PageBlockBlockquoteBlocks {
+	return &tg.PageBlockBlockquoteBlocks{Blocks: blocks, Caption: caption}
+}
+
+// Pullquote returns a pull quotation with an optional caption
+// (pageBlockPullquote).
+func Pullquote(text, caption tg.RichTextClass) *tg.PageBlockPullquote {
+	return &tg.PageBlockPullquote{Text: text, Caption: caption}
+}
+
+// Details returns a collapsible details block (pageBlockDetails). When open is
+// true the block is expanded by default.
+func Details(open bool, title tg.RichTextClass, blocks ...tg.PageBlockClass) *tg.PageBlockDetails {
+	return &tg.PageBlockDetails{Open: open, Title: title, Blocks: blocks}
+}
+
+// List returns an unordered list block (pageBlockList).
+func List(items ...tg.PageListItemClass) *tg.PageBlockList {
+	return &tg.PageBlockList{Items: items}
+}
+
+// OrderedList returns an ordered list block (pageBlockOrderedList).
+func OrderedList(items ...tg.PageListOrderedItemClass) *tg.PageBlockOrderedList {
+	return &tg.PageBlockOrderedList{Items: items}
+}
+
+// Collage returns a collage of blocks with an optional caption
+// (pageBlockCollage).
+func Collage(caption tg.PageCaption, items ...tg.PageBlockClass) *tg.PageBlockCollage {
+	return &tg.PageBlockCollage{Items: items, Caption: caption}
+}
+
+// Slideshow returns a slideshow of blocks with an optional caption
+// (pageBlockSlideshow).
+func Slideshow(caption tg.PageCaption, items ...tg.PageBlockClass) *tg.PageBlockSlideshow {
+	return &tg.PageBlockSlideshow{Items: items, Caption: caption}
+}
+
+// Cover wraps a block as a cover (pageBlockCover).
+func Cover(cover tg.PageBlockClass) *tg.PageBlockCover {
+	return &tg.PageBlockCover{Cover: cover}
+}
+
+// Photo returns a photo block referencing a photo by ID with an optional
+// caption (pageBlockPhoto).
+func Photo(photoID int64, caption tg.PageCaption) *tg.PageBlockPhoto {
+	return &tg.PageBlockPhoto{PhotoID: photoID, Caption: caption}
+}
+
+// Video returns a video block referencing a document by ID with an optional
+// caption (pageBlockVideo).
+func Video(videoID int64, caption tg.PageCaption) *tg.PageBlockVideo {
+	return &tg.PageBlockVideo{VideoID: videoID, Caption: caption}
+}
+
+// Audio returns an audio block referencing a document by ID with an optional
+// caption (pageBlockAudio).
+func Audio(audioID int64, caption tg.PageCaption) *tg.PageBlockAudio {
+	return &tg.PageBlockAudio{AudioID: audioID, Caption: caption}
+}
+
+// Map returns a map block centered on the given input location
+// (inputPageBlockMap), with the given zoom level, size in pixels and an
+// optional caption.
+func Map(geo tg.InputGeoPointClass, zoom, w, h int, caption tg.PageCaption) *tg.InputPageBlockMap {
+	return &tg.InputPageBlockMap{Geo: geo, Zoom: zoom, W: w, H: h, Caption: caption}
+}
+
+// Table returns a table block with the given title (may be [Empty]) and rows
+// (pageBlockTable). Set Bordered and Striped on the result to control styling.
+func Table(title tg.RichTextClass, rows ...tg.PageTableRow) *tg.PageBlockTable {
+	return &tg.PageBlockTable{Title: title, Rows: rows}
+}
+
+// Row returns a table row of the given cells (pageTableRow).
+func Row(cells ...tg.PageTableCell) tg.PageTableRow {
+	return tg.PageTableRow{Cells: cells}
+}
+
+// Cell returns a table cell with the given text (pageTableCell). Set Header,
+// alignment, Colspan and Rowspan on the result as needed.
+func Cell(text tg.RichTextClass) tg.PageTableCell {
+	return tg.PageTableCell{Text: text}
+}
+
+// HeaderCell returns a header table cell with the given text (pageTableCell).
+func HeaderCell(text tg.RichTextClass) tg.PageTableCell {
+	c := Cell(text)
+	c.Header = true
+	return c
+}
+
+// RelatedArticles returns a related-articles block (pageBlockRelatedArticles).
+func RelatedArticles(title tg.RichTextClass, articles ...tg.PageRelatedArticle) *tg.PageBlockRelatedArticles {
+	return &tg.PageBlockRelatedArticles{Title: title, Articles: articles}
+}
+
+// Caption returns a page caption with optional credit (pageCaption). Pass
+// [Empty] for an absent text or credit.
+func Caption(text, credit tg.RichTextClass) tg.PageCaption {
+	return tg.PageCaption{Text: text, Credit: credit}
+}
+
+// ListItem returns an unordered list item holding inline text
+// (pageListItemText).
+func ListItem(text tg.RichTextClass) *tg.PageListItemText {
+	return &tg.PageListItemText{Text: text}
+}
+
+// CheckListItem returns an unordered task-list item holding inline text, with a
+// checkbox in the given checked state (pageListItemText).
+func CheckListItem(checked bool, text tg.RichTextClass) *tg.PageListItemText {
+	return &tg.PageListItemText{Checkbox: true, Checked: checked, Text: text}
+}
+
+// ListItemBlocks returns an unordered list item holding blocks
+// (pageListItemBlocks).
+func ListItemBlocks(blocks ...tg.PageBlockClass) *tg.PageListItemBlocks {
+	return &tg.PageListItemBlocks{Blocks: blocks}
+}
+
+// OrderedListItem returns an ordered list item holding inline text, labelled
+// with num (pageListOrderedItemText).
+func OrderedListItem(num string, text tg.RichTextClass) *tg.PageListOrderedItemText {
+	return &tg.PageListOrderedItemText{Num: num, Text: text}
+}
+
+// OrderedListItemBlocks returns an ordered list item holding blocks, labelled
+// with num (pageListOrderedItemBlocks).
+func OrderedListItemBlocks(num string, blocks ...tg.PageBlockClass) *tg.PageListOrderedItemBlocks {
+	return &tg.PageListOrderedItemBlocks{Num: num, Blocks: blocks}
+}

--- a/telegram/message/rich/html.go
+++ b/telegram/message/rich/html.go
@@ -1,0 +1,370 @@
+package rich
+
+import (
+	"io"
+	"strconv"
+	"strings"
+
+	"github.com/go-faster/errors"
+	"golang.org/x/net/html"
+
+	"github.com/gotd/td/tg"
+)
+
+// ParseHTML parses HTML from r into rich message blocks.
+//
+// It is a best-effort local renderer that covers the text-expressible subset of
+// rich content: paragraphs, headings (h1-h6), dividers (hr), block quotes,
+// preformatted/code blocks, ordered and unordered lists (including task lists),
+// tables, and inline formatting (bold, italic, underline, strikethrough,
+// fixed-width, spoiler, subscript, superscript, marked, links, anchors, custom
+// emoji and inline math). Unknown elements are unwrapped to their content.
+//
+// For full server-side fidelity (media, maps, footnotes and every documented
+// tag) send the HTML via [HTML] instead, which lets Telegram parse it.
+func ParseHTML(r io.Reader) ([]tg.PageBlockClass, error) {
+	root, err := html.Parse(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "parse html")
+	}
+	body := findBody(root)
+	if body == nil {
+		return nil, nil
+	}
+	return htmlBlocks(body), nil
+}
+
+func findBody(n *html.Node) *html.Node {
+	if n.Type == html.ElementNode && n.Data == "body" {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if b := findBody(c); b != nil {
+			return b
+		}
+	}
+	return nil
+}
+
+// htmlBlockTags is the set of element names handled as block-level.
+var htmlBlockTags = map[string]bool{
+	"p": true, "div": true, "section": true, "article": true,
+	"h1": true, "h2": true, "h3": true, "h4": true, "h5": true, "h6": true,
+	"hr": true, "blockquote": true, "pre": true,
+	"ul": true, "ol": true, "table": true, "details": true,
+}
+
+// htmlBlocks renders the block-level children of n, grouping runs of inline
+// content into paragraphs.
+func htmlBlocks(n *html.Node) []tg.PageBlockClass {
+	var (
+		blocks []tg.PageBlockClass
+		inline []tg.RichTextClass
+	)
+	flush := func() {
+		if t, ok := trimInline(inline); ok {
+			blocks = append(blocks, Paragraph(t))
+		}
+		inline = nil
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && htmlBlockTags[c.Data] {
+			flush()
+			blocks = append(blocks, htmlBlock(c)...)
+			continue
+		}
+		inline = append(inline, htmlInline(c)...)
+	}
+	flush()
+	return blocks
+}
+
+// htmlBlock renders a single block-level element.
+func htmlBlock(n *html.Node) []tg.PageBlockClass {
+	switch n.Data {
+	case "div", "section", "article":
+		return htmlBlocks(n)
+	case "p":
+		t, ok := trimInline(htmlInline(n))
+		if !ok {
+			return nil
+		}
+		return []tg.PageBlockClass{Paragraph(t)}
+	case "h1", "h2", "h3", "h4", "h5", "h6":
+		level, _ := strconv.Atoi(n.Data[1:])
+		return []tg.PageBlockClass{Heading(level, join(htmlInline(n)))}
+	case "hr":
+		return []tg.PageBlockClass{Divider()}
+	case "pre":
+		lang, text := htmlPre(n)
+		return []tg.PageBlockClass{Preformatted(Plain(text), lang)}
+	case "blockquote":
+		inner := htmlBlocks(n)
+		if len(inner) == 1 {
+			if p, ok := inner[0].(*tg.PageBlockParagraph); ok {
+				return []tg.PageBlockClass{Blockquote(p.Text, Empty())}
+			}
+		}
+		return []tg.PageBlockClass{BlockquoteBlocks(Empty(), inner...)}
+	case "ul":
+		return []tg.PageBlockClass{List(htmlListItems(n)...)}
+	case "ol":
+		return []tg.PageBlockClass{OrderedList(htmlOrderedItems(n)...)}
+	case "table":
+		return []tg.PageBlockClass{htmlTable(n)}
+	case "details":
+		return []tg.PageBlockClass{htmlDetails(n)}
+	default:
+		return htmlBlocks(n)
+	}
+}
+
+// htmlPre extracts the language (from a nested <code class="language-...">) and
+// text content of a <pre> block.
+func htmlPre(n *html.Node) (lang, text string) {
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "code" {
+			lang = strings.TrimPrefix(attr(c, "class"), "language-")
+		}
+	}
+	return lang, textContent(n)
+}
+
+func htmlListItems(n *html.Node) []tg.PageListItemClass {
+	var items []tg.PageListItemClass
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode || c.Data != "li" {
+			continue
+		}
+		checkbox, checked, body := htmlListItem(c)
+		item := ListItem(body)
+		if checkbox {
+			item.Checkbox = true
+			item.Checked = checked
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+func htmlOrderedItems(n *html.Node) []tg.PageListOrderedItemClass {
+	var items []tg.PageListOrderedItemClass
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode || c.Data != "li" {
+			continue
+		}
+		checkbox, checked, body := htmlListItem(c)
+		item := OrderedListItem("", body)
+		if checkbox {
+			item.Checkbox = true
+			item.Checked = checked
+		}
+		items = append(items, item)
+	}
+	return items
+}
+
+// htmlListItem renders a list item, detecting a leading task-list checkbox
+// (<input type="checkbox">).
+func htmlListItem(n *html.Node) (checkbox, checked bool, body tg.RichTextClass) {
+	var inline []tg.RichTextClass
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "input" && attr(c, "type") == "checkbox" {
+			checkbox = true
+			checked = hasAttr(c, "checked")
+			continue
+		}
+		inline = append(inline, htmlInline(c)...)
+	}
+	return checkbox, checked, join(trimZero(inline))
+}
+
+func htmlTable(n *html.Node) *tg.PageBlockTable {
+	var rows []tg.PageTableRow
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			if c.Type != html.ElementNode {
+				continue
+			}
+			switch c.Data {
+			case "thead", "tbody", "tfoot":
+				walk(c)
+			case "tr":
+				rows = append(rows, htmlTableRow(c))
+			}
+		}
+	}
+	walk(n)
+	t := Table(Empty(), rows...)
+	t.Bordered = true
+	return t
+}
+
+func htmlTableRow(n *html.Node) tg.PageTableRow {
+	var cells []tg.PageTableCell
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type != html.ElementNode || (c.Data != "td" && c.Data != "th") {
+			continue
+		}
+		cell := Cell(join(htmlInline(c)))
+		if c.Data == "th" {
+			cell.Header = true
+		}
+		if v, err := strconv.Atoi(attr(c, "colspan")); err == nil && v > 0 {
+			cell.Colspan = v
+		}
+		if v, err := strconv.Atoi(attr(c, "rowspan")); err == nil && v > 0 {
+			cell.Rowspan = v
+		}
+		cells = append(cells, cell)
+	}
+	return Row(cells...)
+}
+
+func htmlDetails(n *html.Node) *tg.PageBlockDetails {
+	var (
+		title  tg.RichTextClass = Empty()
+		blocks []tg.PageBlockClass
+		inline []tg.RichTextClass
+	)
+	flush := func() {
+		if t, ok := trimInline(inline); ok {
+			blocks = append(blocks, Paragraph(t))
+		}
+		inline = nil
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if c.Type == html.ElementNode && c.Data == "summary" {
+			title = join(htmlInline(c))
+			continue
+		}
+		if c.Type == html.ElementNode && htmlBlockTags[c.Data] {
+			flush()
+			blocks = append(blocks, htmlBlock(c)...)
+			continue
+		}
+		inline = append(inline, htmlInline(c)...)
+	}
+	flush()
+	return Details(hasAttr(n, "open"), title, blocks...)
+}
+
+// htmlInline renders a node and its descendants as inline rich text.
+func htmlInline(n *html.Node) []tg.RichTextClass {
+	switch n.Type {
+	case html.TextNode:
+		s := collapseWS(n.Data)
+		if s == "" {
+			return nil
+		}
+		return []tg.RichTextClass{Plain(s)}
+	case html.ElementNode:
+		return htmlInlineElement(n)
+	default:
+		return nil
+	}
+}
+
+func htmlInlineElement(n *html.Node) []tg.RichTextClass {
+	children := func() []tg.RichTextClass {
+		var out []tg.RichTextClass
+		for c := n.FirstChild; c != nil; c = c.NextSibling {
+			out = append(out, htmlInline(c)...)
+		}
+		return out
+	}
+
+	switch n.Data {
+	case "b", "strong":
+		return []tg.RichTextClass{Bold(children()...)}
+	case "i", "em":
+		return []tg.RichTextClass{Italic(children()...)}
+	case "u", "ins":
+		return []tg.RichTextClass{Underline(children()...)}
+	case "s", "strike", "del":
+		return []tg.RichTextClass{Strike(children()...)}
+	case "code", "tt", "kbd", "samp":
+		return []tg.RichTextClass{Fixed(children()...)}
+	case "sub":
+		return []tg.RichTextClass{Subscript(children()...)}
+	case "sup":
+		return []tg.RichTextClass{Superscript(children()...)}
+	case "mark":
+		return []tg.RichTextClass{Marked(children()...)}
+	case "tg-spoiler":
+		return []tg.RichTextClass{Spoiler(children()...)}
+	case "span":
+		if strings.Contains(attr(n, "class"), "tg-spoiler") {
+			return []tg.RichTextClass{Spoiler(children()...)}
+		}
+		return children()
+	case "tg-emoji":
+		id, err := strconv.ParseInt(attr(n, "emoji-id"), 10, 64)
+		if err != nil {
+			return children()
+		}
+		return []tg.RichTextClass{CustomEmoji(id, textContent(n))}
+	case "tg-math", "math":
+		return []tg.RichTextClass{Math(textContent(n))}
+	case "br":
+		return []tg.RichTextClass{Plain("\n")}
+	case "a":
+		return []tg.RichTextClass{htmlAnchor(n, children())}
+	default:
+		return children()
+	}
+}
+
+func htmlAnchor(n *html.Node, children []tg.RichTextClass) tg.RichTextClass {
+	text := join(children)
+	if name := attr(n, "name"); name != "" {
+		return Anchor(text, name)
+	}
+	href := attr(n, "href")
+	switch {
+	case href == "":
+		return text
+	case strings.HasPrefix(href, "#"):
+		return AnchorLink(text, strings.TrimPrefix(href, "#"))
+	case strings.HasPrefix(href, "mailto:"):
+		return Email(text, strings.TrimPrefix(href, "mailto:"))
+	default:
+		return URL(text, href, 0)
+	}
+}
+
+// textContent returns the concatenated text of a node and its descendants.
+func textContent(n *html.Node) string {
+	var sb strings.Builder
+	var walk func(*html.Node)
+	walk = func(node *html.Node) {
+		if node.Type == html.TextNode {
+			sb.WriteString(node.Data)
+			return
+		}
+		for c := node.FirstChild; c != nil; c = c.NextSibling {
+			walk(c)
+		}
+	}
+	walk(n)
+	return sb.String()
+}
+
+func attr(n *html.Node, key string) string {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return a.Val
+		}
+	}
+	return ""
+}
+
+func hasAttr(n *html.Node, key string) bool {
+	for _, a := range n.Attr {
+		if a.Key == key {
+			return true
+		}
+	}
+	return false
+}

--- a/telegram/message/rich/markdown.go
+++ b/telegram/message/rich/markdown.go
@@ -1,0 +1,542 @@
+package rich
+
+import (
+	"io"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/go-faster/errors"
+	"github.com/yuin/goldmark"
+	"github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/extension"
+	east "github.com/yuin/goldmark/extension/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+	"github.com/yuin/goldmark/util"
+	"golang.org/x/net/html"
+
+	"github.com/gotd/td/tg"
+)
+
+// mdRichParser parses GitHub Flavored Markdown (tables, task lists,
+// strikethrough, autolinks) plus raw HTML and the rich-only inline syntax
+// ==marked==, ||spoiler|| and $math$.
+var mdRichParser = newMarkdownParser()
+
+func newMarkdownParser() parser.Parser {
+	md := goldmark.New(goldmark.WithExtensions(extension.GFM))
+	md.Parser().AddOptions(parser.WithInlineParsers(
+		util.Prioritized(&mathParser{}, 150),
+		util.Prioritized(newPairParser('='), 500),
+		util.Prioritized(newPairParser('|'), 500),
+	))
+	return md.Parser()
+}
+
+// ParseMarkdown parses Markdown from r into rich message blocks.
+//
+// It is a best-effort local renderer following Rich Markdown (GitHub Flavored
+// Markdown plus Telegram extensions):
+//
+//   - Blocks: headings, paragraphs, thematic breaks, block quotes,
+//     fenced/indented code, ordered and unordered lists (including task lists),
+//     tables (with column alignment), and block math via $$...$$ or ```math.
+//   - Inline: **bold**, *italic*, ~~strikethrough~~, `code`, ==marked==,
+//     ||spoiler|| and $math$.
+//   - Links: [t](url), [t](mailto:..), [t](tel:..) and [t](tg://user?id=N);
+//     images ![alt](tg://emoji?id=N) and ![alt](tg://time?unix=N&format=F).
+//   - Any other rich inline styles (underline, subscript, superscript, anchors,
+//     ...) are recognized when written as embedded HTML tags (<u>, <sub>,
+//     <sup>, <a name>, ...), as Rich Markdown allows.
+//
+// Media images referencing a URL (![](photo.jpg)) and footnotes cannot be
+// resolved locally; for full server-side fidelity send the Markdown via
+// [Markdown] instead, which lets Telegram parse it.
+func ParseMarkdown(r io.Reader) ([]tg.PageBlockClass, error) {
+	source, err := io.ReadAll(r)
+	if err != nil {
+		return nil, errors.Wrap(err, "read")
+	}
+	doc := mdRichParser.Parse(text.NewReader(source))
+	return mdBlocks(doc, source), nil
+}
+
+// mdBlocks renders the block-level children of n.
+func mdBlocks(n ast.Node, source []byte) []tg.PageBlockClass {
+	var blocks []tg.PageBlockClass
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		blocks = append(blocks, mdBlock(c, source)...)
+	}
+	return blocks
+}
+
+func mdBlock(n ast.Node, source []byte) []tg.PageBlockClass {
+	switch n := n.(type) {
+	case *ast.Heading:
+		return []tg.PageBlockClass{Heading(n.Level, join(mdInline(n, source)))}
+	case *ast.Paragraph, *ast.TextBlock:
+		// A paragraph holding only a $$...$$ expression is a block-level formula.
+		if src, ok := soleDisplayMath(n); ok {
+			return []tg.PageBlockClass{MathBlock(src)}
+		}
+		if t, ok := trimInline(mdInline(n, source)); ok {
+			return []tg.PageBlockClass{Paragraph(t)}
+		}
+		return nil
+	case *ast.ThematicBreak:
+		return []tg.PageBlockClass{Divider()}
+	case *ast.Blockquote:
+		inner := mdBlocks(n, source)
+		if len(inner) == 1 {
+			if p, ok := inner[0].(*tg.PageBlockParagraph); ok {
+				return []tg.PageBlockClass{Blockquote(p.Text, Empty())}
+			}
+		}
+		return []tg.PageBlockClass{BlockquoteBlocks(Empty(), inner...)}
+	case *ast.FencedCodeBlock:
+		// A ```math fenced block is a block-level formula.
+		if lang := string(n.Language(source)); lang == "math" {
+			return []tg.PageBlockClass{MathBlock(mdCodeText(n, source))}
+		}
+		return []tg.PageBlockClass{Preformatted(Plain(mdCodeText(n, source)), string(n.Language(source)))}
+	case *ast.CodeBlock:
+		return []tg.PageBlockClass{Preformatted(Plain(mdCodeText(n, source)), "")}
+	case *ast.List:
+		return []tg.PageBlockClass{mdList(n, source)}
+	case *east.Table:
+		return []tg.PageBlockClass{mdTable(n, source)}
+	case *ast.HTMLBlock:
+		blocks, err := ParseHTML(strings.NewReader(mdRawText(n, source)))
+		if err != nil {
+			return nil
+		}
+		return blocks
+	default:
+		return mdBlocks(n, source)
+	}
+}
+
+func mdList(n *ast.List, source []byte) tg.PageBlockClass {
+	if n.IsOrdered() {
+		var items []tg.PageListOrderedItemClass
+		for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+			item, ok := c.(*ast.ListItem)
+			if !ok {
+				continue
+			}
+			checkbox, checked := mdTaskCheckbox(item)
+			it := OrderedListItem("", mdItemContent(item, source))
+			if checkbox {
+				it.Checkbox = true
+				it.Checked = checked
+			}
+			items = append(items, it)
+		}
+		return OrderedList(items...)
+	}
+
+	var items []tg.PageListItemClass
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		item, ok := c.(*ast.ListItem)
+		if !ok {
+			continue
+		}
+		checkbox, checked := mdTaskCheckbox(item)
+		it := ListItem(mdItemContent(item, source))
+		if checkbox {
+			it.Checkbox = true
+			it.Checked = checked
+		}
+		items = append(items, it)
+	}
+	return List(items...)
+}
+
+// mdItemContent renders a list item as a single inline rich text, joining its
+// block children.
+func mdItemContent(item *ast.ListItem, source []byte) tg.RichTextClass {
+	var texts []tg.RichTextClass
+	for c := item.FirstChild(); c != nil; c = c.NextSibling() {
+		switch c.(type) {
+		case *ast.Paragraph, *ast.TextBlock:
+			texts = append(texts, mdInline(c, source)...)
+		}
+	}
+	return join(trimZero(texts))
+}
+
+func mdTaskCheckbox(item *ast.ListItem) (checkbox, checked bool) {
+	fc := item.FirstChild()
+	if fc == nil {
+		return false, false
+	}
+	if cb, ok := fc.FirstChild().(*east.TaskCheckBox); ok {
+		return true, cb.IsChecked
+	}
+	return false, false
+}
+
+func mdTable(n *east.Table, source []byte) tg.PageBlockClass {
+	var rows []tg.PageTableRow
+	for r := n.FirstChild(); r != nil; r = r.NextSibling() {
+		switch r := r.(type) {
+		case *east.TableHeader:
+			rows = append(rows, mdTableRow(r, source, true))
+		case *east.TableRow:
+			rows = append(rows, mdTableRow(r, source, false))
+		}
+	}
+	t := Table(Empty(), rows...)
+	t.Bordered = true
+	return t
+}
+
+func mdTableRow(n ast.Node, source []byte, header bool) tg.PageTableRow {
+	var cells []tg.PageTableCell
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		tc, ok := c.(*east.TableCell)
+		if !ok {
+			continue
+		}
+		cell := Cell(join(mdInline(tc, source)))
+		cell.Header = header
+		switch tc.Alignment {
+		case east.AlignCenter:
+			cell.AlignCenter = true
+		case east.AlignRight:
+			cell.AlignRight = true
+		}
+		cells = append(cells, cell)
+	}
+	return Row(cells...)
+}
+
+// mdInline renders the inline children of n into rich text, tracking embedded
+// raw HTML tags with a stack so paired tags such as <sub>..</sub> wrap their
+// content.
+func mdInline(n ast.Node, source []byte) []tg.RichTextClass {
+	type frame struct {
+		name string
+		wrap func([]tg.RichTextClass) tg.RichTextClass
+		acc  []tg.RichTextClass
+	}
+	stack := []*frame{{}}
+	top := func() *frame { return stack[len(stack)-1] }
+	emit := func(ts ...tg.RichTextClass) { top().acc = append(top().acc, ts...) }
+	pop := func() {
+		f := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		top().acc = append(top().acc, f.wrap(f.acc))
+	}
+
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		raw, ok := c.(*ast.RawHTML)
+		if !ok {
+			emit(mdInlineNode(c, source)...)
+			continue
+		}
+		name, closing, selfClose, attrs := parseTag(mdRawText(raw, source))
+		switch {
+		case name == "":
+			continue
+		case closing:
+			for i := len(stack) - 1; i >= 1; i-- {
+				if stack[i].name == name {
+					for len(stack) > i {
+						pop()
+					}
+					break
+				}
+			}
+		case name == "br":
+			emit(Plain("\n"))
+		default:
+			wrap, supported := inlineWrapper(name, attrs)
+			if !supported {
+				continue
+			}
+			if selfClose {
+				emit(wrap(nil))
+				continue
+			}
+			stack = append(stack, &frame{name: name, wrap: wrap})
+		}
+	}
+	for len(stack) > 1 {
+		pop()
+	}
+	return stack[0].acc
+}
+
+func mdInlineNode(c ast.Node, source []byte) []tg.RichTextClass {
+	switch c := c.(type) {
+	case *ast.Text:
+		out := []tg.RichTextClass{Plain(string(util.UnescapePunctuations(c.Segment.Value(source))))}
+		if c.SoftLineBreak() || c.HardLineBreak() {
+			out = append(out, Plain("\n"))
+		}
+		return out
+	case *ast.String:
+		return []tg.RichTextClass{Plain(string(c.Value))}
+	case *ast.CodeSpan:
+		return []tg.RichTextClass{Fixed(Plain(astText(c, source)))}
+	case *ast.Emphasis:
+		inner := mdInline(c, source)
+		if c.Level >= 2 {
+			return []tg.RichTextClass{Bold(inner...)}
+		}
+		return []tg.RichTextClass{Italic(inner...)}
+	case *east.Strikethrough:
+		return []tg.RichTextClass{Strike(mdInline(c, source)...)}
+	case *markedNode:
+		return []tg.RichTextClass{Marked(mdInline(c, source)...)}
+	case *spoilerNode:
+		return []tg.RichTextClass{Spoiler(mdInline(c, source)...)}
+	case *mathNode:
+		return []tg.RichTextClass{Math(c.Source)}
+	case *ast.Link:
+		return []tg.RichTextClass{mdLink(string(c.Destination), mdInline(c, source))}
+	case *ast.AutoLink:
+		label := Plain(string(c.Label(source)))
+		url := string(c.URL(source))
+		if c.AutoLinkType == ast.AutoLinkEmail {
+			return []tg.RichTextClass{Email(label, url)}
+		}
+		return []tg.RichTextClass{URL(label, url, 0)}
+	case *ast.Image:
+		return []tg.RichTextClass{mdImage(string(c.Destination), mdInline(c, source))}
+	default:
+		return mdInline(c, source)
+	}
+}
+
+// soleDisplayMath reports whether n's only meaningful inline child is a $$...$$
+// display-math node and returns its source.
+func soleDisplayMath(n ast.Node) (string, bool) {
+	var math *mathNode
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if t, ok := c.(*ast.Text); ok && t.SoftLineBreak() && t.Segment.Len() == 0 {
+			continue
+		}
+		m, ok := c.(*mathNode)
+		if !ok || math != nil {
+			return "", false
+		}
+		math = m
+	}
+	if math == nil || !math.Display {
+		return "", false
+	}
+	return math.Source, true
+}
+
+func mdLink(dest string, inner []tg.RichTextClass) tg.RichTextClass {
+	text := join(inner)
+	switch {
+	case dest == "":
+		return text
+	case strings.HasPrefix(dest, "#"):
+		return AnchorLink(text, strings.TrimPrefix(dest, "#"))
+	case strings.HasPrefix(dest, "mailto:"):
+		return Email(text, strings.TrimPrefix(dest, "mailto:"))
+	case strings.HasPrefix(dest, "tel:"):
+		return Phone(text, strings.TrimPrefix(dest, "tel:"))
+	}
+
+	if u, err := url.Parse(dest); err == nil && u.Scheme == "tg" && u.Host == "user" {
+		if id, err := strconv.ParseInt(u.Query().Get("id"), 10, 64); err == nil {
+			return MentionName(text, id)
+		}
+	}
+	return URL(text, dest, 0)
+}
+
+// mdImage renders a Markdown image. tg://emoji and tg://time destinations map to
+// custom emoji and formatted-date rich text; media destinations cannot be
+// resolved locally and fall back to their alt text.
+func mdImage(dest string, alt []tg.RichTextClass) tg.RichTextClass {
+	u, err := url.Parse(dest)
+	if err != nil || u.Scheme != "tg" {
+		return join(alt)
+	}
+	switch u.Host {
+	case "emoji":
+		id, err := strconv.ParseInt(u.Query().Get("id"), 10, 64)
+		if err != nil {
+			return join(alt)
+		}
+		return CustomEmoji(id, plainText(alt))
+	case "time":
+		unix, err := strconv.Atoi(u.Query().Get("unix"))
+		if err != nil || unix <= 0 {
+			return join(alt)
+		}
+		return Date(join(alt), unix, parseDateFlags(u.Query().Get("format")))
+	default:
+		return join(alt)
+	}
+}
+
+// parseDateFlags parses a Telegram date format string (as in
+// tg://time?format=...) into DateFlags. "r"/"R" select relative time and must
+// be the only character; otherwise each character toggles a component.
+func parseDateFlags(format string) DateFlags {
+	if format == "r" || format == "R" {
+		return DateFlags{Relative: true}
+	}
+	var f DateFlags
+	for _, c := range format {
+		switch c {
+		case 't':
+			f.ShortTime = true
+		case 'T':
+			f.LongTime = true
+		case 'd':
+			f.ShortDate = true
+		case 'D':
+			f.LongDate = true
+		case 'w', 'W':
+			f.DayOfWeek = true
+		}
+	}
+	return f
+}
+
+// inlineWrapper maps an inline HTML tag onto a rich text wrapper.
+func inlineWrapper(name string, attrs map[string]string) (func([]tg.RichTextClass) tg.RichTextClass, bool) {
+	switch name {
+	case "b", "strong":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Bold(ts...) }, true
+	case "i", "em":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Italic(ts...) }, true
+	case "u", "ins":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Underline(ts...) }, true
+	case "s", "strike", "del":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Strike(ts...) }, true
+	case "code", "tt", "kbd", "samp":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Fixed(ts...) }, true
+	case "sub":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Subscript(ts...) }, true
+	case "sup":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Superscript(ts...) }, true
+	case "mark":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Marked(ts...) }, true
+	case "tg-spoiler":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Spoiler(ts...) }, true
+	case "span":
+		if strings.Contains(attrs["class"], "tg-spoiler") {
+			return func(ts []tg.RichTextClass) tg.RichTextClass { return Spoiler(ts...) }, true
+		}
+		return nil, false
+	case "tg-math", "math":
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return Math(plainText(ts)) }, true
+	case "tg-emoji":
+		id, err := strconv.ParseInt(attrs["emoji-id"], 10, 64)
+		if err != nil {
+			return nil, false
+		}
+		return func(ts []tg.RichTextClass) tg.RichTextClass { return CustomEmoji(id, plainText(ts)) }, true
+	case "a":
+		return func(ts []tg.RichTextClass) tg.RichTextClass {
+			if name := attrs["name"]; name != "" {
+				return Anchor(join(ts), name)
+			}
+			return mdLink(attrs["href"], ts)
+		}, true
+	default:
+		return nil, false
+	}
+}
+
+// parseTag parses a single HTML tag, returning its lower-cased name, whether it
+// is a closing or self-closing tag, and its attributes.
+func parseTag(raw string) (name string, closing, selfClose bool, attrs map[string]string) {
+	z := html.NewTokenizer(strings.NewReader(raw))
+	attrs = map[string]string{}
+	switch z.Next() {
+	case html.StartTagToken, html.SelfClosingTagToken, html.EndTagToken:
+		tn, hasAttr := z.TagName()
+		name = string(tn)
+		raw = strings.TrimSpace(raw)
+		closing = strings.HasPrefix(raw, "</")
+		selfClose = strings.HasSuffix(raw, "/>")
+		if hasAttr {
+			for {
+				k, v, more := z.TagAttr()
+				attrs[string(k)] = string(v)
+				if !more {
+					break
+				}
+			}
+		}
+	}
+	return name, closing, selfClose, attrs
+}
+
+// astText returns the concatenated literal text of an inline AST node.
+func astText(n ast.Node, source []byte) string {
+	var b strings.Builder
+	for c := n.FirstChild(); c != nil; c = c.NextSibling() {
+		if t, ok := c.(*ast.Text); ok {
+			b.Write(t.Segment.Value(source))
+		} else {
+			b.WriteString(astText(c, source))
+		}
+	}
+	return b.String()
+}
+
+// mdCodeText returns the raw text of a code block.
+func mdCodeText(n ast.Node, source []byte) string {
+	var b strings.Builder
+	lines := n.Lines()
+	for i := 0; i < lines.Len(); i++ {
+		seg := lines.At(i)
+		b.Write(seg.Value(source))
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+// mdRawText returns the raw source of an HTML node (block or inline).
+func mdRawText(n ast.Node, source []byte) string {
+	var b strings.Builder
+	switch n := n.(type) {
+	case *ast.RawHTML:
+		for i := 0; i < n.Segments.Len(); i++ {
+			seg := n.Segments.At(i)
+			b.Write(seg.Value(source))
+		}
+	case *ast.HTMLBlock:
+		lines := n.Lines()
+		for i := 0; i < lines.Len(); i++ {
+			seg := lines.At(i)
+			b.Write(seg.Value(source))
+		}
+		if n.HasClosure() {
+			b.Write(n.ClosureLine.Value(source))
+		}
+	}
+	return b.String()
+}
+
+// plainText extracts the plain text content of rich text nodes (best effort,
+// used for math sources and custom emoji alt text).
+func plainText(texts []tg.RichTextClass) string {
+	var b strings.Builder
+	var walk func(tg.RichTextClass)
+	walk = func(t tg.RichTextClass) {
+		switch t := t.(type) {
+		case *tg.TextPlain:
+			b.WriteString(t.Text)
+		case *tg.TextConcat:
+			for _, x := range t.Texts {
+				walk(x)
+			}
+		}
+	}
+	for _, t := range texts {
+		walk(t)
+	}
+	return b.String()
+}

--- a/telegram/message/rich/markdown_ext.go
+++ b/telegram/message/rich/markdown_ext.go
@@ -1,0 +1,117 @@
+package rich
+
+import (
+	gast "github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// Custom inline AST node kinds for the rich-only Markdown syntax that goldmark
+// does not parse natively: ==marked==, ||spoiler|| and $math$.
+var (
+	kindMarked  = gast.NewNodeKind("RichMarked")
+	kindSpoiler = gast.NewNodeKind("RichSpoiler")
+	kindMath    = gast.NewNodeKind("RichMath")
+)
+
+type markedNode struct{ gast.BaseInline }
+
+func (n *markedNode) Kind() gast.NodeKind        { return kindMarked }
+func (n *markedNode) Dump(src []byte, level int) { gast.DumpHelper(n, src, level, nil, nil) }
+
+type spoilerNode struct{ gast.BaseInline }
+
+func (n *spoilerNode) Kind() gast.NodeKind        { return kindSpoiler }
+func (n *spoilerNode) Dump(src []byte, level int) { gast.DumpHelper(n, src, level, nil, nil) }
+
+type mathNode struct {
+	gast.BaseInline
+	Source  string
+	Display bool
+}
+
+func (n *mathNode) Kind() gast.NodeKind        { return kindMath }
+func (n *mathNode) Dump(src []byte, level int) { gast.DumpHelper(n, src, level, nil, nil) }
+
+// pairDelimiterProcessor matches a paired two-character delimiter (== or ||).
+type pairDelimiterProcessor struct{ char byte }
+
+func (p *pairDelimiterProcessor) IsDelimiter(b byte) bool { return b == p.char }
+
+func (p *pairDelimiterProcessor) CanOpenCloser(opener, closer *parser.Delimiter) bool {
+	return opener.Char == closer.Char
+}
+
+func (p *pairDelimiterProcessor) OnMatch(int) gast.Node {
+	if p.char == '=' {
+		return &markedNode{}
+	}
+	return &spoilerNode{}
+}
+
+// pairParser parses a two-character paired delimiter such as ==text== (marked)
+// or ||text|| (spoiler).
+type pairParser struct {
+	char byte
+	proc *pairDelimiterProcessor
+}
+
+func newPairParser(char byte) *pairParser {
+	return &pairParser{char: char, proc: &pairDelimiterProcessor{char: char}}
+}
+
+func (s *pairParser) Trigger() []byte { return []byte{s.char} }
+
+func (s *pairParser) Parse(_ gast.Node, block text.Reader, pc parser.Context) gast.Node {
+	before := block.PrecendingCharacter()
+	line, segment := block.PeekLine()
+	node := parser.ScanDelimiter(line, before, 2, s.proc)
+	// Only a run of exactly two delimiter characters opens/closes the span.
+	if node == nil || node.OriginalLength != 2 {
+		return nil
+	}
+	node.Segment = segment.WithStop(segment.Start + node.OriginalLength)
+	block.Advance(node.OriginalLength)
+	pc.PushDelimiter(node)
+	return node
+}
+
+func (s *pairParser) CloseBlock(gast.Node, parser.Context) {}
+
+// mathParser parses inline $...$ and display $$...$$ mathematical expressions
+// whose content is literal LaTeX.
+type mathParser struct{}
+
+func (m *mathParser) Trigger() []byte { return []byte{'$'} }
+
+func (m *mathParser) Parse(_ gast.Node, block text.Reader, _ parser.Context) gast.Node {
+	line, _ := block.PeekLine()
+	if len(line) < 2 || line[0] != '$' {
+		return nil
+	}
+	display := line[1] == '$'
+	open := 1
+	if display {
+		open = 2
+	}
+
+	rest := line[open:]
+	closeIdx := -1
+	for i := 0; i+open <= len(rest); i++ {
+		if rest[i] != '$' {
+			continue
+		}
+		if open == 1 || (i+1 < len(rest) && rest[i+1] == '$') {
+			closeIdx = i
+			break
+		}
+	}
+	// Require non-empty content and a closing delimiter on the same line.
+	if closeIdx <= 0 {
+		return nil
+	}
+
+	source := string(rest[:closeIdx])
+	block.Advance(open + closeIdx + open)
+	return &mathNode{Source: source, Display: display}
+}

--- a/telegram/message/rich/message.go
+++ b/telegram/message/rich/message.go
@@ -1,0 +1,147 @@
+package rich
+
+import "github.com/gotd/td/tg"
+
+// Message assembles a [tg.InputRichMessage] from blocks and attachments.
+//
+// The zero value is not usable; create one with [New]. Methods return the same
+// pointer so they can be chained, and [Message.Input] produces the request
+// value.
+type Message struct {
+	msg tg.InputRichMessage
+}
+
+// New creates a rich message from the given top-level blocks.
+func New(blocks ...tg.PageBlockClass) *Message {
+	return &Message{msg: tg.InputRichMessage{Blocks: blocks}}
+}
+
+// Block appends top-level blocks to the message.
+func (m *Message) Block(blocks ...tg.PageBlockClass) *Message {
+	m.msg.Blocks = append(m.msg.Blocks, blocks...)
+	return m
+}
+
+// RTL marks the message as right-to-left.
+func (m *Message) RTL() *Message {
+	m.msg.Rtl = true
+	return m
+}
+
+// NoAutoLink disables automatic detection of links, mentions and similar
+// entities in the message text.
+func (m *Message) NoAutoLink() *Message {
+	m.msg.Noautolink = true
+	return m
+}
+
+// Photos sets the photos referenced by the message blocks.
+func (m *Message) Photos(photos ...tg.InputPhotoClass) *Message {
+	m.msg.Photos = photos
+	return m
+}
+
+// Documents sets the documents referenced by the message blocks.
+func (m *Message) Documents(documents ...tg.InputDocumentClass) *Message {
+	m.msg.Documents = documents
+	return m
+}
+
+// Users sets the users referenced by the message blocks.
+func (m *Message) Users(users ...tg.InputUserClass) *Message {
+	m.msg.Users = users
+	return m
+}
+
+// Input returns the assembled input rich message.
+func (m *Message) Input() *tg.InputRichMessage {
+	cp := m.msg
+	return &cp
+}
+
+// Source describes an HTML or Markdown rich message source to be parsed by
+// Telegram's servers, together with its attachments.
+//
+// The zero value is a valid empty source; configure it with the methods and
+// finalize it with [Source.HTML] or [Source.Markdown].
+type Source struct {
+	rtl        bool
+	noAutoLink bool
+	photos     []tg.InputPhotoClass
+	documents  []tg.InputDocumentClass
+	users      []tg.InputUserClass
+}
+
+// Rich starts a server-parsed rich message source.
+func Rich() *Source {
+	return &Source{}
+}
+
+// RTL marks the message as right-to-left.
+func (s *Source) RTL() *Source {
+	s.rtl = true
+	return s
+}
+
+// NoAutoLink disables automatic detection of links, mentions and similar
+// entities in the message text.
+func (s *Source) NoAutoLink() *Source {
+	s.noAutoLink = true
+	return s
+}
+
+// Photos sets the photos referenced by the message.
+func (s *Source) Photos(photos ...tg.InputPhotoClass) *Source {
+	s.photos = photos
+	return s
+}
+
+// Documents sets the documents referenced by the message.
+func (s *Source) Documents(documents ...tg.InputDocumentClass) *Source {
+	s.documents = documents
+	return s
+}
+
+// Users sets the users referenced by the message.
+func (s *Source) Users(users ...tg.InputUserClass) *Source {
+	s.users = users
+	return s
+}
+
+// HTML finalizes the source as an HTML rich message parsed by the server
+// (inputRichMessageHTML).
+func (s *Source) HTML(html string) *tg.InputRichMessageHTML {
+	return &tg.InputRichMessageHTML{
+		Rtl:        s.rtl,
+		Noautolink: s.noAutoLink,
+		HTML:       html,
+		Photos:     s.photos,
+		Documents:  s.documents,
+		Users:      s.users,
+	}
+}
+
+// Markdown finalizes the source as a Markdown rich message parsed by the server
+// (inputRichMessageMarkdown).
+func (s *Source) Markdown(markdown string) *tg.InputRichMessageMarkdown {
+	return &tg.InputRichMessageMarkdown{
+		Rtl:        s.rtl,
+		Noautolink: s.noAutoLink,
+		Markdown:   markdown,
+		Photos:     s.photos,
+		Documents:  s.documents,
+		Users:      s.users,
+	}
+}
+
+// HTML wraps an HTML source into an inputRichMessageHTML to be parsed by
+// Telegram's servers. For attachments or flags, use [Rich] instead.
+func HTML(html string) *tg.InputRichMessageHTML {
+	return Rich().HTML(html)
+}
+
+// Markdown wraps a Markdown source into an inputRichMessageMarkdown to be parsed
+// by Telegram's servers. For attachments or flags, use [Rich] instead.
+func Markdown(markdown string) *tg.InputRichMessageMarkdown {
+	return Rich().Markdown(markdown)
+}

--- a/telegram/message/rich/rich.go
+++ b/telegram/message/rich/rich.go
@@ -1,0 +1,38 @@
+// Package rich builds Telegram rich messages.
+//
+// Rich messages (layer 227, Bot API 10.1) carry highly structured content:
+// headings, paragraphs, lists, tables, block quotes, media, anchors, footnotes,
+// mathematical expressions and more. Unlike ordinary messages — which are a
+// flat string plus a list of [tg.MessageEntityClass] ranges — a rich message is
+// a tree of [tg.PageBlockClass] blocks whose inline text is a tree of
+// [tg.RichTextClass] nodes (the same model Telegram uses for Instant View
+// pages).
+//
+// This package provides three things:
+//
+//   - Builder helpers for every RichText and PageBlock constructor, e.g.
+//     [Bold], [Subscript], [Math], [Paragraph], [Heading1], [Table].
+//   - [Message], which assembles a [tg.InputRichMessage] from blocks.
+//   - [HTML] and [Markdown], which wrap an HTML or Markdown source into a
+//     [tg.InputRichMessageHTML] / [tg.InputRichMessageMarkdown] for server-side
+//     parsing, and [ParseHTML] / [ParseMarkdown], which parse a useful subset
+//     locally into blocks.
+//
+// The result is a [tg.InputRichMessageClass] that can be sent or edited through
+// the message sender (see (*message.Builder).RichMessage).
+package rich
+
+import "github.com/gotd/td/tg"
+
+// join collapses a list of rich texts into a single RichText node, wrapping
+// multiple nodes in a textConcat and returning textEmpty for none.
+func join(texts []tg.RichTextClass) tg.RichTextClass {
+	switch len(texts) {
+	case 0:
+		return &tg.TextEmpty{}
+	case 1:
+		return texts[0]
+	default:
+		return &tg.TextConcat{Texts: texts}
+	}
+}

--- a/telegram/message/rich/rich_test.go
+++ b/telegram/message/rich/rich_test.go
@@ -1,0 +1,297 @@
+package rich
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func parseHTML(t *testing.T, s string) []tg.PageBlockClass {
+	t.Helper()
+	blocks, err := ParseHTML(strings.NewReader(s))
+	require.NoError(t, err)
+	return blocks
+}
+
+func parseMarkdown(t *testing.T, s string) []tg.PageBlockClass {
+	t.Helper()
+	blocks, err := ParseMarkdown(strings.NewReader(s))
+	require.NoError(t, err)
+	return blocks
+}
+
+func TestParseHTML(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		want []tg.PageBlockClass
+	}{
+		{
+			name: "Paragraph",
+			in:   "<p>Hello <b>world</b></p>",
+			want: []tg.PageBlockClass{Paragraph(Concat(Plain("Hello "), Bold(Plain("world"))))},
+		},
+		{
+			name: "Headings",
+			in:   "<h1>One</h1><h3>Three</h3>",
+			want: []tg.PageBlockClass{Heading1(Plain("One")), Heading3(Plain("Three"))},
+		},
+		{
+			name: "Divider",
+			in:   "<p>a</p><hr><p>b</p>",
+			want: []tg.PageBlockClass{Paragraph(Plain("a")), Divider(), Paragraph(Plain("b"))},
+		},
+		{
+			name: "Subscript and superscript",
+			in:   "<p>H<sub>2</sub>O and E=mc<sup>2</sup></p>",
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Plain("H"), Subscript(Plain("2")), Plain("O and E=mc"), Superscript(Plain("2")),
+			))},
+		},
+		{
+			name: "Marked and spoiler and math",
+			in:   `<p><mark>hi</mark> <tg-spoiler>secret</tg-spoiler> <tg-math>x^2</tg-math></p>`,
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Marked(Plain("hi")), Plain(" "), Spoiler(Plain("secret")), Plain(" "), Math("x^2"),
+			))},
+		},
+		{
+			name: "Anchor and anchor link",
+			in:   `<p><a name="top">Top</a> <a href="#top">back</a></p>`,
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Anchor(Plain("Top"), "top"), Plain(" "), AnchorLink(Plain("back"), "top"),
+			))},
+		},
+		{
+			name: "Link and email",
+			in:   `<p><a href="https://go.dev">Go</a> <a href="mailto:a@b.c">mail</a></p>`,
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				URL(Plain("Go"), "https://go.dev", 0), Plain(" "), Email(Plain("mail"), "a@b.c"),
+			))},
+		},
+		{
+			name: "Preformatted",
+			in:   `<pre><code class="language-go">x := 1</code></pre>`,
+			want: []tg.PageBlockClass{Preformatted(Plain("x := 1"), "go")},
+		},
+		{
+			name: "Blockquote",
+			in:   "<blockquote><p>quoted</p></blockquote>",
+			want: []tg.PageBlockClass{Blockquote(Plain("quoted"), Empty())},
+		},
+		{
+			name: "Unordered list",
+			in:   "<ul><li>one</li><li>two</li></ul>",
+			want: []tg.PageBlockClass{List(ListItem(Plain("one")), ListItem(Plain("two")))},
+		},
+		{
+			name: "Task list",
+			in:   `<ul><li><input type="checkbox" checked>done</li><li><input type="checkbox">todo</li></ul>`,
+			want: []tg.PageBlockClass{List(
+				CheckListItem(true, Plain("done")),
+				CheckListItem(false, Plain("todo")),
+			)},
+		},
+		{
+			name: "Table",
+			in:   "<table><tr><th>A</th><th>B</th></tr><tr><td>1</td><td>2</td></tr></table>",
+			want: []tg.PageBlockClass{func() tg.PageBlockClass {
+				tbl := Table(Empty(),
+					Row(HeaderCell(Plain("A")), HeaderCell(Plain("B"))),
+					Row(Cell(Plain("1")), Cell(Plain("2"))),
+				)
+				tbl.Bordered = true
+				return tbl
+			}()},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseHTML(t, tt.in))
+		})
+	}
+}
+
+func TestParseMarkdown(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   string
+		want []tg.PageBlockClass
+	}{
+		{
+			name: "Heading",
+			in:   "# Title",
+			want: []tg.PageBlockClass{Heading1(Plain("Title"))},
+		},
+		{
+			name: "Bold italic",
+			in:   "**bold** and *italic*",
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Bold(Plain("bold")), Plain(" and "), Italic(Plain("italic")),
+			))},
+		},
+		{
+			name: "Strikethrough",
+			in:   "~~gone~~",
+			want: []tg.PageBlockClass{Paragraph(Strike(Plain("gone")))},
+		},
+		{
+			name: "Inline code",
+			in:   "`code`",
+			want: []tg.PageBlockClass{Paragraph(Fixed(Plain("code")))},
+		},
+		{
+			name: "Link",
+			in:   "[Go](https://go.dev)",
+			want: []tg.PageBlockClass{Paragraph(URL(Plain("Go"), "https://go.dev", 0))},
+		},
+		{
+			name: "Thematic break",
+			in:   "a\n\n---\n\nb",
+			want: []tg.PageBlockClass{Paragraph(Plain("a")), Divider(), Paragraph(Plain("b"))},
+		},
+		{
+			name: "Fenced code",
+			in:   "```go\nx := 1\n```",
+			want: []tg.PageBlockClass{Preformatted(Plain("x := 1"), "go")},
+		},
+		{
+			name: "Blockquote",
+			in:   "> quoted",
+			want: []tg.PageBlockClass{Blockquote(Plain("quoted"), Empty())},
+		},
+		{
+			name: "Unordered list",
+			in:   "- one\n- two",
+			want: []tg.PageBlockClass{List(ListItem(Plain("one")), ListItem(Plain("two")))},
+		},
+		{
+			name: "Task list",
+			in:   "- [x] done\n- [ ] todo",
+			want: []tg.PageBlockClass{List(
+				CheckListItem(true, Plain("done")),
+				CheckListItem(false, Plain("todo")),
+			)},
+		},
+		{
+			name: "Embedded subscript HTML",
+			in:   "H<sub>2</sub>O",
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Plain("H"), Subscript(Plain("2")), Plain("O"),
+			))},
+		},
+		{
+			name: "Ordered list",
+			in:   "1. one\n2. two",
+			want: []tg.PageBlockClass{OrderedList(
+				OrderedListItem("", Plain("one")),
+				OrderedListItem("", Plain("two")),
+			)},
+		},
+		{
+			name: "Multi-paragraph blockquote",
+			in:   "> one\n>\n> two",
+			want: []tg.PageBlockClass{BlockquoteBlocks(Empty(),
+				Paragraph(Plain("one")),
+				Paragraph(Plain("two")),
+			)},
+		},
+		{
+			name: "Marked",
+			in:   "==marked text==",
+			want: []tg.PageBlockClass{Paragraph(Marked(Plain("marked text")))},
+		},
+		{
+			name: "Spoiler",
+			in:   "||spoiler||",
+			want: []tg.PageBlockClass{Paragraph(Spoiler(Plain("spoiler")))},
+		},
+		{
+			name: "Inline math",
+			in:   "before $x^2 + y^2$ after",
+			want: []tg.PageBlockClass{Paragraph(Concat(
+				Plain("before "), Math("x^2 + y^2"), Plain(" after"),
+			))},
+		},
+		{
+			name: "Display math",
+			in:   "$$E = mc^2$$",
+			want: []tg.PageBlockClass{MathBlock("E = mc^2")},
+		},
+		{
+			name: "Fenced math",
+			in:   "```math\nE = mc^2\n```",
+			want: []tg.PageBlockClass{MathBlock("E = mc^2")},
+		},
+		{
+			name: "Phone link",
+			in:   "[call](tel:+123456789)",
+			want: []tg.PageBlockClass{Paragraph(Phone(Plain("call"), "+123456789"))},
+		},
+		{
+			name: "User mention link",
+			in:   "[me](tg://user?id=123456789)",
+			want: []tg.PageBlockClass{Paragraph(MentionName(Plain("me"), 123456789))},
+		},
+		{
+			name: "Custom emoji image",
+			in:   "![👍](tg://emoji?id=5368324170671202286)",
+			want: []tg.PageBlockClass{Paragraph(CustomEmoji(5368324170671202286, "👍"))},
+		},
+		{
+			name: "Date image",
+			in:   "![22:45 tomorrow](tg://time?unix=1647531900&format=wDT)",
+			want: []tg.PageBlockClass{Paragraph(Date(Plain("22:45 tomorrow"), 1647531900, DateFlags{
+				LongTime:  true,
+				LongDate:  true,
+				DayOfWeek: true,
+			}))},
+		},
+		{
+			name: "Table alignment",
+			in:   "| H1 | H2 |\n|:---|:--:|\n| a | b |",
+			want: []tg.PageBlockClass{func() tg.PageBlockClass {
+				h2 := HeaderCell(Plain("H2"))
+				h2.AlignCenter = true
+				b := Cell(Plain("b"))
+				b.AlignCenter = true
+				tbl := Table(Empty(),
+					Row(HeaderCell(Plain("H1")), h2),
+					Row(Cell(Plain("a")), b),
+				)
+				tbl.Bordered = true
+				return tbl
+			}()},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseMarkdown(t, tt.in))
+		})
+	}
+}
+
+func TestMessage(t *testing.T) {
+	msg := New(Heading1(Plain("Title"))).
+		Block(Paragraph(Plain("body"))).
+		RTL().
+		NoAutoLink().
+		Input()
+
+	require.True(t, msg.Rtl)
+	require.True(t, msg.Noautolink)
+	require.Equal(t, []tg.PageBlockClass{
+		Heading1(Plain("Title")),
+		Paragraph(Plain("body")),
+	}, msg.Blocks)
+}
+
+func TestSourceConstructors(t *testing.T) {
+	h := Rich().RTL().HTML("<p>hi</p>")
+	require.Equal(t, "<p>hi</p>", h.HTML)
+	require.True(t, h.Rtl)
+
+	m := Markdown("# hi")
+	require.Equal(t, "# hi", m.Markdown)
+}

--- a/telegram/message/rich/text.go
+++ b/telegram/message/rich/text.go
@@ -1,0 +1,189 @@
+package rich
+
+import "github.com/gotd/td/tg"
+
+// Empty returns an empty rich text node (textEmpty).
+func Empty() *tg.TextEmpty {
+	return &tg.TextEmpty{}
+}
+
+// Plain returns a plain (unstyled) rich text node (textPlain).
+func Plain(s string) *tg.TextPlain {
+	return &tg.TextPlain{Text: s}
+}
+
+// Concat concatenates the given rich text nodes (textConcat).
+func Concat(texts ...tg.RichTextClass) *tg.TextConcat {
+	return &tg.TextConcat{Texts: texts}
+}
+
+// Bold formats the given text as bold (textBold).
+func Bold(texts ...tg.RichTextClass) *tg.TextBold {
+	return &tg.TextBold{Text: join(texts)}
+}
+
+// Italic formats the given text as italic (textItalic).
+func Italic(texts ...tg.RichTextClass) *tg.TextItalic {
+	return &tg.TextItalic{Text: join(texts)}
+}
+
+// Underline formats the given text as underlined (textUnderline).
+func Underline(texts ...tg.RichTextClass) *tg.TextUnderline {
+	return &tg.TextUnderline{Text: join(texts)}
+}
+
+// Strike formats the given text as strikethrough (textStrike).
+func Strike(texts ...tg.RichTextClass) *tg.TextStrike {
+	return &tg.TextStrike{Text: join(texts)}
+}
+
+// Fixed formats the given text as fixed-width / monospace (textFixed).
+func Fixed(texts ...tg.RichTextClass) *tg.TextFixed {
+	return &tg.TextFixed{Text: join(texts)}
+}
+
+// Subscript formats the given text as subscript (textSubscript).
+func Subscript(texts ...tg.RichTextClass) *tg.TextSubscript {
+	return &tg.TextSubscript{Text: join(texts)}
+}
+
+// Superscript formats the given text as superscript (textSuperscript).
+func Superscript(texts ...tg.RichTextClass) *tg.TextSuperscript {
+	return &tg.TextSuperscript{Text: join(texts)}
+}
+
+// Marked formats the given text as marked / highlighted (textMarked).
+func Marked(texts ...tg.RichTextClass) *tg.TextMarked {
+	return &tg.TextMarked{Text: join(texts)}
+}
+
+// Spoiler formats the given text as a spoiler (textSpoiler).
+func Spoiler(texts ...tg.RichTextClass) *tg.TextSpoiler {
+	return &tg.TextSpoiler{Text: join(texts)}
+}
+
+// Mention formats the given text as a username mention (textMention).
+func Mention(texts ...tg.RichTextClass) *tg.TextMention {
+	return &tg.TextMention{Text: join(texts)}
+}
+
+// Hashtag formats the given text as a hashtag (textHashtag).
+func Hashtag(texts ...tg.RichTextClass) *tg.TextHashtag {
+	return &tg.TextHashtag{Text: join(texts)}
+}
+
+// BotCommand formats the given text as a bot command (textBotCommand).
+func BotCommand(texts ...tg.RichTextClass) *tg.TextBotCommand {
+	return &tg.TextBotCommand{Text: join(texts)}
+}
+
+// Cashtag formats the given text as a cashtag (textCashtag).
+func Cashtag(texts ...tg.RichTextClass) *tg.TextCashtag {
+	return &tg.TextCashtag{Text: join(texts)}
+}
+
+// BankCard formats the given text as a bank card number (textBankCard).
+func BankCard(texts ...tg.RichTextClass) *tg.TextBankCard {
+	return &tg.TextBankCard{Text: join(texts)}
+}
+
+// AutoURL formats the given text as an automatically detected URL (textAutoUrl).
+func AutoURL(texts ...tg.RichTextClass) *tg.TextAutoURL {
+	return &tg.TextAutoURL{Text: join(texts)}
+}
+
+// AutoEmail formats the given text as an automatically detected email address
+// (textAutoEmail).
+func AutoEmail(texts ...tg.RichTextClass) *tg.TextAutoEmail {
+	return &tg.TextAutoEmail{Text: join(texts)}
+}
+
+// AutoPhone formats the given text as an automatically detected phone number
+// (textAutoPhone).
+func AutoPhone(texts ...tg.RichTextClass) *tg.TextAutoPhone {
+	return &tg.TextAutoPhone{Text: join(texts)}
+}
+
+// URL formats the given text as a link to url (textUrl).
+//
+// webpageID may be zero if the linked webpage is not previewed.
+func URL(text tg.RichTextClass, url string, webpageID int64) *tg.TextURL {
+	return &tg.TextURL{Text: text, URL: url, WebpageID: webpageID}
+}
+
+// Email formats the given text as a link to an email address (textEmail).
+func Email(text tg.RichTextClass, email string) *tg.TextEmail {
+	return &tg.TextEmail{Text: text, Email: email}
+}
+
+// Phone formats the given text as a link to a phone number (textPhone).
+func Phone(text tg.RichTextClass, phone string) *tg.TextPhone {
+	return &tg.TextPhone{Text: text, Phone: phone}
+}
+
+// Anchor marks the given text as the target of an in-document anchor with the
+// given name (textAnchor). See [AnchorLink] to link to it.
+func Anchor(text tg.RichTextClass, name string) *tg.TextAnchor {
+	return &tg.TextAnchor{Text: text, Name: name}
+}
+
+// AnchorLink links the given text to an in-document [Anchor] with the given
+// name, rendered as a relative URL.
+func AnchorLink(text tg.RichTextClass, name string) *tg.TextURL {
+	return &tg.TextURL{Text: text, URL: "#" + name}
+}
+
+// Math returns an inline mathematical expression with the given LaTeX source
+// (textMath).
+func Math(source string) *tg.TextMath {
+	return &tg.TextMath{Source: source}
+}
+
+// Image returns an inline image referencing a document by ID with the given
+// size in pixels (textImage).
+func Image(documentID int64, w, h int) *tg.TextImage {
+	return &tg.TextImage{DocumentID: documentID, W: w, H: h}
+}
+
+// CustomEmoji returns an inline custom emoji referencing a document by ID, with
+// the given fallback alt text (textCustomEmoji).
+func CustomEmoji(documentID int64, alt string) *tg.TextCustomEmoji {
+	return &tg.TextCustomEmoji{DocumentID: documentID, Alt: alt}
+}
+
+// MentionName formats the given text as a mention of a user by ID
+// (textMentionName).
+func MentionName(text tg.RichTextClass, userID int64) *tg.TextMentionName {
+	return &tg.TextMentionName{Text: text, UserID: userID}
+}
+
+// DateFlags selects which components of a [Date] are rendered.
+type DateFlags struct {
+	// Relative renders the date relative to now ("5 minutes ago").
+	Relative bool
+	// ShortTime renders a short time.
+	ShortTime bool
+	// LongTime renders a long time.
+	LongTime bool
+	// ShortDate renders a short date.
+	ShortDate bool
+	// LongDate renders a long date.
+	LongDate bool
+	// DayOfWeek renders the day of the week.
+	DayOfWeek bool
+}
+
+// Date formats the given text as the Unix timestamp date, rendered according to
+// flags (textDate).
+func Date(text tg.RichTextClass, date int, flags DateFlags) *tg.TextDate {
+	return &tg.TextDate{
+		Relative:  flags.Relative,
+		ShortTime: flags.ShortTime,
+		LongTime:  flags.LongTime,
+		ShortDate: flags.ShortDate,
+		LongDate:  flags.LongDate,
+		DayOfWeek: flags.DayOfWeek,
+		Text:      text,
+		Date:      date,
+	}
+}

--- a/telegram/message/rich/whitespace.go
+++ b/telegram/message/rich/whitespace.go
@@ -1,0 +1,79 @@
+package rich
+
+import (
+	"strings"
+
+	"github.com/gotd/td/tg"
+)
+
+func isSpace(r rune) bool {
+	switch r {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+// collapseWS collapses runs of inline whitespace into single spaces, preserving
+// a single leading and trailing space, following HTML inline whitespace rules.
+// Whitespace-only input collapses to a single space; empty input stays empty.
+func collapseWS(s string) string {
+	var b strings.Builder
+	pending := false
+	started := false
+	for _, r := range s {
+		if isSpace(r) {
+			pending = true
+			continue
+		}
+		if pending {
+			b.WriteByte(' ')
+			pending = false
+		}
+		b.WriteRune(r)
+		started = true
+	}
+	if pending && (started || b.Len() == 0 && s != "") {
+		b.WriteByte(' ')
+	}
+	return b.String()
+}
+
+// isBlankPlain reports whether t is a plain text node containing only
+// whitespace.
+func isBlankPlain(t tg.RichTextClass) bool {
+	p, ok := t.(*tg.TextPlain)
+	return ok && strings.TrimSpace(p.Text) == ""
+}
+
+// trimZero drops leading and trailing whitespace-only plain nodes and trims the
+// outer whitespace of the remaining edge plain nodes.
+func trimZero(texts []tg.RichTextClass) []tg.RichTextClass {
+	for len(texts) > 0 && isBlankPlain(texts[0]) {
+		texts = texts[1:]
+	}
+	for len(texts) > 0 && isBlankPlain(texts[len(texts)-1]) {
+		texts = texts[:len(texts)-1]
+	}
+	if len(texts) == 0 {
+		return nil
+	}
+	if p, ok := texts[0].(*tg.TextPlain); ok {
+		texts[0] = Plain(strings.TrimLeft(p.Text, " \t\r\n\f"))
+	}
+	if p, ok := texts[len(texts)-1].(*tg.TextPlain); ok {
+		texts[len(texts)-1] = Plain(strings.TrimRight(p.Text, " \t\r\n\f"))
+	}
+	return texts
+}
+
+// trimInline trims whitespace around an inline run and reports whether any
+// meaningful content remains.
+func trimInline(texts []tg.RichTextClass) (tg.RichTextClass, bool) {
+	texts = trimZero(texts)
+	if len(texts) == 0 {
+		return nil, false
+	}
+	return join(texts), true
+}


### PR DESCRIPTION
## Summary

Layer 227 (Bot API 10.1) introduced **Rich Messages** — highly structured content (headings, lists, tables, block quotes, media, anchors, footnotes, math, ...) built from a tree of `RichText` inline nodes and `PageBlock` blocks (the Instant View model), and sent via the `rich_message` field of `messages.sendMessage` / `messages.editMessage`.

This adds a new `telegram/message/rich` package plus the send/edit plumbing.

## What's included

**Builder helpers** (`text.go`, `block.go`) for every `tg.RichTextClass` and `tg.PageBlockClass` constructor, plus `PageCaption`, list items, ordered list items, table rows/cells and related articles.

**Assembly** (`message.go`):
- `Message` builds a `tg.InputRichMessage` from blocks and attachments (photos/documents/users, `rtl`/`noautolink`).
- `Rich()`, `HTML()`, `Markdown()` produce `InputRichMessageHTML` / `InputRichMessageMarkdown` for full **server-side** parsing.

**Local parsers** (`html.go`, `markdown.go`, `markdown_ext.go`): `ParseHTML` and `ParseMarkdown` render a best-effort `[]tg.PageBlockClass` for the text-expressible subset. Rich Markdown follows GFM plus Telegram extensions:
- `==marked==`, `||spoiler||`, `$inline$` / `$$display$$` math, ` ```math ` fences
- GFM table column alignment
- `tel:` / `tg://user` link schemes and `tg://emoji` / `tg://time` image schemes

There is no client-side reference parser (Rich HTML/Markdown is parsed by Telegram's servers via the `Input*` constructors); URL-referenced media and footnotes are therefore left to the server-side path and documented as such.

**Send/edit plumbing** (`rich.go`): `(*message.Builder).RichMessage` and `(*message.EditMessageBuilder).RichMessage` route a `tg.InputRichMessageClass` through `messages.sendMessage` / `messages.editMessage`.

## Testing

`go build ./...`, `go vet`, `gofmt -l` (clean) and `go test -race ./telegram/message/...` all pass. `rich_test.go` covers the HTML and Markdown parsers (including all the rich-only Markdown syntaxes), the `Message` builder and the source constructors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)