### PR TITLE
feat(telegram): make MTProto usage indistinguishable from Telegram Desktop

### DIFF
--- a/crypto/cipher_encrypt.go
+++ b/crypto/cipher_encrypt.go
@@ -9,12 +9,35 @@ import (
 	"github.com/gotd/td/bin"
 )
 
-func countPadding(l int) int { return 16 + (16 - (l % 16)) }
+// countPadding returns the amount of random padding (in bytes) to append to a
+// plaintext of length l before AES-IGE encryption.
+//
+// The padding both aligns the plaintext to the 16-byte block size (with at
+// least 12 bytes of padding, as required by MTProto 2.0) and adds a random
+// number of extra 16-byte blocks. The random component mirrors Telegram
+// Desktop's CountPaddingPrimesCount and removes the deterministic
+// encrypted-message length that would otherwise fingerprint the client.
+//
+// randByte provides the entropy for the random component; only its low 4 bits
+// are used, yielding 0..15 extra 16-byte blocks (0..240 bytes).
+func countPadding(l int, randByte byte) int {
+	padding := (16 - (l % 16)) % 16
+	if padding < 12 {
+		padding += 16
+	}
+	padding += int(randByte&0x0F) * 16
+	return padding
+}
 
 // encryptMessage encrypts plaintext using AES-IGE.
 func (c Cipher) encryptMessage(k AuthKey, plaintext *bin.Buffer) (EncryptedMessage, error) {
 	offset := len(plaintext.Buf)
-	plaintext.Buf = append(plaintext.Buf, make([]byte, countPadding(offset))...)
+
+	var randByte [1]byte
+	if _, err := io.ReadFull(c.rand, randByte[:]); err != nil {
+		return EncryptedMessage{}, err
+	}
+	plaintext.Buf = append(plaintext.Buf, make([]byte, countPadding(offset, randByte[0]))...)
 	if _, err := io.ReadFull(c.rand, plaintext.Buf[offset:]); err != nil {
 		return EncryptedMessage{}, err
 	}

--- a/crypto/cipher_padding_test.go
+++ b/crypto/cipher_padding_test.go
@@ -1,0 +1,37 @@
+package crypto
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCountPadding(t *testing.T) {
+	a := require.New(t)
+
+	for l := range 4096 {
+		for _, randByte := range []byte{0x00, 0x01, 0x0F, 0x7F, 0xF0, 0xFF} {
+			padding := countPadding(l, randByte)
+			total := l + padding
+
+			// MTProto 2.0 requires 12..1024 bytes of padding.
+			a.GreaterOrEqual(padding, 12, "l=%d rand=%#x", l, randByte)
+			a.LessOrEqual(padding, 1024, "l=%d rand=%#x", l, randByte)
+			// Encrypted length must be a multiple of the 16-byte block size.
+			a.Zero(total%16, "l=%d rand=%#x", l, randByte)
+			// Only the low 4 bits of randByte select the random component.
+			a.Equal(countPadding(l, randByte&0x0F), padding, "l=%d rand=%#x", l, randByte)
+		}
+	}
+}
+
+func TestCountPaddingJitter(t *testing.T) {
+	a := require.New(t)
+
+	// The random component must change the total length, otherwise the
+	// encrypted-message size would be a deterministic fingerprint.
+	base := countPadding(64, 0x00)
+	jittered := countPadding(64, 0x0F)
+	a.Equal(base+0x0F*16, jittered)
+	a.NotEqual(base, jittered)
+}

--- a/examples/README.md
+++ b/examples/README.md
@@ -29,6 +29,7 @@ Please don't share `APP_ID` or `APP_HASH`, it can't be easily rotated.
 | [pretty-print](pretty-print/main.go)       | Pretty-print requests, responses and updates                | The tgp package, middleware and custom UpdateHandler for all updates                                       |
 | [updates](updates/main.go)                 | Updates engine example                                      | The `updates` package that recovers missed updates                                                         |
 | [mtproxy-connect](mtproxy-connect/main.go) | Connect through an MTProxy and check MTProto without login  | `dcs.MTProxy` resolver, FakeTLS, pre-auth `help.getNearestDC`                                              |
+| [tdesktop-mimic](tdesktop-mimic/main.go)   | Connect indistinguishably from Telegram Desktop, no login   | `telegram.TDesktopResolver` (Obfuscated2 + abridged), `telegram.DeviceTDesktopWindows`, pre-auth `help.getNearestDC` |
 
 ## Environment variables
 

--- a/examples/tdesktop-mimic/main.go
+++ b/examples/tdesktop-mimic/main.go
@@ -1,0 +1,67 @@
+// Binary tdesktop-mimic connects to Telegram so that the connection is
+// indistinguishable from the official Telegram Desktop client from the server's
+// perspective, without logging in.
+//
+// It combines two presets:
+//
+//   - telegram.TDesktopResolver: every direct connection is wrapped in
+//     Obfuscated2 and uses the abridged transport codec, exactly like Telegram
+//     Desktop (which always obfuscates direct connections).
+//   - telegram.DeviceTDesktopWindows: initConnection reports a Telegram Desktop
+//     (Windows) installation — device model, system/app version, lang_pack
+//     "tdesktop" and a tz_offset param.
+//
+// It then calls help.getNearestDC, which does not require authorization, so a
+// successful response means the mimicking MTProto connection is healthy.
+//
+// Usage:
+//
+//	tdesktop-mimic
+package main
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+	"go.uber.org/zap"
+
+	"github.com/gotd/log/logzap"
+
+	"github.com/gotd/td/examples"
+	"github.com/gotd/td/telegram"
+)
+
+func main() {
+	examples.Run(func(ctx context.Context, log *zap.Logger) error {
+		// Using public test credentials: we only check connectivity, so no real
+		// application id or authentication is required.
+		client := telegram.NewClient(telegram.TestAppID, telegram.TestAppHash, telegram.Options{
+			// Match Telegram Desktop on the transport layer (Obfuscated2 + abridged).
+			Resolver: telegram.TDesktopResolver(),
+			// Match Telegram Desktop in initConnection (device, versions, lang_pack, tz_offset).
+			Device: telegram.DeviceTDesktopWindows(),
+			Logger: logzap.New(log),
+		})
+
+		return client.Run(ctx, func(ctx context.Context) error {
+			// help.getNearestDC works without authorization, so a successful
+			// response means the mimicking MTProto connection is healthy.
+			dc, err := client.API().HelpGetNearestDC(ctx)
+			if err != nil {
+				return errors.Wrap(err, "get nearest DC")
+			}
+
+			device := telegram.DeviceTDesktopWindows()
+			log.Info("Connected to Telegram mimicking Telegram Desktop",
+				zap.Int("this_dc", dc.ThisDC),
+				zap.Int("nearest_dc", dc.NearestDC),
+				zap.String("country", dc.Country),
+				zap.String("device_model", device.DeviceModel),
+				zap.String("system_version", device.SystemVersion),
+				zap.String("app_version", device.AppVersion),
+				zap.String("lang_pack", device.LangPack),
+			)
+			return nil
+		})
+	})
+}

--- a/telegram/dcs/plain.go
+++ b/telegram/dcs/plain.go
@@ -25,6 +25,7 @@ type plain struct {
 	rand         io.Reader
 	network      string
 	noObfuscated bool
+	obfuscated   bool
 	preferIPv6   bool
 }
 
@@ -84,7 +85,7 @@ func (p plain) dialTransport(ctx context.Context, test bool, dc tg.DCOption) (_ 
 	}()
 
 	proto := p.protocol
-	if dc.TCPObfuscatedOnly {
+	if dc.TCPObfuscatedOnly || p.obfuscated {
 		dcID := dc.ID
 		if test {
 			if dcID < 0 {
@@ -95,21 +96,35 @@ func (p plain) dialTransport(ctx context.Context, test bool, dc tg.DCOption) (_ 
 		}
 
 		var (
-			cdc  codec.Codec = codec.Intermediate{}
-			tag              = codec.IntermediateClientStart
-			obfs             = obfuscator.Obfuscated2
+			cdc    codec.Codec = codec.Intermediate{}
+			tag                = codec.IntermediateClientStart
+			obfs               = obfuscator.Obfuscated2
+			secret mtproxy.Secret
 		)
 
-		secret, err := mtproxy.ParseSecret(dc.Secret)
-		if err != nil {
-			return nil, errors.Wrap(err, "check DC secret")
-		}
+		if dc.TCPObfuscatedOnly {
+			var err error
+			secret, err = mtproxy.ParseSecret(dc.Secret)
+			if err != nil {
+				return nil, errors.Wrap(err, "check DC secret")
+			}
 
-		if secret.Type == mtproxy.TLS {
-			obfs = obfuscator.FakeTLS
-		} else if c, ok := secret.ExpectedCodec(); ok {
-			tag = [4]byte{secret.Tag, secret.Tag, secret.Tag, secret.Tag}
-			cdc = c
+			if secret.Type == mtproxy.TLS {
+				obfs = obfuscator.FakeTLS
+			} else if c, ok := secret.ExpectedCodec(); ok {
+				tag = [4]byte{secret.Tag, secret.Tag, secret.Tag, secret.Tag}
+				cdc = c
+			}
+		} else {
+			// Direct obfuscated connection, mimicking the official clients
+			// (e.g. Telegram Desktop) which always wrap direct connections in
+			// Obfuscated2 with an empty secret. Use the configured transport
+			// codec; its tag travels inside the obfuscation header instead of
+			// as a plaintext codec prefix.
+			cdc = p.protocol.Codec()
+			if tagged, ok := cdc.(codec.TaggedCodec); ok {
+				tag = tagged.ObfuscatedTag()
+			}
 		}
 
 		obfsConn := obfs(p.rand, conn)
@@ -201,6 +216,13 @@ type PlainOptions struct {
 	Network string
 	// NoObfuscated denotes to filter out TCP Obfuscated Only DCs.
 	NoObfuscated bool
+	// Obfuscated enables transport obfuscation (Obfuscated2) for all
+	// connections, not only for TCP-obfuscated-only DCs.
+	//
+	// The official clients (e.g. Telegram Desktop) always obfuscate direct
+	// connections, so enabling this together with Protocol: transport.Abridged
+	// makes the connection indistinguishable from Telegram Desktop on the wire.
+	Obfuscated bool
 	// PreferIPv6 gives IPv6 DCs higher precedence.
 	// Default is to prefer IPv4 DCs over IPv6.
 	PreferIPv6 bool
@@ -231,6 +253,7 @@ func Plain(opts PlainOptions) Resolver {
 		rand:         opts.Rand,
 		network:      opts.Network,
 		noObfuscated: opts.NoObfuscated,
+		obfuscated:   opts.Obfuscated,
 		preferIPv6:   opts.PreferIPv6,
 	}
 }

--- a/telegram/dcs/plain_obfuscated_test.go
+++ b/telegram/dcs/plain_obfuscated_test.go
@@ -1,0 +1,66 @@
+package dcs
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/mtproxy/obfuscated2"
+	"github.com/gotd/td/proto/codec"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/transport"
+)
+
+// TestPlainObfuscatedDirect verifies that PlainOptions.Obfuscated wraps a
+// regular (not TCP-obfuscated-only) DC connection in Obfuscated2 using the
+// configured codec's tag, matching how Telegram Desktop connects directly.
+func TestPlainObfuscatedDirect(t *testing.T) {
+	a := require.New(t)
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	a.NoError(err)
+	defer func() { _ = ln.Close() }()
+
+	type result struct {
+		meta obfuscated2.Metadata
+		err  error
+	}
+	resultCh := make(chan result, 1)
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			resultCh <- result{err: err}
+			return
+		}
+		defer func() { _ = conn.Close() }()
+		_, meta, err := obfuscated2.Accept(conn, nil)
+		resultCh <- result{meta: meta, err: err}
+	}()
+
+	addr := ln.Addr().(*net.TCPAddr)
+	r := Plain(PlainOptions{
+		Protocol:   transport.Abridged,
+		Obfuscated: true,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	conn, err := r.Primary(ctx, 2, List{
+		Options: []tg.DCOption{
+			{ID: 2, IPAddress: addr.IP.String(), Port: addr.Port},
+		},
+	})
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	got := <-resultCh
+	a.NoError(got.err)
+	// The obfuscation header must carry the abridged codec tag, not a plaintext
+	// codec prefix on the wire.
+	a.Equal(codec.Abridged{}.ObfuscatedTag(), got.meta.Protocol)
+	a.Equal(uint16(2), got.meta.DC)
+}

--- a/telegram/device.go
+++ b/telegram/device.go
@@ -1,6 +1,85 @@
 package telegram
 
-import "github.com/gotd/td/telegram/internal/manager"
+import (
+	"time"
+
+	"github.com/gotd/td/telegram/dcs"
+	"github.com/gotd/td/telegram/internal/manager"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/transport"
+)
 
 // DeviceConfig is config which send when Telegram connection session created.
 type DeviceConfig = manager.DeviceConfig
+
+// Telegram Desktop application version sent in initConnection.
+//
+// Keep in sync with the bundled tdesktop reference (Telegram/SourceFiles/core/version.h).
+const tdesktopAppVersion = "6.9.1"
+
+// TimezoneParams builds the initConnection params value with the tz_offset
+// field, matching what the official clients (e.g. Telegram Desktop) send.
+//
+// The offset is the timezone offset of loc in seconds, rounded to the nearest
+// 15 minutes (900 seconds) and clamped to the [-12h, +14h] range, exactly like
+// Telegram Desktop's prepareInitParams.
+func TimezoneParams(loc *time.Location) tg.JSONValueClass {
+	_, offset := time.Now().In(loc).Zone()
+
+	for offset < -12*3600 {
+		offset += 24 * 3600
+	}
+	for offset > 14*3600 {
+		offset -= 24 * 3600
+	}
+
+	sign := 1
+	if offset < 0 {
+		sign = -1
+		offset = -offset
+	}
+	rounded := ((offset + 450) / 900) * 900 * sign
+
+	return &tg.JSONObject{
+		Value: []tg.JSONObjectValue{
+			{Key: "tz_offset", Value: &tg.JSONNumber{Value: float64(rounded)}},
+		},
+	}
+}
+
+// TDesktopResolver returns a DC resolver that connects the same way as Telegram
+// Desktop: every direct connection is wrapped in Obfuscated2 and uses the
+// abridged transport codec.
+//
+// Use it together with DeviceTDesktopWindows to be indistinguishable from
+// Telegram Desktop both on the transport layer and in initConnection:
+//
+//	client := telegram.NewClient(appID, appHash, telegram.Options{
+//		Device:   telegram.DeviceTDesktopWindows(),
+//		Resolver: telegram.TDesktopResolver(),
+//	})
+func TDesktopResolver() dcs.Resolver {
+	return dcs.Plain(dcs.PlainOptions{
+		Protocol:   transport.Abridged,
+		Obfuscated: true,
+	})
+}
+
+// DeviceTDesktopWindows returns a DeviceConfig that emulates a Telegram Desktop
+// (Windows build) installation on initConnection, making the connection
+// parameters indistinguishable from Telegram Desktop from the server's
+// perspective.
+//
+// Combine it with TDesktopResolver to also match Telegram Desktop on the
+// transport layer.
+func DeviceTDesktopWindows() DeviceConfig {
+	return DeviceConfig{
+		DeviceModel:    "Desktop",
+		SystemVersion:  "Windows 10",
+		AppVersion:     tdesktopAppVersion + " x64",
+		SystemLangCode: "en-US",
+		LangPack:       "tdesktop",
+		LangCode:       "en",
+		Params:         TimezoneParams(time.Local),
+	}
+}

--- a/telegram/device_test.go
+++ b/telegram/device_test.go
@@ -1,0 +1,57 @@
+package telegram
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestTimezoneParams(t *testing.T) {
+	a := require.New(t)
+
+	// Fixed offset of +3h must map to a tz_offset of 10800 seconds.
+	loc := time.FixedZone("MSK", 3*3600)
+	v := TimezoneParams(loc)
+
+	obj, ok := v.(*tg.JSONObject)
+	a.True(ok)
+	a.Len(obj.Value, 1)
+	a.Equal("tz_offset", obj.Value[0].Key)
+
+	num, ok := obj.Value[0].Value.(*tg.JSONNumber)
+	a.True(ok)
+	a.Equal(float64(3*3600), num.Value)
+}
+
+func TestTimezoneParamsRounding(t *testing.T) {
+	a := require.New(t)
+
+	// Non-15-minute offsets are rounded to the nearest 900 seconds.
+	loc := time.FixedZone("NPT", 5*3600+45*60) // +05:45
+	v := TimezoneParams(loc)
+	num := v.(*tg.JSONObject).Value[0].Value.(*tg.JSONNumber)
+	a.Zero(int(num.Value) % 900)
+	a.Equal(float64(5*3600+45*60), num.Value)
+}
+
+func TestDeviceTDesktopWindows(t *testing.T) {
+	a := require.New(t)
+
+	d := DeviceTDesktopWindows()
+	a.Equal("Desktop", d.DeviceModel)
+	a.Equal("Windows 10", d.SystemVersion)
+	a.Equal("tdesktop", d.LangPack)
+	a.Equal("en", d.LangCode)
+	a.Equal("en-US", d.SystemLangCode)
+	a.NotEmpty(d.AppVersion)
+	a.NotNil(d.Params)
+}
+
+func TestTDesktopResolver(t *testing.T) {
+	// Wire-level obfuscated abridged behavior is covered by
+	// dcs.TestPlainObfuscatedDirect; here we only ensure the helper is wired.
+	require.NotNil(t, TDesktopResolver())
+}


### PR DESCRIPTION
## Summary

Aligns gotd's MTProto usage with Telegram Desktop so a connection is indistinguishable from tdesktop on the server side. Three independent areas, derived from the bundled tdesktop reference (`connection_tcp.cpp`, `session_private.cpp`, `mtproto_serialized_request.cpp`).

### 1. Transport: obfuscated abridged (opt-in)
tdesktop *always* wraps direct connections in Obfuscated2 and uses the **abridged** codec (`0xefefefef`); gotd's default sent plain, unobfuscated **intermediate** (`0xeeeeeeee`) — different from the first byte on the wire.

- `dcs.PlainOptions.Obfuscated`: when set, *all* connections (not just `TCPObfuscatedOnly` DCs) are wrapped in Obfuscated2 using the configured codec's tag (carried inside the obfuscation header).

### 2. Encrypted-message padding jitter (global)
tdesktop's `CountPaddingPrimesCount` aligns to 16 bytes, guarantees ≥12, then adds a **random** number of extra 16-byte blocks. gotd used a fixed `16 + (16 - len%16)`, giving a deterministic encrypted length — itself a fingerprint.

- `crypto.countPadding` now matches tdesktop. Applied globally since it's MTProto-2.0-compliant (12..1024 bytes, 16-byte aligned) and a strict privacy improvement, not impersonation. The grammers golden vector still passes (with zero rand the jitter is 0 and padding coincides).

### 3. initConnection identity — Windows tdesktop (opt-in)
- `telegram.DeviceTDesktopWindows()` — device model, system/app version, `lang_pack="tdesktop"`, `tz_offset` params.
- `telegram.TimezoneParams()` — ports tdesktop's 900s-rounded, clamped tz offset.
- `telegram.TDesktopResolver()` — the matching obfuscated abridged resolver, so the two layers can't be misconfigured.

### Usage
```go
client := telegram.NewClient(appID, appHash, telegram.Options{
    Device:   telegram.DeviceTDesktopWindows(),
    Resolver: telegram.TDesktopResolver(),
})
```

### Example
`examples/tdesktop-mimic` — a login-free connectivity check (`help.getNearestDC`) using both presets, modeled on `mtproxy-connect`.

## Tests
- `crypto/cipher_padding_test.go` — padding bounds (12..1024), 16-byte alignment, jitter, low-4-bits-only.
- `telegram/dcs/plain_obfuscated_test.go` — end-to-end: a real listener decodes the Obfuscated2 header via `obfuscated2.Accept` and confirms the abridged tag + DC id.
- `telegram/device_test.go` — tz_offset value/rounding, device fields, resolver wiring.

All affected packages pass with `-race`; build clean, `go vet` clean, gofmt clean, no generated/schema files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)