### PR TITLE
feat(updates): apply affectedMessages/affectedHistory pts

### DIFF
--- a/examples/updates/main.go
+++ b/examples/updates/main.go
@@ -51,6 +51,10 @@ func run(ctx context.Context) error {
 		UpdateHandler: gaps,
 		Middlewares: []telegram.Middleware{
 			updhook.UpdateHook(gaps.Handle),
+			// Keep local pts in sync after self-initiated reads/deletes
+			// (messages.readHistory, messages.deleteMessages, ...), whose
+			// affectedMessages/affectedHistory results are not regular updates.
+			updhook.AffectedHook(gaps),
 		},
 	})
 	if err != nil {

--- a/examples/userbot/main.go
+++ b/examples/userbot/main.go
@@ -34,6 +34,7 @@ import (
 	"github.com/gotd/td/telegram/message/peer"
 	"github.com/gotd/td/telegram/query"
 	"github.com/gotd/td/telegram/updates"
+	updhook "github.com/gotd/td/telegram/updates/hook"
 	"github.com/gotd/td/tg"
 )
 
@@ -164,6 +165,9 @@ func run(ctx context.Context) error {
 		Middlewares: []telegram.Middleware{
 			// Setting up FLOOD_WAIT handler to automatically wait and retry request.
 			waiter,
+			// Keeping local pts in sync after self-initiated reads/deletes, whose
+			// affectedMessages/affectedHistory results are not regular updates.
+			updhook.AffectedHook(updatesRecovery),
 			// Setting up general rate limits to less likely get flood wait errors.
 			ratelimit.New(rate.Every(time.Millisecond*100), 5),
 		},

--- a/telegram/updates/hook/affected.go
+++ b/telegram/updates/hook/affected.go
@@ -48,7 +48,15 @@ func (h affectedHook) Handle(next tg.Invoker) telegram.InvokeFunc {
 			return nil
 		}
 
-		if err := h.handler.HandleAffected(ctx, channelIDFromRequest(input), pts, ptsCount); err != nil {
+		channelID, ok := channelIDFromRequest(input)
+		if !ok {
+			// A channel-scoped request whose channel could not be identified
+			// (e.g. InputChannelEmpty). Skip rather than misapply a channel pts
+			// to the common sequence, which would desync update processing.
+			return nil
+		}
+
+		if err := h.handler.HandleAffected(ctx, channelID, pts, ptsCount); err != nil {
 			return errors.Wrap(err, "affected hook")
 		}
 		return nil
@@ -67,25 +75,38 @@ func affectedPts(output bin.Decoder) (pts, ptsCount int, ok bool) {
 	}
 }
 
+// hasChannelID is implemented by every channel-bearing input type that carries a
+// bare channel ID: *tg.InputChannel, *tg.InputChannelFromMessage,
+// *tg.InputPeerChannel and *tg.InputPeerChannelFromMessage. The non-channel input
+// peers (user/chat/self/empty) do not implement it.
+type hasChannelID interface {
+	GetChannelID() int64
+}
+
 // channelIDFromRequest determines which pts sequence an affected result belongs
-// to. A request carrying an InputChannel (channels.*) or an InputPeerChannel
-// (messages.* targeting a channel) routes to that channel; anything else routes
-// to the common sequence (channelID 0).
-func channelIDFromRequest(input bin.Encoder) int64 {
+// to. ok is false only for a channel-scoped request (channels.*) whose channel
+// cannot be identified, in which case the caller must skip rather than route to
+// the common sequence.
+//
+//   - channels.* request: routes to the request's channel (ok=false if it carries
+//     no channel ID, e.g. InputChannelEmpty).
+//   - messages.* request with an InputPeerChannel(FromMessage) peer: that channel.
+//   - any other request (user/chat peer, or no peer at all): common sequence (0).
+func channelIDFromRequest(input bin.Encoder) (channelID int64, ok bool) {
 	if r, ok := input.(interface {
 		GetChannel() tg.InputChannelClass
 	}); ok {
-		if ch, ok := r.GetChannel().(*tg.InputChannel); ok {
-			return ch.ChannelID
+		if ch, ok := r.GetChannel().(hasChannelID); ok {
+			return ch.GetChannelID(), true
 		}
-		return 0
+		return 0, false
 	}
 	if r, ok := input.(interface {
 		GetPeer() tg.InputPeerClass
 	}); ok {
-		if p, ok := r.GetPeer().(*tg.InputPeerChannel); ok {
-			return p.ChannelID
+		if p, ok := r.GetPeer().(hasChannelID); ok {
+			return p.GetChannelID(), true
 		}
 	}
-	return 0
+	return 0, true
 }

--- a/telegram/updates/hook/affected.go
+++ b/telegram/updates/hook/affected.go
@@ -1,0 +1,91 @@
+package hook
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// AffectedHandler applies the pts increment from a messages.affected* RPC result.
+//
+// It is implemented by *updates.Manager via its HandleAffected method.
+type AffectedHandler interface {
+	HandleAffected(ctx context.Context, channelID int64, pts, ptsCount int) error
+}
+
+// AffectedHook middleware keeps the updates manager's local pts in sync after
+// self-initiated reads and deletes.
+//
+// Methods such as messages.readHistory, messages.deleteMessages and
+// channels.deleteMessages return messages.affectedMessages /
+// messages.affectedHistory, which carry a pts increment the client must apply.
+// These results are not tg.UpdatesClass, so they bypass the regular update hook;
+// without applying them the server pts advances while the local pts stays behind,
+// making the next genuine update look like a gap (see issue #1382).
+//
+// Place it in telegram.Options.Middlewares, like UpdateHook.
+func AffectedHook(handler AffectedHandler) telegram.Middleware {
+	return affectedHook{handler: handler}
+}
+
+type affectedHook struct {
+	handler AffectedHandler
+}
+
+// Handle implements telegram.Middleware.
+func (h affectedHook) Handle(next tg.Invoker) telegram.InvokeFunc {
+	return func(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+		if err := next.Invoke(ctx, input, output); err != nil {
+			return err
+		}
+
+		pts, ptsCount, ok := affectedPts(output)
+		if !ok {
+			return nil
+		}
+
+		if err := h.handler.HandleAffected(ctx, channelIDFromRequest(input), pts, ptsCount); err != nil {
+			return errors.Wrap(err, "affected hook")
+		}
+		return nil
+	}
+}
+
+// affectedPts extracts the pts increment from a messages.affected* result.
+func affectedPts(output bin.Decoder) (pts, ptsCount int, ok bool) {
+	switch o := output.(type) {
+	case *tg.MessagesAffectedMessages:
+		return o.Pts, o.PtsCount, true
+	case *tg.MessagesAffectedHistory:
+		return o.Pts, o.PtsCount, true
+	default:
+		return 0, 0, false
+	}
+}
+
+// channelIDFromRequest determines which pts sequence an affected result belongs
+// to. A request carrying an InputChannel (channels.*) or an InputPeerChannel
+// (messages.* targeting a channel) routes to that channel; anything else routes
+// to the common sequence (channelID 0).
+func channelIDFromRequest(input bin.Encoder) int64 {
+	if r, ok := input.(interface {
+		GetChannel() tg.InputChannelClass
+	}); ok {
+		if ch, ok := r.GetChannel().(*tg.InputChannel); ok {
+			return ch.ChannelID
+		}
+		return 0
+	}
+	if r, ok := input.(interface {
+		GetPeer() tg.InputPeerClass
+	}); ok {
+		if p, ok := r.GetPeer().(*tg.InputPeerChannel); ok {
+			return p.ChannelID
+		}
+	}
+	return 0
+}

--- a/telegram/updates/hook/affected_test.go
+++ b/telegram/updates/hook/affected_test.go
@@ -1,0 +1,94 @@
+package hook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+type recordedAffected struct {
+	called    bool
+	channelID int64
+	pts       int
+	ptsCount  int
+}
+
+func (r *recordedAffected) HandleAffected(_ context.Context, channelID int64, pts, ptsCount int) error {
+	r.called = true
+	r.channelID = channelID
+	r.pts = pts
+	r.ptsCount = ptsCount
+	return nil
+}
+
+func invoke(t *testing.T, rec *recordedAffected, input bin.Encoder, output bin.Decoder) error {
+	t.Helper()
+	return AffectedHook(rec).Handle(telegram.InvokeFunc(
+		func(context.Context, bin.Encoder, bin.Decoder) error { return nil },
+	)).Invoke(context.Background(), input, output)
+}
+
+func TestAffectedHook(t *testing.T) {
+	t.Run("CommonByPeer", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.MessagesReadHistoryRequest{Peer: &tg.InputPeerUser{UserID: 1}}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedMessages{Pts: 5, PtsCount: 1}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(0), rec.channelID, "user peer routes to common")
+		assert.Equal(t, 5, rec.pts)
+		assert.Equal(t, 1, rec.ptsCount)
+	})
+
+	t.Run("CommonNoPeer", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.MessagesDeleteMessagesRequest{ID: []int{1, 2}}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedMessages{Pts: 9, PtsCount: 2}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(0), rec.channelID)
+		assert.Equal(t, 9, rec.pts)
+	})
+
+	t.Run("ChannelByInputChannel", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.ChannelsDeleteMessagesRequest{
+			Channel: &tg.InputChannel{ChannelID: 77, AccessHash: 1},
+			ID:      []int{3},
+		}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedMessages{Pts: 4, PtsCount: 1}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(77), rec.channelID, "InputChannel routes to that channel")
+	})
+
+	t.Run("ChannelByPeer", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.MessagesReadMentionsRequest{Peer: &tg.InputPeerChannel{ChannelID: 88, AccessHash: 1}}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedHistory{Pts: 7, PtsCount: 1}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(88), rec.channelID, "channel peer routes to that channel")
+		assert.Equal(t, 7, rec.pts)
+	})
+
+	t.Run("NotAffectedResult", func(t *testing.T) {
+		rec := &recordedAffected{}
+		assert.NoError(t, invoke(t, rec, &tg.MessagesReadHistoryRequest{}, &tg.UpdatesBox{
+			Updates: &tg.UpdateShortMessage{ID: 1},
+		}))
+		assert.False(t, rec.called, "non-affected results must be ignored")
+	})
+
+	t.Run("InvokeErrorSkipsHook", func(t *testing.T) {
+		rec := &recordedAffected{}
+		boom := errors.New("boom")
+		err := AffectedHook(rec).Handle(telegram.InvokeFunc(
+			func(context.Context, bin.Encoder, bin.Decoder) error { return boom },
+		)).Invoke(context.Background(), &tg.MessagesReadHistoryRequest{}, &tg.MessagesAffectedMessages{Pts: 5, PtsCount: 1})
+		assert.ErrorIs(t, err, boom)
+		assert.False(t, rec.called, "hook must not run when the RPC failed")
+	})
+}

--- a/telegram/updates/hook/affected_test.go
+++ b/telegram/updates/hook/affected_test.go
@@ -74,6 +74,35 @@ func TestAffectedHook(t *testing.T) {
 		assert.Equal(t, 7, rec.pts)
 	})
 
+	t.Run("ChannelByInputChannelFromMessage", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.ChannelsDeleteMessagesRequest{
+			Channel: &tg.InputChannelFromMessage{ChannelID: 99, MsgID: 5, Peer: &tg.InputPeerSelf{}},
+			ID:      []int{1},
+		}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedMessages{Pts: 3, PtsCount: 1}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(99), rec.channelID, "InputChannelFromMessage must route to its channel, not common")
+	})
+
+	t.Run("ChannelByPeerFromMessage", func(t *testing.T) {
+		rec := &recordedAffected{}
+		input := &tg.MessagesReadMentionsRequest{
+			Peer: &tg.InputPeerChannelFromMessage{ChannelID: 111, MsgID: 5, Peer: &tg.InputPeerSelf{}},
+		}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedHistory{Pts: 8, PtsCount: 1}))
+		assert.True(t, rec.called)
+		assert.Equal(t, int64(111), rec.channelID, "InputPeerChannelFromMessage must route to its channel, not common")
+	})
+
+	t.Run("UnidentifiedChannelSkipped", func(t *testing.T) {
+		rec := &recordedAffected{}
+		// channels.* request with no resolvable channel: must skip, not route to common.
+		input := &tg.ChannelsDeleteMessagesRequest{Channel: &tg.InputChannelEmpty{}, ID: []int{1}}
+		assert.NoError(t, invoke(t, rec, input, &tg.MessagesAffectedMessages{Pts: 3, PtsCount: 1}))
+		assert.False(t, rec.called, "must not apply a channel pts to the common sequence")
+	})
+
 	t.Run("NotAffectedResult", func(t *testing.T) {
 		rec := &recordedAffected{}
 		assert.NoError(t, invoke(t, rec, &tg.MessagesReadHistoryRequest{}, &tg.UpdatesBox{

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -71,6 +71,36 @@ func (m *Manager) Handle(ctx context.Context, u tg.UpdatesClass) error {
 	return state.Push(ctx, u)
 }
 
+// HandleAffected applies the pts increment carried by a messages.affectedMessages
+// or messages.affectedHistory RPC result, keeping the local pts in sync after a
+// self-initiated read or delete (e.g. messages.readHistory, messages.deleteMessages).
+//
+// Without this, such results silently advance the server pts while the local pts
+// stays behind, so the next genuine update looks like a gap and is postponed
+// until the next pts-changing update or a getDifference (see issue #1382).
+//
+// channelID must be the channel the result belongs to, or 0 for the common
+// (user/basic-group) sequence. The affected pts for a channel is applied only
+// when that channel is already tracked. It is a no-op before Run is called.
+//
+// Most callers should not call this directly: use the hook middleware in
+// telegram/updates/hook, which wires it from RPC results automatically.
+func (m *Manager) HandleAffected(ctx context.Context, channelID int64, pts, ptsCount int) error {
+	ctx, span := m.tracer.Start(ctx, "updates.Manager.HandleAffected")
+	defer span.End()
+
+	m.mux.Lock()
+	state := m.state
+	m.mux.Unlock()
+
+	if state == nil {
+		m.lg.Debug(ctx, "HandleAffected (no internalState)")
+		return nil
+	}
+
+	return state.PushAffected(ctx, channelID, pts, ptsCount)
+}
+
 type AuthOptions struct {
 	IsBot   bool
 	Forget  bool

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -30,6 +30,17 @@ type tracedUpdate struct {
 	span   trace.SpanContext
 }
 
+// affectedUpdate carries a pts increment from a messages.affectedMessages /
+// messages.affectedHistory RPC result to be applied on the internalState
+// goroutine. A non-zero channelID routes it to that channel's pts sequence;
+// zero targets the common sequence.
+type affectedUpdate struct {
+	channelID int64
+	pts       int
+	ptsCount  int
+	span      trace.SpanContext
+}
+
 type internalState struct {
 	// Updates channel.
 	externalQueue chan tracedUpdate
@@ -37,6 +48,10 @@ type internalState struct {
 	// Updates from channel states
 	// during updates.getChannelDifference.
 	internalQueue chan tracedUpdate
+
+	// affectedQueue receives pts increments from messages.affected* RPC results
+	// (see Manager.HandleAffected) to apply on the internalState goroutine.
+	affectedQueue chan affectedUpdate
 
 	// Common internalState.
 	pts, qts, seq *sequenceBox
@@ -91,6 +106,7 @@ func newState(ctx context.Context, cfg stateConfig) *internalState {
 	s := &internalState{
 		externalQueue: make(chan tracedUpdate, 10),
 		internalQueue: make(chan tracedUpdate, 10),
+		affectedQueue: make(chan affectedUpdate, 10),
 
 		date:        cfg.State.Date,
 		idleTimeout: time.NewTimer(idleTimeout),
@@ -154,6 +170,22 @@ func (s *internalState) Push(ctx context.Context, u tg.UpdatesClass) error {
 	}
 }
 
+// PushAffected enqueues a pts increment from a messages.affected* RPC result.
+func (s *internalState) PushAffected(ctx context.Context, channelID int64, pts, ptsCount int) error {
+	au := affectedUpdate{
+		channelID: channelID,
+		pts:       pts,
+		ptsCount:  ptsCount,
+		span:      trace.SpanContextFromContext(ctx),
+	}
+	select {
+	case s.affectedQueue <- au:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
 // isFatalError returns true if error is fatal so we should stop updates handler.
 func isFatalError(err error) bool {
 	// See https://github.com/gotd/td/issues/1458.
@@ -199,6 +231,11 @@ func (s *internalState) Run(ctx context.Context) error {
 				if isFatalError(err) {
 					return errors.Wrap(err, "fatal error")
 				}
+			}
+		case a := <-s.affectedQueue:
+			ctx := trace.ContextWithSpanContext(ctx, a.span)
+			if err := s.handleAffected(ctx, a.channelID, a.pts, a.ptsCount); err != nil {
+				s.log.Error(ctx, "Handle affected error", log.Error(err))
 			}
 		case <-s.pts.gapTimeout.C:
 			s.log.Debug(ctx, "Pts gap timeout")
@@ -324,6 +361,47 @@ func (s *internalState) handlePts(ctx context.Context, pts, ptsCount int, u tg.U
 		State:    pts,
 		Count:    ptsCount,
 		Entities: ents,
+	})
+}
+
+// handleAffected applies a pts increment from a messages.affectedMessages /
+// messages.affectedHistory result. A non-zero channelID targets that channel's
+// pts sequence (only when already tracked); zero targets the common sequence.
+//
+// A pts of 0 means the operation reported no pts and is ignored: feeding 0 to a
+// sequenceBox would reset its state to 0 and desync everything.
+func (s *internalState) handleAffected(ctx context.Context, channelID int64, pts, ptsCount int) error {
+	if pts == 0 {
+		return nil
+	}
+
+	if err := validatePts(pts, ptsCount); err != nil {
+		s.log.Error(ctx, "Affected pts validation failed", log.Error(err),
+			log.Int64("channel_id", channelID), log.Int("pts", pts), log.Int("pts_count", ptsCount))
+		return nil
+	}
+
+	if channelID != 0 {
+		st, ok := s.channels[channelID]
+		if !ok {
+			// Not tracked yet: skip. When the channel becomes tracked it runs its
+			// own getChannelDifference, which reconciles pts from storage.
+			s.log.Debug(ctx, "Affected pts for untracked channel, ignored",
+				log.Int64("channel_id", channelID), log.Int("pts", pts))
+			return nil
+		}
+		return st.Push(ctx, channelUpdate{
+			affected: true,
+			pts:      pts,
+			ptsCount: ptsCount,
+			span:     trace.SpanContextFromContext(ctx),
+		})
+	}
+
+	return s.pts.Handle(ctx, update{
+		Value: affectedPts{},
+		State: pts,
+		Count: ptsCount,
 	})
 }
 

--- a/telegram/updates/state_affected_test.go
+++ b/telegram/updates/state_affected_test.go
@@ -1,0 +1,129 @@
+package updates
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gotd/log/logzap"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// recordingHandler records every dispatched update for assertions.
+type recordingHandler struct {
+	mu      sync.Mutex
+	batches []tg.UpdatesClass
+}
+
+func (h *recordingHandler) Handle(_ context.Context, u tg.UpdatesClass) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.batches = append(h.batches, u)
+	return nil
+}
+
+func (h *recordingHandler) updates() (out []tg.UpdateClass) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	for _, b := range h.batches {
+		switch u := b.(type) {
+		case *tg.Updates:
+			out = append(out, u.Updates...)
+		case *tg.UpdatesCombined:
+			out = append(out, u.Updates...)
+		}
+	}
+	return out
+}
+
+func newAffectedTestState(t *testing.T, h telegram.UpdateHandler, pts int) *internalState {
+	t.Helper()
+	ctx := context.Background()
+	const selfID = 123
+	storage := newMemStorage()
+	require.NoError(t, storage.SetState(ctx, selfID, State{Pts: pts}))
+	return newState(ctx, stateConfig{
+		State:            State{Pts: pts},
+		RawClient:        &diffAPI{diffs: []tg.UpdatesDifferenceClass{&tg.UpdatesDifferenceEmpty{}}},
+		Logger:           logzap.New(zaptest.NewLogger(t)),
+		Tracer:           noop.NewTracerProvider().Tracer(""),
+		Handler:          h,
+		OnChannelTooLong: func(int64) {},
+		OnTooLong:        func() {},
+		Storage:          storage,
+		Hasher:           newMemAccessHasher(),
+		SelfID:           selfID,
+		DiffLimit:        diffLimitUser,
+		WorkGroup:        &errgroup.Group{},
+	})
+}
+
+// TestHandleAffectedAdvancesPts ensures a contiguous affected pts advances the
+// common sequence without dispatching anything to the handler.
+func TestHandleAffectedAdvancesPts(t *testing.T) {
+	ctx := context.Background()
+	h := &recordingHandler{}
+	s := newAffectedTestState(t, h, 100)
+
+	require.NoError(t, s.handleAffected(ctx, 0, 101, 1))
+	require.Equal(t, 101, s.pts.State(), "pts must advance to the affected value")
+	require.Empty(t, h.updates(), "affected pts must not dispatch an update")
+}
+
+// TestHandleAffectedZeroIgnored ensures a zero affected pts is ignored instead
+// of resetting the sequence state to 0.
+func TestHandleAffectedZeroIgnored(t *testing.T) {
+	ctx := context.Background()
+	h := &recordingHandler{}
+	s := newAffectedTestState(t, h, 100)
+
+	require.NoError(t, s.handleAffected(ctx, 0, 0, 0))
+	require.Equal(t, 100, s.pts.State(), "zero affected pts must leave state untouched")
+}
+
+// TestHandleAffectedFillsGap reproduces issue #1382: an edit update arrives with
+// a pts gap (the intermediate pts came from a self-initiated read whose
+// affectedMessages result was dropped). The edit is postponed until the affected
+// pts is applied, after which both are delivered in order.
+func TestHandleAffectedFillsGap(t *testing.T) {
+	ctx := context.Background()
+	h := &recordingHandler{}
+	s := newAffectedTestState(t, h, 4416)
+
+	edit := &tg.UpdateEditMessage{
+		Message:  &tg.Message{ID: 777, Message: "edited"},
+		Pts:      4418,
+		PtsCount: 1,
+	}
+	// Edit creates a gap [4416, 4417): pts 4417 (the read) is missing.
+	require.NoError(t, s.handlePts(ctx, edit.Pts, edit.PtsCount, edit, entities{}))
+	require.Empty(t, h.updates(), "edit must be postponed while the gap is open")
+	require.Equal(t, 4416, s.pts.State())
+
+	// The dropped read's affectedMessages pts fills the gap.
+	require.NoError(t, s.handleAffected(ctx, 0, 4417, 1))
+
+	require.Equal(t, 4418, s.pts.State(), "pts must advance past the edit")
+	got := h.updates()
+	require.Len(t, got, 1, "exactly the edit must be dispatched (not the marker)")
+	require.IsType(t, &tg.UpdateEditMessage{}, got[0])
+}
+
+// TestHandleAffectedUntrackedChannelIgnored ensures an affected pts for a channel
+// that is not tracked is dropped rather than spuriously subscribing.
+func TestHandleAffectedUntrackedChannelIgnored(t *testing.T) {
+	ctx := context.Background()
+	h := &recordingHandler{}
+	s := newAffectedTestState(t, h, 100)
+
+	require.NoError(t, s.handleAffected(ctx, 555, 10, 1))
+	require.Empty(t, h.updates())
+	require.Equal(t, 100, s.pts.State(), "common pts must be untouched by a channel affected pts")
+}

--- a/telegram/updates/state_apply.go
+++ b/telegram/updates/state_apply.go
@@ -146,16 +146,23 @@ func (s *internalState) applyPts(ctx context.Context, state int, updates []updat
 	)
 
 	for _, update := range updates {
+		// affectedPts is a pts-only marker (see Manager.HandleAffected): it
+		// advances the sequence but has nothing to dispatch.
+		if _, ok := update.Value.(affectedPts); ok {
+			continue
+		}
 		converted = append(converted, update.Value.(tg.UpdateClass))
 		ents.Merge(update.Entities)
 	}
 
-	if err := s.handler.Handle(ctx, &tg.Updates{
-		Updates: converted,
-		Users:   ents.Users,
-		Chats:   ents.Chats,
-	}); err != nil {
-		s.log.Error(ctx, "Handle updates error", log.Error(err))
+	if len(converted) > 0 {
+		if err := s.handler.Handle(ctx, &tg.Updates{
+			Updates: converted,
+			Users:   ents.Users,
+			Chats:   ents.Chats,
+		}); err != nil {
+			s.log.Error(ctx, "Handle updates error", log.Error(err))
+		}
 	}
 
 	if err := s.storage.SetPts(ctx, s.selfID, state); err != nil {

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -22,6 +22,13 @@ type channelUpdate struct {
 	update   tg.UpdateClass
 	entities entities
 	span     trace.SpanContext
+
+	// affected, when true, makes the worker advance its pts by (pts, ptsCount)
+	// without dispatching, applying a messages.affected* result for this channel
+	// (see Manager.HandleAffected). update is nil in this case.
+	affected bool
+	pts      int
+	ptsCount int
 }
 
 type channelState struct {
@@ -133,7 +140,13 @@ func (s *channelState) Run(ctx context.Context) error {
 		select {
 		case u := <-s.updates:
 			ctx := trace.ContextWithSpanContext(ctx, u.span)
-			if err := s.handleUpdate(ctx, u.update, u.entities); err != nil {
+			handle := s.handleUpdate
+			if u.affected {
+				handle = func(ctx context.Context, _ tg.UpdateClass, _ entities) error {
+					return s.handleAffected(ctx, u.pts, u.ptsCount)
+				}
+			}
+			if err := handle(ctx, u.update, u.entities); err != nil {
 				if errors.Is(err, errChannelInaccessible) {
 					return nil
 				}
@@ -191,6 +204,25 @@ func (s *channelState) handleUpdate(ctx context.Context, u tg.UpdateClass, ents 
 	})
 }
 
+// handleAffected applies a pts increment from a messages.affected* result to
+// this channel's pts sequence without dispatching. A pts of 0 is ignored: it
+// would reset the sequence state to 0 (see internalState.handleAffected).
+func (s *channelState) handleAffected(ctx context.Context, pts, ptsCount int) error {
+	if pts == 0 {
+		return nil
+	}
+	if err := validatePts(pts, ptsCount); err != nil {
+		s.log.Error(ctx, "Affected pts validation failed", log.Error(err),
+			log.Int("pts", pts), log.Int("pts_count", ptsCount))
+		return nil
+	}
+	return s.pts.Handle(ctx, update{
+		Value: affectedPts{},
+		State: pts,
+		Count: ptsCount,
+	})
+}
+
 func (s *channelState) handleTooLong(ctx context.Context, long *tg.UpdateChannelTooLong) error {
 	ctx, span := s.tracer.Start(ctx, "channelState.handleTooLong")
 	defer span.End()
@@ -221,17 +253,24 @@ func (s *channelState) applyPts(ctx context.Context, state int, updates []update
 	)
 
 	for _, update := range updates {
+		// affectedPts is a pts-only marker (see Manager.HandleAffected): it
+		// advances the sequence but has nothing to dispatch.
+		if _, ok := update.Value.(affectedPts); ok {
+			continue
+		}
 		converted = append(converted, update.Value.(tg.UpdateClass))
 		ents.Merge(update.Entities)
 	}
 
-	if err := s.handler.Handle(ctx, &tg.Updates{
-		Updates: converted,
-		Users:   ents.Users,
-		Chats:   ents.Chats,
-	}); err != nil {
-		s.log.Error(ctx, "Handle update error", log.Error(err))
-		return nil
+	if len(converted) > 0 {
+		if err := s.handler.Handle(ctx, &tg.Updates{
+			Updates: converted,
+			Users:   ents.Users,
+			Chats:   ents.Chats,
+		}); err != nil {
+			s.log.Error(ctx, "Handle update error", log.Error(err))
+			return nil
+		}
 	}
 
 	if err := s.storage.SetChannelPts(ctx, s.selfID, s.channelID, state); err != nil {

--- a/telegram/updates/update.go
+++ b/telegram/updates/update.go
@@ -11,6 +11,15 @@ type update struct {
 	Entities entities
 }
 
+// affectedPts is a synthetic, non-dispatchable pts update. It carries only the
+// pts increment from a messages.affectedMessages / messages.affectedHistory RPC
+// result so the local pts stays in sync with the server after a self-initiated
+// read or delete, without fabricating a user-visible update.
+//
+// It is fed to a sequenceBox as update.Value; applyPts skips it instead of
+// dispatching it to the handler. See Manager.HandleAffected.
+type affectedPts struct{}
+
 func (u update) start() int { return u.State - u.Count }
 
 func (u update) end() int { return u.State }


### PR DESCRIPTION
Fixes #1382.

## Problem

A user account stops receiving an update (e.g. an edit) until the *next* pts-changing update arrives. Reproduction (from #1382): receive a message, read it, then have the other side edit it — the `UpdateEditMessage` is postponed.

Root cause: methods such as `messages.readHistory`, `messages.deleteMessages`, `channels.deleteMessages`, `messages.readMentions`, `messages.deleteHistory` return `messages.affectedMessages` / `messages.affectedHistory`, which carry a **pts increment the client must apply**. These results are *not* `tg.UpdatesClass`, so they never reach the updates manager — `updhook.UpdateHook` only forwards `*tg.UpdatesBox` results. The server pts advances while the local pts stays behind, so the next genuine pts update looks like a gap and is buffered:

```
pts  Gap detected            gap=[{from:4416,to:4417}]
pts  Out of gap range, postponed   upd_from:4418 upd_to:4418
```

The reporter's own `messages.readHistory` call (inside `OnNewMessage`) is what creates the missing pts. This matches TDLib, which applies the affected pts in each query's result handler.

## Fix

- **`Manager.HandleAffected(ctx, channelID, pts, ptsCount)`** — applies the increment to the common sequence, or to an already-tracked channel's sequence. It feeds a non-dispatchable `affectedPts` marker through the normal `sequenceBox`, so the pts advances (and fills any open gap, releasing postponed updates) without fabricating a user-visible update. `applyPts` skips the marker; an empty batch dispatches nothing but still persists pts.
  - `pts == 0` is ignored — feeding 0 to a `sequenceBox` would reset its state to 0 and desync everything.
  - A channel affected pts for an untracked channel is dropped (its own `getChannelDifference` reconciles later).
- **`hook.AffectedHook(handler)`** middleware — wires it from RPC results automatically. Routing by request: an `InputChannel` (`channels.*`) or `InputPeerChannel` peer (`messages.*` targeting a channel) → that channel; everything else → the common sequence.

Opt-in alongside `UpdateHook`:

```go
telegram.Options{Middlewares: []telegram.Middleware{
    updhook.UpdateHook(gaps.Handle),
    hook.AffectedHook(gaps), // gaps is *updates.Manager
}}
```

## Tests

- `TestHandleAffectedFillsGap` reproduces #1382: an edit postponed behind a missing read-pts is delivered (in order, exactly once) after the affected pts is applied.
- `TestHandleAffectedAdvancesPts` / `ZeroIgnored` / `UntrackedChannelIgnored` cover the marker, the pts==0 guard, and channel gating.
- `TestAffectedHook` covers result detection and common-vs-channel routing (by peer, by `InputChannel`, no-peer), plus RPC-error short-circuit.

All `./telegram/...` tests pass, including `-race` on `telegram/updates`.

## Notes

- Behavior change is opt-in (the middleware); the manager primitive is a no-op before `Run`.
- Independent of #1781 (logging diagnostics); both touch `telegram/updates` but do not overlap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)