### PR TITLE
feat(gen): derive mappings with caller-supplied parameters

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -30,7 +30,14 @@ Triage of all open issues as of 2026-06-11. Grouped into **Invalid**, **Already 
   users/channels already covered by `telegram/peers`), #825 → tdesktop modern `key_datas`
   layout: `session/tdesktop` now prefers the modern `s`-suffixed file over legacy `0`/`1`
   (matching Telegram Desktop), so a stale legacy file no longer shadows the current one;
-  added an end-to-end modern-layout read test.
+  added an end-to-end modern-layout read test, #376 → parameterized `As`-mappers: the
+  code generator now exposes target fields that can't be derived from the source
+  constructor as method parameters instead of skipping the mapping. `thumb_size` on
+  file-location inputs is supplied by the caller, so `Document`/`InputDocument` gain
+  `AsInputDocumentFileLocation(thumbSize string)` and `Photo`/`InputPhoto` get a new
+  `AsInputPhotoFileLocation(thumbSize string)` (previously dropped because `thumb_size`
+  is required); `telegram/query/messages` now uses these mappers instead of building the
+  location structs by hand.
 - **Done (partial — tgtest server epic):** #199 → personal-messages service
   (`tgtest/services/messages`): implements `messages.sendMessage` (stores the
   dialog, echoes the sent message back as `UpdateMessageID`+`UpdateNewMessage`)
@@ -164,7 +171,7 @@ Legitimate open bugs and actionable enhancements. Tracked in the backlog issue.
 | 615 | auth: helpers for (re)setting/updating/recovering password | **done — recovery helpers added** |
 | 597 | bot: fix inspection of service messages | open (lives in `gotd/bot`) |
 | 392 | mtproto: containerize small messages | open |
-| 376 | gen: derive mappings with parameters | open |
+| 376 | gen: derive mappings with parameters | **done — see Progress** |
 | 283 | query: generate resolve helpers when query needs peer parameter | open |
 | 263 | client: improve FLOOD_WAIT handling | open |
 | 217 | client: get-by-id helpers | **done — see Progress** |

--- a/examples/gif-download/main.go
+++ b/examples/gif-download/main.go
@@ -165,7 +165,8 @@ func run(ctx context.Context) error {
 					}
 
 					// Downloading gif to gifPath.
-					loc := doc.AsInputDocumentFileLocation()
+					// Empty thumb size downloads the full document, not a thumbnail.
+					loc := doc.AsInputDocumentFileLocation("")
 					if _, err := d.Download(api, loc).ToPath(ctx, gifPath); err != nil {
 						return errors.Wrap(err, "download")
 					}

--- a/gen/_template/interface_mapping.tmpl
+++ b/gen/_template/interface_mapping.tmpl
@@ -42,6 +42,9 @@ func ({{ $s.Receiver }} *{{ $s.Name }}) {{ template "mapper_func_type" $mapping 
         {{- end }}
     {{- end }}
     {{- end }}
+    {{- range $param := $mapping.Params }}
+    value.{{ $param.Name }} = {{ camel $param.RawName }}
+    {{- end }}
 
     return value
 {{- else }}

--- a/gen/_template/utils.tmpl
+++ b/gen/_template/utils.tmpl
@@ -34,9 +34,13 @@ Get{{$.Name}}() (value {{ template "print_type" $ }}{{ if and ($.Conditional) (n
 {{- if not ($mapping.Concrete) }}{{ $mapping.Name }}{{- else }}*{{ $mapping.Name }}{{- end -}}
 {{ end }}
 
+{{ define "mapper_params" }}{{- /*gotype: []github.com/gotd/td/gen.fieldDef*/ -}}
+{{- range $i, $p := . }}{{ if $i }}, {{ end }}{{ camel $p.RawName }} {{ template "print_type" $p }}{{ end }}
+{{- end }}
+
 {{ define "mapper_func_type" }}{{ $mapping := . -}}
 {{- /*gotype: github.com/gotd/td/gen.constructorMapping*/ -}}
-{{- if $mapping.Fields }}As{{ $mapping.MapperName }}() {{ template "print_mapper_type" $mapping }}
+{{- if $mapping.Fields }}As{{ $mapping.MapperName }}({{ template "mapper_params" $mapping.Params }}) {{ template "print_mapper_type" $mapping }}
 {{- else }}As{{ $mapping.MapperName }}() ({{ template "print_mapper_type" $mapping }}, bool)
 {{- end }}{{- end }}
 

--- a/gen/fields.go
+++ b/gen/fields.go
@@ -4,15 +4,19 @@ import (
 	"strings"
 )
 
-func optionalField(s structDef, f fieldDef) bool {
-	switch {
-	case f.Conditional:
-		return true
-	case f.Type == "string" && f.Name == "ThumbSize":
-		return s.RawName == "inputDocumentFileLocation"
-	}
+func optionalField(_ structDef, f fieldDef) bool {
+	return f.Conditional
+}
 
-	return false
+// parameterField reports whether an unmapped field of the target constructor
+// should be exposed as a parameter of the generated As-mapper instead of
+// causing the mapping to be skipped.
+//
+// thumb_size on inputDocumentFileLocation/inputPhotoFileLocation is required by
+// the wire format but cannot be derived from the source constructor, so the
+// caller selects the thumbnail by passing it in. See issue #376.
+func parameterField(_ structDef, f fieldDef) bool {
+	return !f.Conditional && f.Type == "string" && f.RawName == "thumb_size"
 }
 
 func hasField(fields []fieldDef, name, typ string) bool {
@@ -45,10 +49,21 @@ func mappableFields(constructor, to structDef) (constructorMapping, bool) {
 		}
 	}
 
+	// Fields that can't be derived from the constructor but should still be
+	// filled by the caller via generated method parameters.
+	var params []fieldDef
 	// Return false if we can't fill all fields.
 	if len(mapped) != len(to.Fields) {
 		for _, field := range to.Fields {
-			if _, ok := mapped[field.Name]; !ok && !optionalField(to, field) {
+			if _, ok := mapped[field.Name]; ok {
+				continue
+			}
+			switch {
+			case optionalField(to, field):
+				// Optional in the wire format, left unset.
+			case parameterField(to, field):
+				params = append(params, field)
+			default:
 				return constructorMapping{}, false
 			}
 		}
@@ -67,6 +82,7 @@ func mappableFields(constructor, to structDef) (constructorMapping, bool) {
 		Concrete:    true,
 		MapperName:  mapperName,
 		Fields:      r,
+		Params:      params,
 	}
 
 	return mapping, true

--- a/gen/fields_test.go
+++ b/gen/fields_test.go
@@ -1,0 +1,89 @@
+package gen
+
+import (
+	"testing"
+)
+
+func fieldNames(fields []fieldDef) []string {
+	names := make([]string, len(fields))
+	for i, f := range fields {
+		names[i] = f.Name
+	}
+	return names
+}
+
+func TestMappableFields(t *testing.T) {
+	longField := func(name, raw string) fieldDef {
+		return fieldDef{Name: name, RawName: raw, Type: "int64", Func: "Long"}
+	}
+	bytesField := func(name, raw string) fieldDef {
+		return fieldDef{Name: name, RawName: raw, Type: "byte", Func: "Bytes", Slice: true}
+	}
+	stringField := func(name, raw string) fieldDef {
+		return fieldDef{Name: name, RawName: raw, Type: "string", Func: "String"}
+	}
+
+	photo := structDef{
+		Name:    "Photo",
+		RawName: "photo",
+		Fields: []fieldDef{
+			longField("ID", "id"),
+			longField("AccessHash", "access_hash"),
+			bytesField("FileReference", "file_reference"),
+		},
+	}
+	inputPhotoFileLocation := structDef{
+		Name:    "InputPhotoFileLocation",
+		RawName: "inputPhotoFileLocation",
+		Fields: []fieldDef{
+			longField("ID", "id"),
+			longField("AccessHash", "access_hash"),
+			bytesField("FileReference", "file_reference"),
+			stringField("ThumbSize", "thumb_size"),
+		},
+	}
+
+	t.Run("ThumbSizeBecomesParameter", func(t *testing.T) {
+		mapping, ok := mappableFields(photo, inputPhotoFileLocation)
+		if !ok {
+			t.Fatal("expected mapping to be generated")
+		}
+		if got := fieldNames(mapping.Params); len(got) != 1 || got[0] != "ThumbSize" {
+			t.Fatalf("expected ThumbSize parameter, got %v", got)
+		}
+		// id/access_hash/file_reference must still be mapped from the source.
+		if len(mapping.Fields) != 3 {
+			t.Fatalf("expected 3 mapped fields, got %d", len(mapping.Fields))
+		}
+	})
+
+	t.Run("UnmappableFieldRejected", func(t *testing.T) {
+		// A required field that is neither mappable nor a known parameter must
+		// still cause the mapping to be skipped.
+		withExtra := inputPhotoFileLocation
+		withExtra.Fields = append(append([]fieldDef{}, inputPhotoFileLocation.Fields...),
+			longField("Secret", "secret"))
+		if _, ok := mappableFields(photo, withExtra); ok {
+			t.Fatal("expected mapping with unmappable required field to be skipped")
+		}
+	})
+}
+
+func TestParameterField(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		field fieldDef
+		want  bool
+	}{
+		{"ThumbSize", fieldDef{RawName: "thumb_size", Type: "string"}, true},
+		{"Conditional", fieldDef{RawName: "thumb_size", Type: "string", Conditional: true}, false},
+		{"WrongType", fieldDef{RawName: "thumb_size", Type: "int64"}, false},
+		{"Other", fieldDef{RawName: "access_hash", Type: "string"}, false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parameterField(structDef{}, tt.field); got != tt.want {
+				t.Fatalf("parameterField() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/gen/make_interfaces.go
+++ b/gen/make_interfaces.go
@@ -16,6 +16,9 @@ type constructorMapping struct {
 	MapperName string
 	// Fields is slice of field mappings from this struct to target.
 	Fields []fieldPair
+	// Params are target fields that can't be derived from the source
+	// constructor and are passed as parameters of the generated As-mapper.
+	Params []fieldDef
 }
 
 // interfaceDef represents generic interface, type which has multiple constructors.

--- a/gen/templates.go
+++ b/gen/templates.go
@@ -58,6 +58,7 @@ func Funcs() template.FuncMap {
 	return template.FuncMap{
 		"trim":                 strings.TrimSpace,
 		"lower":                strings.ToLower,
+		"camel":                camel,
 		"trimPrefix":           strings.TrimPrefix,
 		"trimSuffix":           strings.TrimSuffix,
 		"hasPrefix":            strings.HasPrefix,

--- a/telegram/query/messages/specialize.go
+++ b/telegram/query/messages/specialize.go
@@ -153,12 +153,7 @@ func (e Elem) File() (File, bool) {
 		return File{
 			Name:     filename,
 			MIMEType: "image/jpeg",
-			Location: &tg.InputPhotoFileLocation{
-				ID:            photo.ID,
-				AccessHash:    photo.AccessHash,
-				FileReference: photo.FileReference,
-				ThumbSize:     thumbSize,
-			},
+			Location: photo.AsInputPhotoFileLocation(thumbSize),
 		}, true
 	case *tg.MessageMediaDocument:
 		doc, ok := media.Document.AsNotEmpty()
@@ -169,7 +164,8 @@ func (e Elem) File() (File, bool) {
 		return File{
 			Name:     getDocFilename(doc),
 			MIMEType: doc.MimeType,
-			Location: doc.AsInputDocumentFileLocation(),
+			// Empty thumb size downloads the full document, not a thumbnail.
+			Location: doc.AsInputDocumentFileLocation(""),
 		}, true
 	default:
 		return File{}, false

--- a/tg/tl_document_gen.go
+++ b/tg/tl_document_gen.go
@@ -733,11 +733,12 @@ type DocumentClass interface {
 }
 
 // AsInputDocumentFileLocation tries to map Document to InputDocumentFileLocation.
-func (d *Document) AsInputDocumentFileLocation() *InputDocumentFileLocation {
+func (d *Document) AsInputDocumentFileLocation(thumbSize string) *InputDocumentFileLocation {
 	value := new(InputDocumentFileLocation)
 	value.ID = d.GetID()
 	value.AccessHash = d.GetAccessHash()
 	value.FileReference = d.GetFileReference()
+	value.ThumbSize = thumbSize
 
 	return value
 }

--- a/tg/tl_input_document_gen.go
+++ b/tg/tl_input_document_gen.go
@@ -373,11 +373,12 @@ type InputDocumentClass interface {
 }
 
 // AsInputDocumentFileLocation tries to map InputDocument to InputDocumentFileLocation.
-func (i *InputDocument) AsInputDocumentFileLocation() *InputDocumentFileLocation {
+func (i *InputDocument) AsInputDocumentFileLocation(thumbSize string) *InputDocumentFileLocation {
 	value := new(InputDocumentFileLocation)
 	value.ID = i.GetID()
 	value.AccessHash = i.GetAccessHash()
 	value.FileReference = i.GetFileReference()
+	value.ThumbSize = thumbSize
 
 	return value
 }

--- a/tg/tl_input_photo_gen.go
+++ b/tg/tl_input_photo_gen.go
@@ -372,6 +372,17 @@ type InputPhotoClass interface {
 	AsNotEmpty() (*InputPhoto, bool)
 }
 
+// AsInputPhotoFileLocation tries to map InputPhoto to InputPhotoFileLocation.
+func (i *InputPhoto) AsInputPhotoFileLocation(thumbSize string) *InputPhotoFileLocation {
+	value := new(InputPhotoFileLocation)
+	value.ID = i.GetID()
+	value.AccessHash = i.GetAccessHash()
+	value.FileReference = i.GetFileReference()
+	value.ThumbSize = thumbSize
+
+	return value
+}
+
 // AsNotEmpty tries to map InputPhotoEmpty to InputPhoto.
 func (i *InputPhotoEmpty) AsNotEmpty() (*InputPhoto, bool) {
 	return nil, false

--- a/tg/tl_photo_gen.go
+++ b/tg/tl_photo_gen.go
@@ -652,6 +652,17 @@ func (p *Photo) AsInput() *InputPhoto {
 	return value
 }
 
+// AsInputPhotoFileLocation tries to map Photo to InputPhotoFileLocation.
+func (p *Photo) AsInputPhotoFileLocation(thumbSize string) *InputPhotoFileLocation {
+	value := new(InputPhotoFileLocation)
+	value.ID = p.GetID()
+	value.AccessHash = p.GetAccessHash()
+	value.FileReference = p.GetFileReference()
+	value.ThumbSize = thumbSize
+
+	return value
+}
+
 // AsNotEmpty tries to map PhotoEmpty to Photo.
 func (p *PhotoEmpty) AsNotEmpty() (*Photo, bool) {
 	return nil, false


### PR DESCRIPTION
Closes #376.

## Problem

PR #374 dropped the `Photo`/`InputPhoto` → `InputPhotoFileLocation` mappings
because `InputPhotoFileLocation` requires a `thumb_size` field that can't be
derived from the source constructor. As #376 notes, the generator could instead
emit `AsInputPhotoFileLocation(thumbSize string)` and let the caller pass it in.

## Change

`mappableFields` now splits the target's unmappable fields:

- conditional fields stay optional (left unset, as before);
- `thumb_size` on file-location inputs becomes a **method parameter** (`parameterField`);
- anything else still causes the mapping to be skipped (unchanged).

The generated concrete `As`-mappers render those fields as parameters and assign
them after the derived fields.

### Generated API

```go
// changed (thumb_size was previously left empty)
func (d *Document) AsInputDocumentFileLocation(thumbSize string) *InputDocumentFileLocation
func (i *InputDocument) AsInputDocumentFileLocation(thumbSize string) *InputDocumentFileLocation

// new (previously not generated)
func (p *Photo) AsInputPhotoFileLocation(thumbSize string) *InputPhotoFileLocation
func (i *InputPhoto) AsInputPhotoFileLocation(thumbSize string) *InputPhotoFileLocation
```

`telegram/query/messages` now uses these mappers instead of building the
location structs by hand.

> **Breaking:** `AsInputDocumentFileLocation()` gains a `thumbSize` argument.
> Pass `""` to keep the previous behavior (full file, not a thumbnail).

## Scope

The blast radius is exactly the four file-location mappers above — the
parameterized mappings carry a `Constructor`, so the slice/field wrapper
templates (which only handle constructor-less interface mappings) are untouched.

## Tests

- `gen`: unit tests for `mappableFields` (thumb_size → parameter; unmappable
  required field still skipped) and `parameterField`.
- `make check_generated` clean; full build + `telegram/query/messages` race
  tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)