### PR TITLE
feat(query): accept lazy peer.Resolve in query builders

### DIFF
--- a/telegram/message/peer.go
+++ b/telegram/message/peer.go
@@ -78,7 +78,7 @@ func (s *Sender) Self() *RequestBuilder {
 //	+1 (311) 555-0123
 //	+1 311 555-6162
 func (s *Sender) Resolve(from string, decorators ...peer.PromiseDecorator) *RequestBuilder {
-	return s.builder(peer.Resolve(s.resolver, from), decorators)
+	return s.builder(peer.Resolve(from).Bind(s.resolver), decorators)
 }
 
 // ResolvePhone uses given phone to create new peer promise.

--- a/telegram/message/peer/input.go
+++ b/telegram/message/peer/input.go
@@ -1,0 +1,89 @@
+package peer
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/tg"
+)
+
+// InputPeer is a peer input accepted by helpers that need a peer.
+//
+// It is implemented both by concrete tg.InputPeerClass values and by lazy
+// references created with Resolve, allowing peers to be passed by
+// username/phone/deeplink and resolved lazily.
+type InputPeer interface {
+	// Zero reports whether the value has a zero value.
+	Zero() bool
+	// String implements fmt.Stringer.
+	String() string
+}
+
+// Resolved is a lazily-resolved peer reference produced by Resolve.
+//
+// It implements InputPeer, so it can be passed directly to helpers that accept
+// a peer. The actual resolution is deferred until the helper runs, using the
+// resolver provided by that helper.
+type Resolved struct {
+	fn func(ctx context.Context, r Resolver) (tg.InputPeerClass, error)
+}
+
+// Zero reports whether r is unset.
+func (r *Resolved) Zero() bool {
+	return r == nil || r.fn == nil
+}
+
+// String implements fmt.Stringer.
+func (r *Resolved) String() string {
+	return "peer.Resolved"
+}
+
+// Bind binds the given resolver to the reference, producing a Promise.
+func (r *Resolved) Bind(resolver Resolver) Promise {
+	return func(ctx context.Context) (tg.InputPeerClass, error) {
+		if r.Zero() {
+			return nil, errors.New("empty peer reference")
+		}
+		return r.fn(ctx, resolver)
+	}
+}
+
+// Resolve creates a lazy peer reference from the given text.
+//
+// It auto-detects domain, phone and deeplink forms. The reference is resolved
+// lazily, using the resolver of the helper it is passed to.
+// Input examples:
+//
+//	@telegram
+//	telegram
+//	t.me/telegram
+//	https://t.me/telegram
+//	tg:resolve?domain=telegram
+//	tg://resolve?domain=telegram
+//	+13115552368
+//	+1 (311) 555-0123
+//	+1 311 555-6162
+//	13115556162
+func Resolve(from string) *Resolved {
+	return &Resolved{fn: func(ctx context.Context, r Resolver) (tg.InputPeerClass, error) {
+		return resolve(r, from)(ctx)
+	}}
+}
+
+// ResolveInputPeer resolves input to a concrete tg.InputPeerClass.
+//
+// Concrete tg.InputPeerClass values are returned as-is; lazy references created
+// by Resolve are resolved using r.
+func ResolveInputPeer(ctx context.Context, r Resolver, input InputPeer) (tg.InputPeerClass, error) {
+	switch v := input.(type) {
+	case nil:
+		return nil, errors.New("nil peer")
+	case tg.InputPeerClass:
+		return v, nil
+	case *Resolved:
+		return v.Bind(r)(ctx)
+	default:
+		return nil, errors.Errorf("unsupported peer input type %T", input)
+	}
+}

--- a/telegram/message/peer/input_test.go
+++ b/telegram/message/peer/input_test.go
@@ -1,0 +1,63 @@
+package peer
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+type stubResolver struct {
+	peer tg.InputPeerClass
+}
+
+func (s stubResolver) ResolveDomain(context.Context, string) (tg.InputPeerClass, error) {
+	return s.peer, nil
+}
+
+func (s stubResolver) ResolvePhone(context.Context, string) (tg.InputPeerClass, error) {
+	return s.peer, nil
+}
+
+func TestResolveInputPeer(t *testing.T) {
+	ctx := context.Background()
+	want := &tg.InputPeerUser{UserID: 1, AccessHash: 2}
+	r := stubResolver{peer: want}
+
+	t.Run("Concrete", func(t *testing.T) {
+		got, err := ResolveInputPeer(ctx, r, want)
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("Resolved", func(t *testing.T) {
+		got, err := ResolveInputPeer(ctx, r, Resolve("telegram"))
+		require.NoError(t, err)
+		require.Equal(t, want, got)
+	})
+
+	t.Run("Nil", func(t *testing.T) {
+		_, err := ResolveInputPeer(ctx, r, nil)
+		require.Error(t, err)
+	})
+
+	t.Run("Unsupported", func(t *testing.T) {
+		// An InputUser satisfies InputPeer (Zero/String) but is not a peer.
+		_, err := ResolveInputPeer(ctx, r, &tg.InputUser{UserID: 1})
+		require.Error(t, err)
+	})
+}
+
+func TestResolvedBind(t *testing.T) {
+	ctx := context.Background()
+	want := &tg.InputPeerUser{UserID: 1, AccessHash: 2}
+
+	got, err := Resolve("telegram").Bind(stubResolver{peer: want})(ctx)
+	require.NoError(t, err)
+	require.Equal(t, want, got)
+
+	var empty *Resolved
+	require.True(t, empty.Zero())
+}

--- a/telegram/message/peer/resolve.go
+++ b/telegram/message/peer/resolve.go
@@ -14,7 +14,7 @@ import (
 // Promise is a peer promise.
 type Promise func(ctx context.Context) (tg.InputPeerClass, error)
 
-// Resolve uses given string to create new peer promise.
+// resolve uses given string to create new peer promise.
 // It resolves peer of message using given Resolver.
 // Input examples:
 //
@@ -28,7 +28,7 @@ type Promise func(ctx context.Context) (tg.InputPeerClass, error)
 //	+1 (311) 555-0123
 //	+1 311 555-6162
 //	13115556162
-func Resolve(r Resolver, from string) Promise {
+func resolve(r Resolver, from string) Promise {
 	from = strings.TrimSpace(from)
 
 	if deeplink.IsDeeplinkLike(from) {

--- a/telegram/message/peer/resolve_test.go
+++ b/telegram/message/peer/resolve_test.go
@@ -68,9 +68,8 @@ func TestSender_Resolve(t *testing.T) {
 					a := require.New(t)
 
 					p, err := Resolve(
-						resolver(t, tt.domain, expected),
 						fmt.Sprintf(format.fmt, tt.domain),
-					)(context.Background())
+					).Bind(resolver(t, tt.domain, expected))(context.Background())
 					if tt.wantErr || format.wantErr {
 						a.Error(err)
 						return

--- a/telegram/query/internal/itergen/_template/gen.tmpl
+++ b/telegram/query/internal/itergen/_template/gen.tmpl
@@ -77,7 +77,8 @@ type {{ $.Name }}QueryBuilder struct {
     req {{ $.RequestName }}
     batchSize int
     {{- if $.PeerParam }}
-    peerPromise peer.Promise
+    resolver peer.Resolver
+    peerInput peer.InputPeer
     {{- end }}
     {{- range $mapping := $.AdditionalMapping }}
     {{ $mapping.Arg.Name }} {{ $mapping.Arg.Type }}
@@ -85,9 +86,21 @@ type {{ $.Name }}QueryBuilder struct {
 }
 
 // {{ $.Name }} creates query builder of {{ $.OriginalName }}.
-func (q *QueryBuilder) {{ $.Name }}({{ range $arg := $.RequiredParams }}param{{ $arg.OriginalName }} {{ $arg.Type }},{{ end }}) *{{ $.Name }}QueryBuilder {
+{{- if $.PeerParam }}
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	{{ $.Name }}(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+{{- end }}
+func (q *QueryBuilder) {{ $.Name }}({{ range $arg := $.RequiredParams }}param{{ $arg.OriginalName }} {{ if and $.PeerParam (eq $arg.OriginalName $.PeerParam.OriginalName) }}peer.InputPeer{{ else }}{{ $arg.Type }}{{ end }},{{ end }}) *{{ $.Name }}QueryBuilder {
     b := &{{ $.Name }}QueryBuilder{
         raw: q.raw,
+        {{- if $.PeerParam }}
+        resolver: q.resolver,
+        {{- end }}
         batchSize: 1,
         req:{{ $.RequestName }}{
         {{- range $f := $.AdditionalParams }}{{ if eq ($f.Type) ("tg.MessagesFilterClass") }}
@@ -100,29 +113,18 @@ func (q *QueryBuilder) {{ $.Name }}({{ range $arg := $.RequiredParams }}param{{ 
         },
     }
 {{ range $arg := $.RequiredParams }}
+{{- if and $.PeerParam (eq $arg.OriginalName $.PeerParam.OriginalName) }}
+   if p, ok := param{{ $arg.OriginalName }}.(tg.InputPeerClass); ok {
+       b.req.{{ $arg.OriginalName }} = p
+   } else {
+       b.peerInput = param{{ $arg.OriginalName }}
+   }
+{{- else }}
    b.req.{{ $arg.OriginalName }} = param{{ $arg.OriginalName }}
+{{- end }}
 {{- end }}
     return b
 }
-{{ if $.PeerParam }}
-// {{ $.Name }}Resolve creates query builder of {{ $.OriginalName }}, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) {{ $.Name }}Resolve({{ range $arg := $.RequiredParams }}{{ if eq $arg.OriginalName $.PeerParam.OriginalName }}from string,{{ else }}param{{ $arg.OriginalName }} {{ $arg.Type }},{{ end }}{{ end }}) *{{ $.Name }}QueryBuilder {
-    b := q.{{ $.Name }}({{ range $arg := $.RequiredParams }}{{ if eq $arg.OriginalName $.PeerParam.OriginalName }}&tg.InputPeerEmpty{},{{ else }}param{{ $arg.OriginalName }},{{ end }}{{ end }})
-    b.peerPromise = peer.Resolve(q.resolver, from)
-    return b
-}
-{{ end }}
 
 // BatchSize sets buffer of message loaded from one request.
 // Be carefully, when set this limit, because Telegram does not return error if limit is too big,
@@ -164,13 +166,13 @@ func (b *{{ $.Name }}QueryBuilder) {{ $f.ConstructorName }}({{ range $arg := $f.
 // Query implements Query interface.
 func (b *{{ $.Name }}QueryBuilder) Query(ctx context.Context, req Request) ({{ $.ResultName }}, error) {
     {{- if $.PeerParam }}
-    if b.peerPromise != nil {
-        p, err := b.peerPromise(ctx)
+    if b.peerInput != nil {
+        p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
         if err != nil {
             return nil, errors.Wrap(err, "resolve peer")
         }
         b.req.{{ $.PeerParam.OriginalName }} = p
-        b.peerPromise = nil
+        b.peerInput = nil
     }
     {{- end }}
 	r := &{{ $.RequestName }}{

--- a/telegram/query/messages/queries.gen.go
+++ b/telegram/query/messages/queries.gen.go
@@ -172,44 +172,39 @@ func (b *ChannelsSearchPostsQueryBuilder) Collect(ctx context.Context) ([]Elem, 
 
 // GetHistoryQueryBuilder is query builder of MessagesGetHistory.
 type GetHistoryQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetHistoryRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetDate  int
-	offsetID    int
+	raw        *tg.Client
+	req        tg.MessagesGetHistoryRequest
+	batchSize  int
+	resolver   peer.Resolver
+	peerInput  peer.InputPeer
+	addOffset  int
+	offsetDate int
+	offsetID   int
 }
 
 // GetHistory creates query builder of MessagesGetHistory.
-func (q *QueryBuilder) GetHistory(paramPeer tg.InputPeerClass) *GetHistoryQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetHistory(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetHistory(paramPeer peer.InputPeer) *GetHistoryQueryBuilder {
 	b := &GetHistoryQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetHistoryRequest{
 			Peer: &tg.InputPeerEmpty{},
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetHistoryResolve creates query builder of MessagesGetHistory, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetHistoryResolve(from string) *GetHistoryQueryBuilder {
-	b := q.GetHistory(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -241,13 +236,13 @@ func (b *GetHistoryQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetHistoryQu
 
 // Query implements Query interface.
 func (b *GetHistoryQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetHistoryRequest{
 		Limit: req.Limit,
@@ -393,41 +388,36 @@ func (b *GetPersonalChannelHistoryQueryBuilder) Collect(ctx context.Context) ([]
 
 // GetRecentLocationsQueryBuilder is query builder of MessagesGetRecentLocations.
 type GetRecentLocationsQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetRecentLocationsRequest
-	batchSize   int
-	peerPromise peer.Promise
+	raw       *tg.Client
+	req       tg.MessagesGetRecentLocationsRequest
+	batchSize int
+	resolver  peer.Resolver
+	peerInput peer.InputPeer
 }
 
 // GetRecentLocations creates query builder of MessagesGetRecentLocations.
-func (q *QueryBuilder) GetRecentLocations(paramPeer tg.InputPeerClass) *GetRecentLocationsQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetRecentLocations(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetRecentLocations(paramPeer peer.InputPeer) *GetRecentLocationsQueryBuilder {
 	b := &GetRecentLocationsQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetRecentLocationsRequest{
 			Peer: &tg.InputPeerEmpty{},
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetRecentLocationsResolve creates query builder of MessagesGetRecentLocations, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetRecentLocationsResolve(from string) *GetRecentLocationsQueryBuilder {
-	b := q.GetRecentLocations(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -447,13 +437,13 @@ func (b *GetRecentLocationsQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetR
 
 // Query implements Query interface.
 func (b *GetRecentLocationsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetRecentLocationsRequest{
 		Limit: req.Limit,
@@ -508,44 +498,39 @@ func (b *GetRecentLocationsQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // GetRepliesQueryBuilder is query builder of MessagesGetReplies.
 type GetRepliesQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetRepliesRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetDate  int
-	offsetID    int
+	raw        *tg.Client
+	req        tg.MessagesGetRepliesRequest
+	batchSize  int
+	resolver   peer.Resolver
+	peerInput  peer.InputPeer
+	addOffset  int
+	offsetDate int
+	offsetID   int
 }
 
 // GetReplies creates query builder of MessagesGetReplies.
-func (q *QueryBuilder) GetReplies(paramPeer tg.InputPeerClass) *GetRepliesQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetReplies(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetReplies(paramPeer peer.InputPeer) *GetRepliesQueryBuilder {
 	b := &GetRepliesQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetRepliesRequest{
 			Peer: &tg.InputPeerEmpty{},
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetRepliesResolve creates query builder of MessagesGetReplies, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetRepliesResolve(from string) *GetRepliesQueryBuilder {
-	b := q.GetReplies(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -583,13 +568,13 @@ func (b *GetRepliesQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetRepliesQu
 
 // Query implements Query interface.
 func (b *GetRepliesQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetRepliesRequest{
 		Limit: req.Limit,
@@ -650,19 +635,28 @@ func (b *GetRepliesQueryBuilder) Collect(ctx context.Context) ([]Elem, error) {
 
 // GetSavedHistoryQueryBuilder is query builder of MessagesGetSavedHistory.
 type GetSavedHistoryQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetSavedHistoryRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetDate  int
-	offsetID    int
+	raw        *tg.Client
+	req        tg.MessagesGetSavedHistoryRequest
+	batchSize  int
+	resolver   peer.Resolver
+	peerInput  peer.InputPeer
+	addOffset  int
+	offsetDate int
+	offsetID   int
 }
 
 // GetSavedHistory creates query builder of MessagesGetSavedHistory.
-func (q *QueryBuilder) GetSavedHistory(paramPeer tg.InputPeerClass) *GetSavedHistoryQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetSavedHistory(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetSavedHistory(paramPeer peer.InputPeer) *GetSavedHistoryQueryBuilder {
 	b := &GetSavedHistoryQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetSavedHistoryRequest{
 			ParentPeer: &tg.InputPeerEmpty{},
@@ -670,25 +664,11 @@ func (q *QueryBuilder) GetSavedHistory(paramPeer tg.InputPeerClass) *GetSavedHis
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetSavedHistoryResolve creates query builder of MessagesGetSavedHistory, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetSavedHistoryResolve(from string) *GetSavedHistoryQueryBuilder {
-	b := q.GetSavedHistory(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -726,13 +706,13 @@ func (b *GetSavedHistoryQueryBuilder) Peer(paramPeer tg.InputPeerClass) *GetSave
 
 // Query implements Query interface.
 func (b *GetSavedHistoryQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetSavedHistoryRequest{
 		Limit: req.Limit,
@@ -793,43 +773,38 @@ func (b *GetSavedHistoryQueryBuilder) Collect(ctx context.Context) ([]Elem, erro
 
 // GetUnreadMentionsQueryBuilder is query builder of MessagesGetUnreadMentions.
 type GetUnreadMentionsQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetUnreadMentionsRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetID    int
+	raw       *tg.Client
+	req       tg.MessagesGetUnreadMentionsRequest
+	batchSize int
+	resolver  peer.Resolver
+	peerInput peer.InputPeer
+	addOffset int
+	offsetID  int
 }
 
 // GetUnreadMentions creates query builder of MessagesGetUnreadMentions.
-func (q *QueryBuilder) GetUnreadMentions(paramPeer tg.InputPeerClass) *GetUnreadMentionsQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetUnreadMentions(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetUnreadMentions(paramPeer peer.InputPeer) *GetUnreadMentionsQueryBuilder {
 	b := &GetUnreadMentionsQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetUnreadMentionsRequest{
 			Peer: &tg.InputPeerEmpty{},
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetUnreadMentionsResolve creates query builder of MessagesGetUnreadMentions, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetUnreadMentionsResolve(from string) *GetUnreadMentionsQueryBuilder {
-	b := q.GetUnreadMentions(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -861,13 +836,13 @@ func (b *GetUnreadMentionsQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadMe
 
 // Query implements Query interface.
 func (b *GetUnreadMentionsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetUnreadMentionsRequest{
 		Limit: req.Limit,
@@ -926,43 +901,38 @@ func (b *GetUnreadMentionsQueryBuilder) Collect(ctx context.Context) ([]Elem, er
 
 // GetUnreadPollVotesQueryBuilder is query builder of MessagesGetUnreadPollVotes.
 type GetUnreadPollVotesQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetUnreadPollVotesRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetID    int
+	raw       *tg.Client
+	req       tg.MessagesGetUnreadPollVotesRequest
+	batchSize int
+	resolver  peer.Resolver
+	peerInput peer.InputPeer
+	addOffset int
+	offsetID  int
 }
 
 // GetUnreadPollVotes creates query builder of MessagesGetUnreadPollVotes.
-func (q *QueryBuilder) GetUnreadPollVotes(paramPeer tg.InputPeerClass) *GetUnreadPollVotesQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetUnreadPollVotes(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetUnreadPollVotes(paramPeer peer.InputPeer) *GetUnreadPollVotesQueryBuilder {
 	b := &GetUnreadPollVotesQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetUnreadPollVotesRequest{
 			Peer: &tg.InputPeerEmpty{},
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetUnreadPollVotesResolve creates query builder of MessagesGetUnreadPollVotes, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetUnreadPollVotesResolve(from string) *GetUnreadPollVotesQueryBuilder {
-	b := q.GetUnreadPollVotes(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -994,13 +964,13 @@ func (b *GetUnreadPollVotesQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadP
 
 // Query implements Query interface.
 func (b *GetUnreadPollVotesQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetUnreadPollVotesRequest{
 		Limit: req.Limit,
@@ -1059,18 +1029,27 @@ func (b *GetUnreadPollVotesQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // GetUnreadReactionsQueryBuilder is query builder of MessagesGetUnreadReactions.
 type GetUnreadReactionsQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesGetUnreadReactionsRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetID    int
+	raw       *tg.Client
+	req       tg.MessagesGetUnreadReactionsRequest
+	batchSize int
+	resolver  peer.Resolver
+	peerInput peer.InputPeer
+	addOffset int
+	offsetID  int
 }
 
 // GetUnreadReactions creates query builder of MessagesGetUnreadReactions.
-func (q *QueryBuilder) GetUnreadReactions(paramPeer tg.InputPeerClass) *GetUnreadReactionsQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	GetUnreadReactions(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) GetUnreadReactions(paramPeer peer.InputPeer) *GetUnreadReactionsQueryBuilder {
 	b := &GetUnreadReactionsQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesGetUnreadReactionsRequest{
 			Peer:        &tg.InputPeerEmpty{},
@@ -1078,25 +1057,11 @@ func (q *QueryBuilder) GetUnreadReactions(paramPeer tg.InputPeerClass) *GetUnrea
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// GetUnreadReactionsResolve creates query builder of MessagesGetUnreadReactions, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) GetUnreadReactionsResolve(from string) *GetUnreadReactionsQueryBuilder {
-	b := q.GetUnreadReactions(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -1134,13 +1099,13 @@ func (b *GetUnreadReactionsQueryBuilder) TopMsgID(paramTopMsgID int) *GetUnreadR
 
 // Query implements Query interface.
 func (b *GetUnreadReactionsQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesGetUnreadReactionsRequest{
 		Limit: req.Limit,
@@ -1200,18 +1165,27 @@ func (b *GetUnreadReactionsQueryBuilder) Collect(ctx context.Context) ([]Elem, e
 
 // SearchQueryBuilder is query builder of MessagesSearch.
 type SearchQueryBuilder struct {
-	raw         *tg.Client
-	req         tg.MessagesSearchRequest
-	batchSize   int
-	peerPromise peer.Promise
-	addOffset   int
-	offsetID    int
+	raw       *tg.Client
+	req       tg.MessagesSearchRequest
+	batchSize int
+	resolver  peer.Resolver
+	peerInput peer.InputPeer
+	addOffset int
+	offsetID  int
 }
 
 // Search creates query builder of MessagesSearch.
-func (q *QueryBuilder) Search(paramPeer tg.InputPeerClass) *SearchQueryBuilder {
+//
+// The peer may be a concrete tg.InputPeerClass or a lazy reference created with
+// peer.Resolve, e.g.
+//
+//	Search(peer.Resolve("telegram"))
+//
+// resolved lazily using the QueryBuilder's resolver.
+func (q *QueryBuilder) Search(paramPeer peer.InputPeer) *SearchQueryBuilder {
 	b := &SearchQueryBuilder{
 		raw:       q.raw,
+		resolver:  q.resolver,
 		batchSize: 1,
 		req: tg.MessagesSearchRequest{
 			Filter:      &tg.InputMessagesFilterEmpty{},
@@ -1221,25 +1195,11 @@ func (q *QueryBuilder) Search(paramPeer tg.InputPeerClass) *SearchQueryBuilder {
 		},
 	}
 
-	b.req.Peer = paramPeer
-	return b
-}
-
-// SearchResolve creates query builder of MessagesSearch, resolving the
-// peer from the given input using the QueryBuilder's resolver.
-//
-// Input examples:
-//
-//	@telegram
-//	telegram
-//	t.me/telegram
-//	https://t.me/telegram
-//	tg:resolve?domain=telegram
-//	tg://resolve?domain=telegram
-//	+13115552368
-func (q *QueryBuilder) SearchResolve(from string) *SearchQueryBuilder {
-	b := q.Search(&tg.InputPeerEmpty{})
-	b.peerPromise = peer.Resolve(q.resolver, from)
+	if p, ok := paramPeer.(tg.InputPeerClass); ok {
+		b.req.Peer = p
+	} else {
+		b.peerInput = paramPeer
+	}
 	return b
 }
 
@@ -1417,13 +1377,13 @@ func (b *SearchQueryBuilder) Voice() *SearchQueryBuilder {
 
 // Query implements Query interface.
 func (b *SearchQueryBuilder) Query(ctx context.Context, req Request) (tg.MessagesMessagesClass, error) {
-	if b.peerPromise != nil {
-		p, err := b.peerPromise(ctx)
+	if b.peerInput != nil {
+		p, err := peer.ResolveInputPeer(ctx, b.resolver, b.peerInput)
 		if err != nil {
 			return nil, errors.Wrap(err, "resolve peer")
 		}
 		b.req.Peer = p
-		b.peerPromise = nil
+		b.peerInput = nil
 	}
 	r := &tg.MessagesSearchRequest{
 		Limit: req.Limit,

--- a/telegram/query/messages/resolve_test.go
+++ b/telegram/query/messages/resolve_test.go
@@ -32,7 +32,27 @@ func TestGetHistoryResolve(t *testing.T) {
 	}).ThenResult(messagesClass(generateMessages(1), 1))
 
 	res, err := NewQueryBuilder(raw).
-		GetHistoryResolve("telegram").
+		GetHistory(peer.Resolve("telegram")).
+		Query(ctx, Request{Limit: 1})
+	require.NoError(t, err)
+	require.Equal(t, 1, res.(*tg.MessagesChannelMessages).Count)
+}
+
+func TestGetHistoryConcretePeer(t *testing.T) {
+	ctx := context.Background()
+	mock := tgmock.NewRequire(t)
+	raw := tg.NewClient(mock)
+
+	peerInput := &tg.InputPeerUser{UserID: 5, AccessHash: 7}
+
+	// Concrete peers are used as-is, without any resolve round-trip.
+	mock.ExpectCall(&tg.MessagesGetHistoryRequest{
+		Peer:  peerInput,
+		Limit: 1,
+	}).ThenResult(messagesClass(generateMessages(1), 1))
+
+	res, err := NewQueryBuilder(raw).
+		GetHistory(peerInput).
 		Query(ctx, Request{Limit: 1})
 	require.NoError(t, err)
 	require.Equal(t, 1, res.(*tg.MessagesChannelMessages).Count)
@@ -67,7 +87,7 @@ func TestGetHistoryResolveWithResolver(t *testing.T) {
 
 	res, err := NewQueryBuilder(raw).
 		WithResolver(stubResolver{peer: resolved}).
-		GetHistoryResolve("telegram").
+		GetHistory(peer.Resolve("telegram")).
 		Query(ctx, Request{Limit: 1})
 	require.NoError(t, err)
 	require.Equal(t, 1, res.(*tg.MessagesChannelMessages).Count)

--- a/telegram/query/query_example_test.go
+++ b/telegram/query/query_example_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/gotd/td/telegram"
 	"github.com/gotd/td/telegram/downloader"
+	"github.com/gotd/td/telegram/message/peer"
 	"github.com/gotd/td/telegram/query"
 	"github.com/gotd/td/telegram/query/channels/participants"
 	"github.com/gotd/td/telegram/query/dialogs"
@@ -168,7 +169,7 @@ func ExampleQuery_resolveHistory() {
 
 		return query.NewQuery(raw).
 			Messages().
-			GetHistoryResolve("telegram").
+			GetHistory(peer.Resolve("telegram")).
 			ForEach(ctx, func(ctx context.Context, elem messages.Elem) error {
 				msg, ok := elem.Msg.(*tg.Message)
 				if !ok {


### PR DESCRIPTION
Reworks the peer-resolve ergonomics to match the API in #283 directly, replacing the generated `GetHistoryResolve`-style helpers merged in #1779.

## Before

```go
p, err := peer.Resolve(resolver, "durov")(ctx)
if err != nil {
    // ...
}
query.NewQuery(raw).Messages().GetHistory(p).ForEach(ctx, cb)
```

## After (as per the issue)

```go
query.NewQuery(raw).Messages().GetHistory(peer.Resolve("durov")).ForEach(ctx, cb)
```

## How

- Peer-taking query builders now accept `peer.InputPeer` instead of `tg.InputPeerClass`.
  - `peer.InputPeer` is a small interface (`Zero`/`String`) satisfied **both** by concrete `tg.InputPeerClass` values and by lazy references, so existing `GetHistory(&tg.InputPeerUser{...})` calls keep compiling.
  - `tg.InputPeerClass` is a sealed interface (unexported `construct()`), so a lazy type cannot masquerade as one — hence the new interface.
- `peer.Resolve(from string)` now returns a lazy `*peer.Resolved` (auto-detecting domain/phone/deeplink). It is resolved inside `Query` using the builder's resolver, wrapping errors per the repo's context-error semantics.
- The package `QueryBuilder` carries a `peer.Resolver` (`peer.DefaultResolver` by default, overridable via `WithResolver`).
- `peer.ResolveInputPeer(ctx, resolver, input)` resolves a `peer.InputPeer` to a concrete peer; `(*Resolved).Bind(resolver)` yields a `peer.Promise`.

## Breaking change

`peer.Resolve(resolver, from)` → `peer.Resolve(from)`. Use `peer.Resolve(from).Bind(resolver)` for the previous behavior. `message.Sender` is updated accordingly; `peer.ResolveDomain/ResolvePhone/ResolveDeeplink` are unchanged.

## Generator-only edits

Per `CLAUDE.md`, only the `itergen` generator was hand-edited; `messages/queries.gen.go` is regenerated. `make generate` is stable.

## Testing

- `go test -race ./telegram/message/... ./telegram/query/...` — green.
- New tests: `peer.ResolveInputPeer`/`Resolved.Bind` (concrete, lazy, nil, unsupported paths) and `messages` query builder with both `peer.Resolve(...)` and a concrete peer, plus a custom `WithResolver`.
- Updated `ExampleQuery_resolveHistory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)