### PR TITLE
feat(query): generate peer-resolve helpers for query builders

### DIFF
--- a/telegram/query/internal/itergen/_template/gen.tmpl
+++ b/telegram/query/internal/itergen/_template/gen.tmpl
@@ -8,7 +8,8 @@ import (
 
     "github.com/go-faster/errors"
 
-    "github.com/gotd/td/tg"
+    {{ if $.HasPeerMethods }}"github.com/gotd/td/telegram/message/peer"
+    {{ end }}"github.com/gotd/td/tg"
 )
 
 // No-op definition for keeping imports.
@@ -40,12 +41,29 @@ func (q QueryFunc) Query(ctx context.Context, req Request) (tg.{{ $.ResultName }
 // QueryBuilder is a helper to create message queries.
 type QueryBuilder struct {
     raw *tg.Client
+    {{- if $.HasPeerMethods }}
+    resolver peer.Resolver
+    {{- end }}
 }
 
 // NewQueryBuilder creates new QueryBuilder.
 func NewQueryBuilder(raw *tg.Client) *QueryBuilder {
+    {{- if $.HasPeerMethods }}
+    return &QueryBuilder{
+        raw: raw,
+        resolver: peer.DefaultResolver(raw),
+    }
+    {{- else }}
     return &QueryBuilder{raw: raw}
+    {{- end }}
 }
+{{ if $.HasPeerMethods }}
+// WithResolver sets peer resolver to use in Resolve helpers.
+func (q *QueryBuilder) WithResolver(resolver peer.Resolver) *QueryBuilder {
+    q.resolver = resolver
+    return q
+}
+{{ end }}
 
 {{ range $method := $.Methods }}
 {{ template "query" $method }}
@@ -58,6 +76,9 @@ type {{ $.Name }}QueryBuilder struct {
     raw *tg.Client
     req {{ $.RequestName }}
     batchSize int
+    {{- if $.PeerParam }}
+    peerPromise peer.Promise
+    {{- end }}
     {{- range $mapping := $.AdditionalMapping }}
     {{ $mapping.Arg.Name }} {{ $mapping.Arg.Type }}
     {{- end }}
@@ -83,6 +104,25 @@ func (q *QueryBuilder) {{ $.Name }}({{ range $arg := $.RequiredParams }}param{{ 
 {{- end }}
     return b
 }
+{{ if $.PeerParam }}
+// {{ $.Name }}Resolve creates query builder of {{ $.OriginalName }}, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) {{ $.Name }}Resolve({{ range $arg := $.RequiredParams }}{{ if eq $arg.OriginalName $.PeerParam.OriginalName }}from string,{{ else }}param{{ $arg.OriginalName }} {{ $arg.Type }},{{ end }}{{ end }}) *{{ $.Name }}QueryBuilder {
+    b := q.{{ $.Name }}({{ range $arg := $.RequiredParams }}{{ if eq $arg.OriginalName $.PeerParam.OriginalName }}&tg.InputPeerEmpty{},{{ else }}param{{ $arg.OriginalName }},{{ end }}{{ end }})
+    b.peerPromise = peer.Resolve(q.resolver, from)
+    return b
+}
+{{ end }}
 
 // BatchSize sets buffer of message loaded from one request.
 // Be carefully, when set this limit, because Telegram does not return error if limit is too big,
@@ -123,6 +163,16 @@ func (b *{{ $.Name }}QueryBuilder) {{ $f.ConstructorName }}({{ range $arg := $f.
 
 // Query implements Query interface.
 func (b *{{ $.Name }}QueryBuilder) Query(ctx context.Context, req Request) ({{ $.ResultName }}, error) {
+    {{- if $.PeerParam }}
+    if b.peerPromise != nil {
+        p, err := b.peerPromise(ctx)
+        if err != nil {
+            return nil, errors.Wrap(err, "resolve peer")
+        }
+        b.req.{{ $.PeerParam.OriginalName }} = p
+        b.peerPromise = nil
+    }
+    {{- end }}
 	r := &{{ $.RequestName }}{
 		Limit:     req.Limit,
 	}

--- a/telegram/query/internal/itergen/collect.go
+++ b/telegram/query/internal/itergen/collect.go
@@ -200,11 +200,20 @@ func (c *collector) Config() (Config, error) {
 		return Config{}, errors.Wrap(err, "collect")
 	}
 
+	hasPeerMethods := false
+	for _, m := range methods {
+		if m.PeerParam != nil {
+			hasPeerMethods = true
+			break
+		}
+	}
+
 	return Config{
-		Methods:       methods,
-		Package:       c.pkgName,
-		ResultName:    c.resultTypeName,
-		RequestFields: sortParams(c.requestFields),
+		Methods:        methods,
+		Package:        c.pkgName,
+		ResultName:     c.resultTypeName,
+		RequestFields:  sortParams(c.requestFields),
+		HasPeerMethods: hasPeerMethods,
 	}, nil
 }
 
@@ -235,6 +244,10 @@ func (c *collector) collect() ([]Method, error) {
 		for _, field := range method.params {
 			if _, ok := c.required[field.OriginalName]; ok {
 				m.RequiredParams = append(m.RequiredParams, field)
+				if field.Type == "tg.InputPeerClass" {
+					peerParam := field
+					m.PeerParam = &peerParam
+				}
 			}
 		}
 		m.RequiredParams = sortParams(m.RequiredParams)

--- a/telegram/query/internal/itergen/method.go
+++ b/telegram/query/internal/itergen/method.go
@@ -79,6 +79,9 @@ type Method struct {
 	ResultName string
 	// RequiredParams is a required params for query builder.
 	RequiredParams []Param
+	// PeerParam is a required parameter of type tg.InputPeerClass, if any.
+	// When set, the generator emits peer-resolving helpers for the method.
+	PeerParam *Param
 	// AdditionalMapping is names of field from iterator.
 	// Some type doesn't have AddOffset for example, so we customize mapping here.
 	AdditionalMapping []RequestArgument
@@ -106,4 +109,7 @@ type Config struct {
 	ResultName string
 	// RequestFields is a slice of request struct fields.
 	RequestFields []Param
+	// HasPeerMethods is true if at least one method has a tg.InputPeerClass
+	// required parameter, so the package needs a peer.Resolver.
+	HasPeerMethods bool
 }

--- a/telegram/query/messages/queries.gen.go
+++ b/telegram/query/messages/queries.gen.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/go-faster/errors"
 
+	"github.com/gotd/td/telegram/message/peer"
 	"github.com/gotd/td/tg"
 )
 
@@ -39,12 +40,22 @@ func (q QueryFunc) Query(ctx context.Context, req Request) (tg.MessagesMessagesC
 
 // QueryBuilder is a helper to create message queries.
 type QueryBuilder struct {
-	raw *tg.Client
+	raw      *tg.Client
+	resolver peer.Resolver
 }
 
 // NewQueryBuilder creates new QueryBuilder.
 func NewQueryBuilder(raw *tg.Client) *QueryBuilder {
-	return &QueryBuilder{raw: raw}
+	return &QueryBuilder{
+		raw:      raw,
+		resolver: peer.DefaultResolver(raw),
+	}
+}
+
+// WithResolver sets peer resolver to use in Resolve helpers.
+func (q *QueryBuilder) WithResolver(resolver peer.Resolver) *QueryBuilder {
+	q.resolver = resolver
+	return q
 }
 
 // ChannelsSearchPostsQueryBuilder is query builder of ChannelsSearchPosts.
@@ -161,12 +172,13 @@ func (b *ChannelsSearchPostsQueryBuilder) Collect(ctx context.Context) ([]Elem, 
 
 // GetHistoryQueryBuilder is query builder of MessagesGetHistory.
 type GetHistoryQueryBuilder struct {
-	raw        *tg.Client
-	req        tg.MessagesGetHistoryRequest
-	batchSize  int
-	addOffset  int
-	offsetDate int
-	offsetID   int
+	raw         *tg.Client
+	req         tg.MessagesGetHistoryRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetDate  int
+	offsetID    int
 }
 
 // GetHistory creates query builder of MessagesGetHistory.
@@ -180,6 +192,24 @@ func (q *QueryBuilder) GetHistory(paramPeer tg.InputPeerClass) *GetHistoryQueryB
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetHistoryResolve creates query builder of MessagesGetHistory, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetHistoryResolve(from string) *GetHistoryQueryBuilder {
+	b := q.GetHistory(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -211,6 +241,14 @@ func (b *GetHistoryQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetHistoryQu
 
 // Query implements Query interface.
 func (b *GetHistoryQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetHistoryRequest{
 		Limit: req.Limit,
 	}
@@ -355,9 +393,10 @@ func (b *GetPersonalChannelHistoryQueryBuilder) Collect(ctx context.Context) ([]
 
 // GetRecentLocationsQueryBuilder is query builder of MessagesGetRecentLocations.
 type GetRecentLocationsQueryBuilder struct {
-	raw       *tg.Client
-	req       tg.MessagesGetRecentLocationsRequest
-	batchSize int
+	raw         *tg.Client
+	req         tg.MessagesGetRecentLocationsRequest
+	batchSize   int
+	peerPromise peer.Promise
 }
 
 // GetRecentLocations creates query builder of MessagesGetRecentLocations.
@@ -371,6 +410,24 @@ func (q *QueryBuilder) GetRecentLocations(paramPeer tg.InputPeerClass) *GetRecen
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetRecentLocationsResolve creates query builder of MessagesGetRecentLocations, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetRecentLocationsResolve(from string) *GetRecentLocationsQueryBuilder {
+	b := q.GetRecentLocations(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -390,6 +447,14 @@ func (b *GetRecentLocationsQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetR
 
 // Query implements Query interface.
 func (b *GetRecentLocationsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetRecentLocationsRequest{
 		Limit: req.Limit,
 	}
@@ -443,12 +508,13 @@ func (b *GetRecentLocationsQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // GetRepliesQueryBuilder is query builder of MessagesGetReplies.
 type GetRepliesQueryBuilder struct {
-	raw        *tg.Client
-	req        tg.MessagesGetRepliesRequest
-	batchSize  int
-	addOffset  int
-	offsetDate int
-	offsetID   int
+	raw         *tg.Client
+	req         tg.MessagesGetRepliesRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetDate  int
+	offsetID    int
 }
 
 // GetReplies creates query builder of MessagesGetReplies.
@@ -462,6 +528,24 @@ func (q *QueryBuilder) GetReplies(paramPeer tg.InputPeerClass) *GetRepliesQueryB
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetRepliesResolve creates query builder of MessagesGetReplies, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetRepliesResolve(from string) *GetRepliesQueryBuilder {
+	b := q.GetReplies(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -499,6 +583,14 @@ func (b *GetRepliesQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetRepliesQu
 
 // Query implements Query interface.
 func (b *GetRepliesQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetRepliesRequest{
 		Limit: req.Limit,
 	}
@@ -558,12 +650,13 @@ func (b *GetRepliesQueryBuilder) Collect(ctx context.Context) ([]Elem, error) {
 
 // GetSavedHistoryQueryBuilder is query builder of MessagesGetSavedHistory.
 type GetSavedHistoryQueryBuilder struct {
-	raw        *tg.Client
-	req        tg.MessagesGetSavedHistoryRequest
-	batchSize  int
-	addOffset  int
-	offsetDate int
-	offsetID   int
+	raw         *tg.Client
+	req         tg.MessagesGetSavedHistoryRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetDate  int
+	offsetID    int
 }
 
 // GetSavedHistory creates query builder of MessagesGetSavedHistory.
@@ -578,6 +671,24 @@ func (q *QueryBuilder) GetSavedHistory(paramPeer tg.InputPeerClass) *GetSavedHis
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetSavedHistoryResolve creates query builder of MessagesGetSavedHistory, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetSavedHistoryResolve(from string) *GetSavedHistoryQueryBuilder {
+	b := q.GetSavedHistory(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -615,6 +726,14 @@ func (b *GetSavedHistoryQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetSave
 
 // Query implements Query interface.
 func (b *GetSavedHistoryQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetSavedHistoryRequest{
 		Limit: req.Limit,
 	}
@@ -674,11 +793,12 @@ func (b *GetSavedHistoryQueryBuilder) Collect(ctx context.Context) ([]Elem, erro
 
 // GetUnreadMentionsQueryBuilder is query builder of MessagesGetUnreadMentions.
 type GetUnreadMentionsQueryBuilder struct {
-	raw       *tg.Client
-	req       tg.MessagesGetUnreadMentionsRequest
-	batchSize int
-	addOffset int
-	offsetID  int
+	raw         *tg.Client
+	req         tg.MessagesGetUnreadMentionsRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetID    int
 }
 
 // GetUnreadMentions creates query builder of MessagesGetUnreadMentions.
@@ -692,6 +812,24 @@ func (q *QueryBuilder) GetUnreadMentions(paramPeer tg.InputPeerClass) *GetUnread
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetUnreadMentionsResolve creates query builder of MessagesGetUnreadMentions, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetUnreadMentionsResolve(from string) *GetUnreadMentionsQueryBuilder {
+	b := q.GetUnreadMentions(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -723,6 +861,14 @@ func (b *GetUnreadMentionsQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadMe
 
 // Query implements Query interface.
 func (b *GetUnreadMentionsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetUnreadMentionsRequest{
 		Limit: req.Limit,
 	}
@@ -780,11 +926,12 @@ func (b *GetUnreadMentionsQueryBuilder) Collect(ctx context.Context) ([]Elem, er
 
 // GetUnreadPollVotesQueryBuilder is query builder of MessagesGetUnreadPollVotes.
 type GetUnreadPollVotesQueryBuilder struct {
-	raw       *tg.Client
-	req       tg.MessagesGetUnreadPollVotesRequest
-	batchSize int
-	addOffset int
-	offsetID  int
+	raw         *tg.Client
+	req         tg.MessagesGetUnreadPollVotesRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetID    int
 }
 
 // GetUnreadPollVotes creates query builder of MessagesGetUnreadPollVotes.
@@ -798,6 +945,24 @@ func (q *QueryBuilder) GetUnreadPollVotes(paramPeer tg.InputPeerClass) *GetUnrea
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetUnreadPollVotesResolve creates query builder of MessagesGetUnreadPollVotes, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetUnreadPollVotesResolve(from string) *GetUnreadPollVotesQueryBuilder {
+	b := q.GetUnreadPollVotes(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -829,6 +994,14 @@ func (b *GetUnreadPollVotesQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadP
 
 // Query implements Query interface.
 func (b *GetUnreadPollVotesQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetUnreadPollVotesRequest{
 		Limit: req.Limit,
 	}
@@ -886,11 +1059,12 @@ func (b *GetUnreadPollVotesQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // GetUnreadReactionsQueryBuilder is query builder of MessagesGetUnreadReactions.
 type GetUnreadReactionsQueryBuilder struct {
-	raw       *tg.Client
-	req       tg.MessagesGetUnreadReactionsRequest
-	batchSize int
-	addOffset int
-	offsetID  int
+	raw         *tg.Client
+	req         tg.MessagesGetUnreadReactionsRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetID    int
 }
 
 // GetUnreadReactions creates query builder of MessagesGetUnreadReactions.
@@ -905,6 +1079,24 @@ func (q *QueryBuilder) GetUnreadReactions(paramPeer tg.InputPeerClass) *GetUnrea
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// GetUnreadReactionsResolve creates query builder of MessagesGetUnreadReactions, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) GetUnreadReactionsResolve(from string) *GetUnreadReactionsQueryBuilder {
+	b := q.GetUnreadReactions(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -942,6 +1134,14 @@ func (b *GetUnreadReactionsQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadR
 
 // Query implements Query interface.
 func (b *GetUnreadReactionsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesGetUnreadReactionsRequest{
 		Limit: req.Limit,
 	}
@@ -1000,11 +1200,12 @@ func (b *GetUnreadReactionsQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // SearchQueryBuilder is query builder of MessagesSearch.
 type SearchQueryBuilder struct {
-	raw       *tg.Client
-	req       tg.MessagesSearchRequest
-	batchSize int
-	addOffset int
-	offsetID  int
+	raw         *tg.Client
+	req         tg.MessagesSearchRequest
+	batchSize   int
+	peerPromise peer.Promise
+	addOffset   int
+	offsetID    int
 }
 
 // Search creates query builder of MessagesSearch.
@@ -1021,6 +1222,24 @@ func (q *QueryBuilder) Search(paramPeer tg.InputPeerClass) *SearchQueryBuilder {
 	}
 
 	b.req.Peer = paramPeer
+	return b
+}
+
+// SearchResolve creates query builder of MessagesSearch, resolving the
+// peer from the given input using the QueryBuilder's resolver.
+//
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+func (q *QueryBuilder) SearchResolve(from string) *SearchQueryBuilder {
+	b := q.Search(&tg.InputPeerEmpty{})
+	b.peerPromise = peer.Resolve(q.resolver, from)
 	return b
 }
 
@@ -1198,6 +1417,14 @@ func (b *SearchQueryBuilder) Voice() *SearchQueryBuilder {
 
 // Query implements Query interface.
 func (b *SearchQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
+	if b.peerPromise != nil {
+		p, err := b.peerPromise(ctx)
+		if err != nil {
+			return nil, errors.Wrap(err, "resolve peer")
+		}
+		b.req.Peer = p
+		b.peerPromise = nil
+	}
 	r := &tg.MessagesSearchRequest{
 		Limit: req.Limit,
 	}

--- a/telegram/query/messages/resolve_test.go
+++ b/telegram/query/messages/resolve_test.go
@@ -1,0 +1,74 @@
+package messages
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram/message/peer"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/tgmock"
+)
+
+func TestGetHistoryResolve(t *testing.T) {
+	ctx := context.Background()
+	mock := tgmock.NewRequire(t)
+	raw := tg.NewClient(mock)
+
+	resolved := &tg.InputPeerUser{UserID: 10, AccessHash: 42}
+
+	// Default resolver issues contacts.resolveUsername for the domain.
+	mock.ExpectCall(&tg.ContactsResolveUsernameRequest{Username: "telegram"}).
+		ThenResult(&tg.ContactsResolvedPeer{
+			Peer:  &tg.PeerUser{UserID: 10},
+			Users: []tg.UserClass{&tg.User{ID: 10, AccessHash: 42}},
+		})
+
+	// The resolved peer must reach messages.getHistory.
+	mock.ExpectCall(&tg.MessagesGetHistoryRequest{
+		Peer:  resolved,
+		Limit: 1,
+	}).ThenResult(messagesClass(generateMessages(1), 1))
+
+	res, err := NewQueryBuilder(raw).
+		GetHistoryResolve("telegram").
+		Query(ctx, Request{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.(*tg.MessagesChannelMessages).Count)
+}
+
+type stubResolver struct {
+	peer tg.InputPeerClass
+}
+
+func (s stubResolver) ResolveDomain(context.Context, string) (tg.InputPeerClass, error) {
+	return s.peer, nil
+}
+
+func (s stubResolver) ResolvePhone(context.Context, string) (tg.InputPeerClass, error) {
+	return s.peer, nil
+}
+
+var _ peer.Resolver = stubResolver{}
+
+func TestGetHistoryResolveWithResolver(t *testing.T) {
+	ctx := context.Background()
+	mock := tgmock.NewRequire(t)
+	raw := tg.NewClient(mock)
+
+	resolved := &tg.InputPeerUser{UserID: 1, AccessHash: 1}
+
+	// Custom resolver short-circuits, so no contacts.resolveUsername is expected.
+	mock.ExpectCall(&tg.MessagesGetHistoryRequest{
+		Peer:  resolved,
+		Limit: 1,
+	}).ThenResult(messagesClass(generateMessages(1), 1))
+
+	res, err := NewQueryBuilder(raw).
+		WithResolver(stubResolver{peer: resolved}).
+		GetHistoryResolve("telegram").
+		Query(ctx, Request{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.(*tg.MessagesChannelMessages).Count)
+}

--- a/telegram/query/query_example_test.go
+++ b/telegram/query/query_example_test.go
@@ -151,3 +151,34 @@ func ExampleQuery_getAdmins() {
 		panic(err)
 	}
 }
+
+func ExampleQuery_resolveHistory() {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
+	defer cancel()
+
+	client, err := telegram.ClientFromEnvironment(telegram.Options{})
+	if err != nil {
+		panic(err)
+	}
+
+	// This example iterates over the history of a peer addressed by username,
+	// resolving the peer lazily instead of resolving it by hand beforehand.
+	if err := client.Run(ctx, func(ctx context.Context) error {
+		raw := tg.NewClient(client)
+
+		return query.NewQuery(raw).
+			Messages().
+			GetHistoryResolve("telegram").
+			ForEach(ctx, func(ctx context.Context, elem messages.Elem) error {
+				msg, ok := elem.Msg.(*tg.Message)
+				if !ok {
+					return nil
+				}
+				fmt.Println(msg.Message)
+
+				return nil
+			})
+	}); err != nil {
+		panic(err)
+	}
+}


### PR DESCRIPTION
Closes #283.

## Problem

Query builders that take a peer required the caller to resolve the peer by hand first:

```go
p, err := peer.Resolve(resolver, "telegram")(ctx)
if err != nil {
    // ...
}
query.NewQuery(raw).Messages().GetHistory(p).ForEach(ctx, cb)
```

## Change

The `itergen` generator now emits a `<Method>Resolve(from string)` sibling for every query builder that has a required `tg.InputPeerClass` parameter, so the peer can be addressed by domain / phone / deeplink directly:

```go
query.NewQuery(raw).Messages().GetHistoryResolve("telegram").ForEach(ctx, cb)
```

- The package `QueryBuilder` now carries a `peer.Resolver`, defaulting to `peer.DefaultResolver(raw)` and overridable via `WithResolver(...)` — mirroring `message.Sender`.
- The peer is resolved **lazily** inside `Query(ctx, …)` and cached; resolve errors are wrapped so context cancellation surfaces correctly.
- `from` accepts the same inputs as `peer.Resolve` (`@telegram`, `telegram`, `t.me/telegram`, `tg://resolve?domain=…`, phone numbers).
- Generated for all 8 peer-taking `messages` builders: `GetHistory`, `GetRecentLocations`, `GetReplies`, `GetSavedHistory`, `GetUnreadMentions`, `GetUnreadPollVotes`, `GetUnreadReactions`, `Search`.
- Packages without peer methods (`photos`, `participants`, `dialogs`, …) are unchanged.

## Generator-only edits

Per `CLAUDE.md`, only the generator was hand-edited; `messages/queries.gen.go` is regenerated. `make generate` is stable (no further diff).

## Testing

- `go test -race ./telegram/query/...` — green, including new `resolve_test.go` covering the default-resolver path and a custom `WithResolver` path.
- Added a runnable `ExampleQuery_resolveHistory`.
- `go build ./...`, `go vet ./telegram/query/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)