### PR TITLE
feat(updates): add getDifference reason and unknown-peer diagnostics

### DIFF
--- a/telegram/updates/short_peer.go
+++ b/telegram/updates/short_peer.go
@@ -3,6 +3,8 @@ package updates
 import (
 	"context"
 
+	"github.com/gotd/log"
+
 	"github.com/gotd/td/tg"
 )
 
@@ -84,6 +86,11 @@ func (s *internalState) userPeersKnown(ctx context.Context, ids []int64) bool {
 			continue
 		}
 		if _, found, err := s.userHasher.GetUserAccessHash(ctx, s.selfID, id); err != nil || !found {
+			s.log.Debug(ctx, "User access hash unknown, forcing getDifference",
+				log.Int64("user_id", id),
+				log.Bool("hasher_error", err != nil),
+				log.Error(err),
+			)
 			return false
 		}
 	}

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -175,13 +175,13 @@ func (s *internalState) Run(ctx context.Context) error {
 	}
 	s.log.Debug(ctx, "Starting updates handler")
 	defer s.log.Debug(ctx, "Updates handler stopped")
-	s.getDifferenceLogger(ctx)
+	s.getDifferenceLogger(ctx, "startup")
 
 	for {
 		select {
 		case <-ctx.Done():
 			if len(s.pts.pending) > 0 || len(s.qts.pending) > 0 || len(s.seq.pending) > 0 {
-				s.getDifferenceLogger(ctx)
+				s.getDifferenceLogger(ctx, "shutdown-flush-pending")
 			}
 			return ctx.Err()
 		case u := <-s.externalQueue:
@@ -202,16 +202,16 @@ func (s *internalState) Run(ctx context.Context) error {
 			}
 		case <-s.pts.gapTimeout.C:
 			s.log.Debug(ctx, "Pts gap timeout")
-			s.getDifferenceLogger(ctx)
+			s.getDifferenceLogger(ctx, "pts-gap-timeout")
 		case <-s.qts.gapTimeout.C:
 			s.log.Debug(ctx, "Qts gap timeout")
-			s.getDifferenceLogger(ctx)
+			s.getDifferenceLogger(ctx, "qts-gap-timeout")
 		case <-s.seq.gapTimeout.C:
 			s.log.Debug(ctx, "Seq gap timeout")
-			s.getDifferenceLogger(ctx)
+			s.getDifferenceLogger(ctx, "seq-gap-timeout")
 		case <-s.idleTimeout.C:
 			s.log.Debug(ctx, "Idle timeout")
-			s.getDifferenceLogger(ctx)
+			s.getDifferenceLogger(ctx, "idle-timeout")
 		case channelID := <-s.removeChannel:
 			s.removeChannelState(channelID)
 		}
@@ -242,7 +242,7 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 		s.saveChannelHashes(ctx, u.Chats)
 		s.saveUserHashes(ctx, u.Users)
 		if !s.messageUpdatesPeersKnown(ctx, u.Updates) {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "updates-peer-access-hash-unknown")
 		}
 		return s.handleSeq(ctx, &tg.UpdatesCombined{
 			Updates:  u.Updates,
@@ -256,7 +256,7 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 		s.saveChannelHashes(ctx, u.Chats)
 		s.saveUserHashes(ctx, u.Users)
 		if !s.messageUpdatesPeersKnown(ctx, u.Updates) {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "combined-peer-access-hash-unknown")
 		}
 		return s.handleSeq(ctx, u)
 	case *tg.UpdateShort:
@@ -266,18 +266,18 @@ func (s *internalState) handleUpdates(ctx context.Context, u tg.UpdatesClass) er
 		})
 	case *tg.UpdateShortMessage:
 		if !s.shortMessagePeersKnown(ctx, u) {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "short-message-peer-access-hash-unknown")
 		}
 		return s.handleUpdates(ctx, s.convertShortMessage(u))
 	case *tg.UpdateShortChatMessage:
 		if !s.shortChatMessagePeersKnown(ctx, u) {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "short-chat-message-peer-access-hash-unknown")
 		}
 		return s.handleUpdates(ctx, s.convertShortChatMessage(u))
 	case *tg.UpdateShortSentMessage:
 		return s.handleUpdates(ctx, s.convertShortSentMessage(u))
 	case *tg.UpdatesTooLong:
-		return s.getDifference(ctx)
+		return s.getDifference(ctx, "updates-too-long")
 	default:
 		panic(fmt.Sprintf("unexpected update type: %T", u))
 	}
@@ -300,7 +300,7 @@ func (s *internalState) handleSeq(ctx context.Context, u *tg.UpdatesCombined) er
 		}
 
 		if ptsChanged {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "seq-zero-pts-changed")
 		}
 
 		return nil
@@ -434,7 +434,7 @@ func (s *internalState) newChannelState(channelID, accessHash int64, initialPts 
 	})
 }
 
-func (s *internalState) getDifference(ctx context.Context) error {
+func (s *internalState) getDifference(ctx context.Context, reason string) error {
 	ctx, span := s.tracer.Start(ctx, "getDifference")
 	defer span.End()
 
@@ -443,7 +443,13 @@ func (s *internalState) getDifference(ctx context.Context) error {
 	s.qts.gaps.Clear()
 	s.seq.gaps.Clear()
 
-	s.log.Debug(ctx, "Getting difference")
+	s.log.Debug(ctx, "Getting difference",
+		log.String("reason", reason),
+		log.Int("pts", s.pts.State()),
+		log.Int("qts", s.qts.State()),
+		log.Int("seq", s.seq.State()),
+		log.Int("date", s.date),
+	)
 
 	setState := func(state tg.UpdatesState, reason string) {
 		if err := s.storage.SetState(ctx, s.selfID, State{}.fromRemote(&state)); err != nil {
@@ -542,7 +548,7 @@ func (s *internalState) getDifference(ctx context.Context) error {
 		}
 
 		setState(diff.IntermediateState, "updates.differenceSlice")
-		return s.getDifference(ctx)
+		return s.getDifference(ctx, "difference-slice-continue")
 
 	// The difference is too long, and the specified internalState must be used to refetch updates.
 	case *tg.UpdatesDifferenceTooLong:
@@ -551,16 +557,16 @@ func (s *internalState) getDifference(ctx context.Context) error {
 		}
 		s.pts.SetState(diff.Pts, "updates.differenceTooLong")
 		s.onCommonTooLong()
-		return s.getDifference(ctx)
+		return s.getDifference(ctx, "difference-too-long-continue")
 
 	default:
 		return errors.Errorf("unexpected diff type: %T", diff)
 	}
 }
 
-func (s *internalState) getDifferenceLogger(ctx context.Context) {
-	if err := s.getDifference(ctx); err != nil {
-		s.log.Error(ctx, "get difference error", log.Error(err))
+func (s *internalState) getDifferenceLogger(ctx context.Context, reason string) {
+	if err := s.getDifference(ctx, reason); err != nil {
+		s.log.Error(ctx, "get difference error", log.Error(err), log.String("reason", reason))
 	}
 }
 

--- a/telegram/updates/state_apply.go
+++ b/telegram/updates/state_apply.go
@@ -27,7 +27,7 @@ func (s *internalState) applySeq(ctx context.Context, state int, updates []updat
 	}
 
 	if recoverState {
-		return s.getDifference(ctx)
+		return s.getDifference(ctx, "seq-combined-pts-changed")
 	}
 
 	return nil

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -122,7 +122,7 @@ func (s *channelState) Run(ctx context.Context) error {
 	defer close(s.done)
 
 	// Subscribe to channel updates.
-	if err := s.getDifference(ctx); err != nil {
+	if err := s.getDifference(ctx, "channel-subscribe"); err != nil {
 		if errors.Is(err, errChannelInaccessible) {
 			return nil
 		}
@@ -141,19 +141,19 @@ func (s *channelState) Run(ctx context.Context) error {
 			}
 		case <-s.pts.gapTimeout.C:
 			s.log.Debug(ctx, "Gap timeout")
-			if s.getDifferenceLogger(ctx) {
+			if s.getDifferenceLogger(ctx, "channel-pts-gap-timeout") {
 				return nil
 			}
 		case <-ctx.Done():
 			if len(s.pts.pending) > 0 {
 				// This will probably fail.
-				s.getDifferenceLogger(ctx)
+				s.getDifferenceLogger(ctx, "channel-shutdown-flush-pending")
 			}
 			return ctx.Err()
 		case <-s.idleTimeout.C:
 			s.log.Debug(ctx, "Idle timeout")
 			s.resetIdleTimer()
-			if s.getDifferenceLogger(ctx) {
+			if s.getDifferenceLogger(ctx, "channel-idle-timeout") {
 				return nil
 			}
 		}
@@ -198,7 +198,7 @@ func (s *channelState) handleTooLong(ctx context.Context, long *tg.UpdateChannel
 	remotePts, ok := long.GetPts()
 	if !ok {
 		s.log.Warn(ctx, "Got UpdateChannelTooLong without pts field")
-		return s.getDifference(ctx)
+		return s.getDifference(ctx, "channel-too-long-no-pts")
 	}
 
 	// Note: we still can fetch latest diffLim updates.
@@ -208,7 +208,7 @@ func (s *channelState) handleTooLong(ctx context.Context, long *tg.UpdateChannel
 		return nil
 	}
 
-	return s.getDifference(ctx)
+	return s.getDifference(ctx, "channel-too-long")
 }
 
 func (s *channelState) applyPts(ctx context.Context, state int, updates []update) error {
@@ -241,12 +241,16 @@ func (s *channelState) applyPts(ctx context.Context, state int, updates []update
 	return nil
 }
 
-func (s *channelState) getDifference(ctx context.Context) error {
+func (s *channelState) getDifference(ctx context.Context, reason string) error {
 	ctx, span := s.tracer.Start(ctx, "channelState.getDifference")
 	defer span.End()
 	s.pts.gaps.Clear()
 
-	s.log.Debug(ctx, "Getting difference")
+	s.log.Debug(ctx, "Getting difference",
+		log.String("reason", reason),
+		log.Int64("channel_id", s.channelID),
+		log.Int("pts", s.pts.State()),
+	)
 
 	if now := time.Now(); now.Before(s.diffTimeout) {
 		dur := s.diffTimeout.Sub(now)
@@ -326,7 +330,7 @@ func (s *channelState) getDifference(ctx context.Context) error {
 		}
 
 		if !diff.Final {
-			return s.getDifference(ctx)
+			return s.getDifference(ctx, "channel-difference-not-final")
 		}
 
 		return nil
@@ -396,12 +400,12 @@ func (s *channelState) sendOut(ctx context.Context, out tracedUpdate) error {
 
 // getDifferenceLogger calls getDifference, logging any error. It returns true
 // if the channel became inaccessible and the worker should stop.
-func (s *channelState) getDifferenceLogger(ctx context.Context) (stop bool) {
-	if err := s.getDifference(ctx); err != nil {
+func (s *channelState) getDifferenceLogger(ctx context.Context, reason string) (stop bool) {
+	if err := s.getDifference(ctx, reason); err != nil {
 		if errors.Is(err, errChannelInaccessible) {
 			return true
 		}
-		s.log.Error(ctx, "get channel difference error", log.Error(err))
+		s.log.Error(ctx, "get channel difference error", log.Error(err), log.String("reason", reason))
 	}
 	return false
 }

--- a/telegram/updates/state_test.go
+++ b/telegram/updates/state_test.go
@@ -75,7 +75,7 @@ func TestStateOnTooLong(t *testing.T) {
 		WorkGroup:        &errgroup.Group{},
 	})
 
-	require.NoError(t, s.getDifference(ctx))
+	require.NoError(t, s.getDifference(ctx, "test"))
 	require.Equal(t, 1, tooLong, "OnTooLong must be called once")
 	require.Equal(t, 100, s.pts.State(), "pts must be advanced to the value from differenceTooLong")
 }


### PR DESCRIPTION
## Motivation

Reports like #1623 ("some `UpdateNewMessage` updates are not received until I send a message myself") are hard to diagnose from logs. The `updates` package already logs gap detection in detail, but two crucial things were invisible:

1. **Why** a `getDifference` fired — it is called from ~20 sites (startup, pts/qts/seq gap timeouts, idle timeout, the access-hash peer gates from #1738, `updatesTooLong`, seq-pts-changed, slice/too-long continuations, channel subscribe/too-long/idle) and every one logged the same bare `"Getting difference"`.
2. **Which peer** was unresolved — the #1738 access-hash gate (`userPeersKnown`) silently forced a `getDifference` with no record of the offending user, which is the exact signature of the "stranger messages me first" case.

## Changes

- Thread a `reason string` through `getDifference`/`getDifferenceLogger` for both the common (`internalState`) and channel (`channelState`) paths. The `"Getting difference"` log now includes the reason plus current `pts`/`qts`/`seq`/`date` (`channel_id`/`pts` for channels).
- Log the offending `user_id` (and whether it was a hasher error vs. a cache miss) in `userPeersKnown` when an access hash is unknown.

A #1623-style trace now reads:

```
User access hash unknown, forcing getDifference  user_id=12345 hasher_error=false
Getting difference  reason=short-message-peer-access-hash-unknown pts=9001 qts=1 seq=42 date=...
```

`reason` values are stable kebab-case tokens (`pts-gap-timeout`, `combined-peer-access-hash-unknown`, `channel-too-long`, …) so they are greppable and could later back a metric label.

## Notes

- Diagnostics only — no behavior change to the state machine.
- All new logging is at **Debug** level (one existing Error path also gets the reason), consistent with the package style; zero noise unless a debug logger is wired in.

## Testing

- `go test ./telegram/updates/` passes
- `go build ./...`, `go vet`, `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)