### PR TITLE
fix(exchange): handle encrypted frame during server key exchange

### DIFF
--- a/exchange/flow_test.go
+++ b/exchange/flow_test.go
@@ -13,6 +13,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/gotd/log/logzap"
+	"github.com/gotd/td/bin"
 	"github.com/gotd/td/crypto"
 	"github.com/gotd/td/tdsync"
 	"github.com/gotd/td/testutil"
@@ -74,6 +75,57 @@ func testExchange(tempMode bool) func(t *testing.T) {
 func TestExchange(t *testing.T) {
 	t.Run("PQInnerData", testExchange(false))
 	t.Run("PQInnerDataDC", testExchange(true))
+}
+
+// TestServerUnexpectedEncrypted verifies that the server flow surfaces a frame
+// bearing a non-zero auth key id as *UnexpectedEncryptedError instead of failing
+// the exchange, so callers can resolve the key and handle it as a normal RPC
+// rather than replying -404 (which makes clients discard a still-valid key).
+func TestServerUnexpectedEncrypted(t *testing.T) {
+	a := require.New(t)
+	log := zaptest.NewLogger(t)
+
+	dc := 2
+	reader := rand.New(rand.NewSource(1))
+	key, err := rsa.GenerateKey(reader, crypto.RSAKeyBits)
+	a.NoError(err)
+	privateKey := PrivateKey{RSA: key}
+
+	i := transport.Intermediate
+	client, server := i.Pipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	// Frame whose leading auth_key_id is non-zero: an encrypted message rather
+	// than an unencrypted key-exchange message.
+	authKeyID := [8]byte{1, 2, 3, 4, 5, 6, 7, 8}
+	var payload bin.Buffer
+	payload.Put(authKeyID[:])
+	// Intermediate transport requires 4-byte-aligned payloads; keep the total
+	// frame length a multiple of 4.
+	payload.Put([]byte("bodybyte"))
+	frame := append([]byte(nil), payload.Buf...)
+
+	var serverErr error
+	g := tdsync.NewCancellableGroup(ctx)
+	g.Go(func(ctx context.Context) error {
+		return client.Send(ctx, &payload)
+	})
+	g.Go(func(ctx context.Context) error {
+		_, serverErr = NewExchanger(server, dc).
+			WithLogger(logzap.New(log.Named("server"))).
+			WithRand(reader).
+			Server(privateKey).
+			Run(ctx)
+		return nil
+	})
+	a.NoError(g.Wait())
+
+	var encErr *UnexpectedEncryptedError
+	a.ErrorAs(serverErr, &encErr)
+	a.Equal(authKeyID, encErr.AuthKeyID)
+	a.Equal(frame, encErr.Frame)
 }
 
 func TestExchangeCorpus(t *testing.T) {

--- a/exchange/proto.go
+++ b/exchange/proto.go
@@ -73,6 +73,22 @@ func (w unencryptedWriter) readUnencrypted(ctx context.Context, b *bin.Buffer, d
 		break
 	}
 
+	// Server side: a frame whose leading auth_key_id is non-zero is an encrypted
+	// message, not an unencrypted key-exchange message. The peer is reusing an
+	// already established auth key rather than performing key exchange. Surface
+	// the raw frame so the caller can resolve the key and handle it as a normal
+	// encrypted message, instead of failing the exchange (which would drop the
+	// connection or reply -404 and make clients discard a still-valid key).
+	if !w.isClient() {
+		var keyID [8]byte
+		if err := b.PeekN(keyID[:], len(keyID)); err == nil && keyID != ([8]byte{}) {
+			return &UnexpectedEncryptedError{
+				AuthKeyID: keyID,
+				Frame:     append([]byte(nil), b.Buf...),
+			}
+		}
+	}
+
 	var msg proto.UnencryptedMessage
 	if err := msg.Decode(b); err != nil {
 		return err

--- a/exchange/server_flow.go
+++ b/exchange/server_flow.go
@@ -2,6 +2,7 @@ package exchange
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/go-faster/errors"
@@ -35,6 +36,28 @@ func serverError(code int32, err error) error {
 		Code: code,
 		Err:  err,
 	}
+}
+
+// UnexpectedEncryptedError is returned by the server key-exchange flow when it
+// reads a frame whose leading auth key id is non-zero while expecting an
+// unencrypted exchange message. This means the peer is using an already
+// established auth key instead of performing key exchange.
+//
+// The caller should resolve the key and handle Frame as an encrypted message
+// rather than treating it as an exchange failure. In particular, callers must
+// not blindly reply with auth_key_not_found (-404): clients such as Telegram
+// Desktop treat a -404 on a temporary key as "key destroyed", discard it and
+// re-run key exchange, which leads to a reconnect/key-exchange storm.
+type UnexpectedEncryptedError struct {
+	// AuthKeyID is the auth key id the encrypted frame was sent with.
+	AuthKeyID [8]byte
+	// Frame is the raw transport frame (the full encrypted message).
+	Frame []byte
+}
+
+// Error implements error.
+func (e *UnexpectedEncryptedError) Error() string {
+	return fmt.Sprintf("unexpected encrypted message (auth key id %x) during key exchange", e.AuthKeyID)
 }
 
 // req_pq#60469778 or req_pq_multi#be7e8ef1


### PR DESCRIPTION
## Problem

The server-side key-exchange read path treated every frame it read as an unencrypted exchange message. When a client reuses an **already-established auth key** on a connection the server still considers to be performing key exchange, the caller could not distinguish this from a malformed message and would typically reply `auth_key_not_found` (`-404`).

Clients such as Telegram Desktop treat a `-404` on a **temporary** key as "key destroyed", discard the key and re-run key exchange — producing a reconnect/key-exchange storm (hundreds of connect/exchange/disconnect cycles per second, with the client logging `-404 error received ... with temporary key, assuming it was destroyed`).

## Fix

On the server side, detect a non-zero leading `auth_key_id` while reading an unencrypted exchange message and return the raw frame as a new exported error type, `*exchange.UnexpectedEncryptedError`, instead of failing the exchange.

This lets the caller resolve the key and dispatch the frame as a normal encrypted message (or reply `-404` only when the key is genuinely unknown), rather than blindly tearing down a still-valid key.

## Verification

Wired into a downstream MTProto server (gotd/teled) via `replace`, rebuilt and restarted against a live Telegram Desktop client:

- **Before:** continuous storm — hundreds of `Client connected` / `Key exchange failed: EOF` per second; client logged 185 `-404 ... temporary key ... destroyed`.
- **After:** `0` `-404` sent, `0` key-exchange failures, ~12 stable connections, normal RPC traffic; client resumed normal sync.

Adds `TestServerUnexpectedEncrypted` covering the new behavior.