### PR TITLE
feat(markdown): support Telegram ||spoiler|| syntax

### DIFF
--- a/telegram/message/markdown/markdown.go
+++ b/telegram/message/markdown/markdown.go
@@ -21,11 +21,13 @@ import (
 // to the given builder.
 //
 // Parsing is backed by goldmark and follows CommonMark (plus GFM
-// strikethrough). The constructs that map onto Telegram message entities are:
+// strikethrough and the Telegram ||spoiler|| extension). The constructs that map
+// onto Telegram message entities are:
 //
 //	*text*, _text_       italic
 //	**text**, __text__   bold
 //	~~text~~             strikethrough
+//	||text||             spoiler
 //	`text`               inline code
 //	```lang              pre-formatted code block
 //	[text](url)          inline URL (tg://user?id=N becomes a mention)

--- a/telegram/message/markdown/parser.go
+++ b/telegram/message/markdown/parser.go
@@ -29,6 +29,7 @@ func newMarkdownParser() parser.Parser {
 			util.Prioritized(parser.NewLinkParser(), 200),
 			util.Prioritized(parser.NewEmphasisParser(), 500),
 			util.Prioritized(extension.NewStrikethroughParser(), 500),
+			util.Prioritized(NewSpoilerParser(), 500),
 		),
 	)
 }
@@ -124,6 +125,8 @@ func (r *renderer) renderInline(n ast.Node) error {
 		return r.styled(n, entity.Italic())
 	case *east.Strikethrough:
 		return r.styled(n, entity.Strike())
+	case *spoiler:
+		return r.styled(n, entity.Spoiler())
 	case *ast.Link:
 		return r.renderLink(n, string(n.Destination), false)
 	case *ast.Image:

--- a/telegram/message/markdown/parser_test.go
+++ b/telegram/message/markdown/parser_test.go
@@ -94,6 +94,31 @@ func TestMarkdown(t *testing.T) {
 		{input: "", msg: ""},
 	}))
 
+	t.Run("Spoiler", runTests([]testCase{
+		{input: "||spoiler||", msg: "spoiler", entities: getEntities(entity.Spoiler())},
+		{
+			input: "before ||hidden|| after", msg: "before hidden after",
+			entities: func(msg string) []tg.MessageEntityClass {
+				return []tg.MessageEntityClass{
+					&tg.MessageEntitySpoiler{Offset: 7, Length: 6},
+				}
+			},
+		},
+		{
+			input: "||spoiler with *bold*||", msg: "spoiler with bold",
+			entities: func(msg string) []tg.MessageEntityClass {
+				return []tg.MessageEntityClass{
+					&tg.MessageEntitySpoiler{Offset: 0, Length: 17},
+					&tg.MessageEntityItalic{Offset: 13, Length: 4},
+				}
+			},
+		},
+		// A single pipe is not a spoiler delimiter.
+		{input: "a | b", msg: "a | b"},
+		// Escaped pipes are literal.
+		{input: `\|\|not spoiler\|\|`, msg: "||not spoiler||"},
+	}))
+
 	t.Run("Nested", runTests([]testCase{
 		{
 			input: "**bold _italic_**", msg: "bold italic",

--- a/telegram/message/markdown/spoiler.go
+++ b/telegram/message/markdown/spoiler.go
@@ -1,0 +1,72 @@
+package markdown
+
+import (
+	gast "github.com/yuin/goldmark/ast"
+	"github.com/yuin/goldmark/parser"
+	"github.com/yuin/goldmark/text"
+)
+
+// KindSpoiler is a NodeKind of a Spoiler node.
+//
+// Spoiler is a Telegram MarkdownV2 construct (||text||) that has no CommonMark
+// equivalent; it maps onto the message spoiler entity.
+var KindSpoiler = gast.NewNodeKind("Spoiler")
+
+// spoiler is an inline node representing ||spoiler|| text.
+type spoiler struct {
+	gast.BaseInline
+}
+
+func (n *spoiler) Kind() gast.NodeKind { return KindSpoiler }
+
+func (n *spoiler) Dump(source []byte, level int) {
+	gast.DumpHelper(n, source, level, nil, nil)
+}
+
+type spoilerDelimiterProcessor struct{}
+
+func (p *spoilerDelimiterProcessor) IsDelimiter(b byte) bool {
+	return b == '|'
+}
+
+func (p *spoilerDelimiterProcessor) CanOpenCloser(opener, closer *parser.Delimiter) bool {
+	return opener.Char == closer.Char
+}
+
+func (p *spoilerDelimiterProcessor) OnMatch(consumes int) gast.Node {
+	return &spoiler{}
+}
+
+var defaultSpoilerDelimiterProcessor = &spoilerDelimiterProcessor{}
+
+type spoilerParser struct{}
+
+// NewSpoilerParser returns a new InlineParser that parses ||spoiler||
+// expressions.
+func NewSpoilerParser() parser.InlineParser {
+	return &spoilerParser{}
+}
+
+func (s *spoilerParser) Trigger() []byte {
+	return []byte{'|'}
+}
+
+func (s *spoilerParser) Parse(parent gast.Node, block text.Reader, pc parser.Context) gast.Node {
+	before := block.PrecendingCharacter()
+	line, segment := block.PeekLine()
+	// Telegram spoilers use exactly "||"; a single '|' or a longer run is not a
+	// delimiter.
+	node := parser.ScanDelimiter(line, before, 2, defaultSpoilerDelimiterProcessor)
+	if node == nil || node.OriginalLength != 2 || before == '|' {
+		return nil
+	}
+
+	node.Segment = segment.WithStop(segment.Start + node.OriginalLength)
+	block.Advance(node.OriginalLength)
+	pc.PushDelimiter(node)
+	return node
+}
+
+func (s *spoilerParser) CloseBlock(parent gast.Node, pc parser.Context) {
+	// nothing to do
+}


### PR DESCRIPTION
## Summary

The `message/markdown` parser is CommonMark (goldmark) and had no spoiler
construct, so Telegram's MarkdownV2 `||text||` was emitted as literal text
instead of a spoiler entity.

This adds a goldmark inline parser for the `||...||` delimiter (exactly two
pipes), mapping it onto the `messageEntitySpoiler` entity. It's modeled on the
existing strikethrough delimiter parser.

## Changes

- `spoiler.go` — `NewSpoilerParser()` inline parser + `spoiler` AST node /
  delimiter processor (trigger `|`, requires a run of exactly 2).
- `parser.go` — register the parser (priority 500) and render the node via
  `entity.Spoiler()`.
- `markdown.go` — document `||text||  spoiler` in the package overview.
- `parser_test.go` — a `Spoiler` test group: basic, mid-text, nested
  (`||spoiler with *italic*||`), single-pipe-stays-literal, and escaped pipes.

## Behavior

```
||spoiler||              -> spoiler entity over "spoiler"
before ||hidden|| after  -> spoiler over "hidden"
a | b                    -> plain text (single pipe is not a delimiter)
\|\|x\|\|                -> literal "||x||"
```

All `telegram/message/...` tests pass; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)