### PR TITLE
fix(rpc): close WaitGroup Add/Wait race in Engine

### DIFF
--- a/rpc/engine.go
+++ b/rpc/engine.go
@@ -31,8 +31,11 @@ type Engine struct {
 	reqCtx    context.Context
 	reqCancel context.CancelCauseFunc
 
-	wg     sync.WaitGroup
-	closed uint32
+	wg sync.WaitGroup
+	// closed is guarded by mux: it must be set and observed atomically with
+	// respect to wg.Add in Do, otherwise Close may observe a zero WaitGroup
+	// counter and return from Wait concurrently with a new Add.
+	closed bool
 }
 
 // New creates new rpc Engine.
@@ -74,11 +77,15 @@ type Request struct {
 // Do sends request to server and blocks until response is received, performing
 // multiple retries if needed.
 func (e *Engine) Do(ctx context.Context, req Request) error {
-	if e.isClosed() {
+	// Register the request under the mutex so Close cannot observe a zero
+	// WaitGroup counter and return from Wait while we are about to Add.
+	e.mux.Lock()
+	if e.closed {
+		e.mux.Unlock()
 		return ErrEngineClosed
 	}
-
 	e.wg.Add(1)
+	e.mux.Unlock()
 	defer e.wg.Done()
 
 	retryCtx, retryClose := context.WithCancel(ctx)
@@ -280,15 +287,13 @@ func (e *Engine) NotifyError(msgID int64, rpcErr error) {
 	_ = fn(nil, rpcErr)
 }
 
-func (e *Engine) isClosed() bool {
-	return atomic.LoadUint32(&e.closed) == 1
-}
-
 // Close gracefully closes the engine.
 // All pending requests will be awaited.
 // All Do method calls of closed engine will return ErrEngineClosed error.
 func (e *Engine) Close() {
-	atomic.StoreUint32(&e.closed, 1)
+	e.mux.Lock()
+	e.closed = true
+	e.mux.Unlock()
 	e.log.Info(context.Background(), "Close called")
 	e.wg.Wait()
 }


### PR DESCRIPTION
## Summary

Fixes a data race between `Engine.Close` and `Engine.Do` reported by the race detector (seen e.g. in `gotd/botapi`'s `TestRunEndToEnd`).

`Do` checked the atomic `closed` flag and then called `e.wg.Add(1)` as a *separate* step, while `Close` stored the flag and called `e.wg.Wait()`. Between `Do`'s check and its `Add`, `Close` could mark the engine closed and have `Wait` return on a zero counter, after which `Do` would call `Add(1)` — violating the `sync.WaitGroup` contract that an `Add` raising the counter from zero must *happen-before* `Wait`.

```
WARNING: DATA RACE
Write at ... by goroutine 248:
  rpc.(*Engine).Close()   engine.go:293   (wg.Wait)
  rpc.(*Engine).ForceClose()
  ...
Previous read at ... by goroutine 264:
  rpc.(*Engine).Do()      engine.go:81    (wg.Add)
  ...
```

## Fix

Guard the close-check and `wg.Add(1)` together under the existing `mux` so they cannot interleave with `Close`:

- `closed` becomes a `mux`-guarded `bool` (was an atomic `uint32`).
- `Do` takes `mux`, returns `ErrEngineClosed` if closed, else `wg.Add(1)`, then unlocks.
- `Close` sets `closed = true` under `mux`, then `wg.Wait()` outside the lock (so pending requests can still `Done`).
- Removes the now-unused `isClosed` helper.

## Testing

`go test -race -count=1 ./rpc/... ./mtproto/...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)