### PR TITLE
fix(telegram): use permanent key only for CDN connections

### DIFF
--- a/telegram/pool.go
+++ b/telegram/pool.go
@@ -80,6 +80,14 @@ func (c *Client) dc(
 
 	opts := c.opts
 	if mode == manager.ConnModeCDN {
+		// CDN datacenters reject auth.bindTempAuthKey with CDN_METHOD_INVALID:
+		// a CDN connection must authenticate with a permanent key only, without
+		// PFS. The official clients do the same, forcing perm-key-only on CDN
+		// DCs regardless of the global PFS setting. opts is a local copy of
+		// c.opts, so this disables PFS for the CDN pool only and leaves it
+		// intact for the primary and data connections.
+		opts.EnablePFS = false
+
 		// TDesktop-compatible gate: CDN connection is allowed only when keyset
 		// for requested CDN DC is present (or can be fetched).
 		cdnKeys, set := c.cachedCDNKeysForDC(dcID)

--- a/telegram/pool_cdn_test.go
+++ b/telegram/pool_cdn_test.go
@@ -408,6 +408,40 @@ func TestClientCDNUsesDCSpecificKeysOverBase(t *testing.T) {
 	require.Equal(t, []PublicKey{cdnKey, baseKey}, got)
 }
 
+func TestClientCDNDisablesPFS(t *testing.T) {
+	c := newCDNPoolTestClient()
+	defer c.cancel()
+
+	// Global PFS is enabled, but CDN connections must still authenticate with a
+	// permanent key only: CDN datacenters reject auth.bindTempAuthKey with
+	// CDN_METHOD_INVALID.
+	c.opts.EnablePFS = true
+
+	captured := make(chan bool, 1)
+	c.create = func(
+		_ mtproto.Dialer,
+		mode manager.ConnMode,
+		_ int,
+		opts mtproto.Options,
+		_ manager.ConnOptions,
+	) pool.Conn {
+		if mode == manager.ConnModeCDN {
+			captured <- opts.EnablePFS
+		}
+		return newIdlePoolConn()
+	}
+
+	inv, err := c.CDN(context.Background(), 203, 1)
+	require.NoError(t, err)
+	require.NotNil(t, inv)
+	defer func() {
+		require.NoError(t, inv.Close())
+	}()
+	require.NoError(t, inv.Invoke(context.Background(), nil, nil))
+
+	require.False(t, <-captured, "CDN connection must not enable PFS")
+}
+
 func TestClientCDNWithoutDCSpecificKeysFailsFast(t *testing.T) {
 	c := newCDNPoolTestClient()
 	defer c.cancel()


### PR DESCRIPTION
## Problem

With PFS enabled (`telegram.WithPFS` / `Options.EnablePFS`), connecting to a CDN datacenter fails. After generating the permanent and temporary auth keys, the connection sends `auth.bindTempAuthKey`, which a CDN DC rejects:

```
rpc error code 400: CDN_METHOD_INVALID
```

The connection is then torn down, so any request routed to that CDN DC — in particular file downloads that follow an `upload.fileCdnRedirect` — can never acquire a usable connection. It fails on the first chunk and on every retry.

**Root cause:** the temporary-key bind is gated solely by the per-connection PFS flag (`mtproto.Options.EnablePFS`). CDN pools are created from a copy of the client options and inherit that flag. The CDN connection mode (`manager.ConnModeCDN`) is already threaded through the rest of the connection setup (CDN public keys, skipping `help.getConfig`, separate sessions, no auth transfer), but it is not consulted at the bind decision — so a CDN connection still attempts `auth.bindTempAuthKey`.

## Official client behavior

CDN datacenters are authenticated with a permanent key only; PFS / temp-key binding is intentionally disabled for them:

- **TDLib** forces PFS off for CDN: `SessionMultiProxy::get_pfs_flag()` returns `use_pfs_ && !is_cdn_`, so `need_send_bind_key()` is always false and `auth.bindTempAuthKey` is never sent on a CDN connection.
- **Telegram for Android** (tgnet) selects the auth key with `usePermKey = isCdnDatacenter || perm || !PFS_ENABLED` and never starts a temp-key handshake for a CDN datacenter, so it never calls `bindTempAuthKey` there.

## Fix

Disable PFS for CDN connections in `(*Client).dc`. The CDN branch operates on a local copy of the options, so PFS stays enabled for the primary and data DCs — only CDN connections become permanent-key-only, matching the official clients.

## Test

`TestClientCDNDisablesPFS`: with PFS enabled globally, asserts that the options passed to a CDN connection have `EnablePFS == false`.
