### PR TITLE
fix(peers): do not persist min channel access hash on first observation

### DIFF
--- a/telegram/peers/apply.go
+++ b/telegram/peers/apply.go
@@ -89,11 +89,15 @@ func (m *Manager) applyChats(ctx context.Context, input ...tg.ChatClass) error {
 			k.Prefix = channelPrefix
 
 			if ch.Min {
-				// If Min is true, skip updating existing peer as it corrupts the full AccessHash
-				if _, ok, err := m.storage.Find(ctx, k); err != nil || ok {
-					// FIXME: merge old channel data with new data from min constructor
-					continue
-				}
+				// A min channel carries a min access hash, valid only for
+				// inputPeerPhotoFileLocation — never for normal RPCs such as
+				// channels.getFullChannel. Per TDLib / Telegram-Android a min peer
+				// does not count as a known peer, so it must never be persisted:
+				// neither overwriting an existing full hash (corruption) nor
+				// inserted as a new peer (a bogus hash that later fails RPCs).
+				// Mirrors applyUsers above and updates.(*internalState).saveChannelHashes.
+				// TODO(tdakkota): call a hook to fetch the full channel (e.g. force gaps to getDifference).
+				continue
 			}
 
 			channels = append(channels, ch)

--- a/telegram/peers/apply_test.go
+++ b/telegram/peers/apply_test.go
@@ -21,6 +21,7 @@ func TestManager_applyChats(t *testing.T) {
 		&tg.Channel{ID: 4, AccessHash: 14},
 		&tg.Channel{ID: 4, Min: true, AccessHash: 16},
 		&tg.ChannelForbidden{ID: 5, AccessHash: 15},
+		&tg.Channel{ID: 6, Min: true, AccessHash: 16},
 	}
 
 	// Ensure nil safety.
@@ -44,4 +45,12 @@ func TestManager_applyChats(t *testing.T) {
 	a.NoError(err)
 	a.True(ok)
 	a.Equal(int64(15), v.AccessHash)
+
+	// A channel observed ONLY as min must never be persisted: a min access hash
+	// is valid solely for inputPeerPhotoFileLocation and later fails normal RPCs
+	// such as channels.getFullChannel. (ID 4 above covers the overwrite case
+	// where a full hash already exists; this covers first observation.)
+	_, ok, err = m.storage.Find(ctx, Key{ID: 6, Prefix: channelPrefix})
+	a.NoError(err)
+	a.False(ok)
 }


### PR DESCRIPTION
## Problem

`(*Manager).applyChats` persists a **min** channel access hash on the **first** observation of a channel.

The min branch only guards against *overwriting* an already-stored hash:

```go
if ch.Min {
    // If Min is true, skip updating existing peer as it corrupts the full AccessHash
    if _, ok, err := m.storage.Find(ctx, k); err != nil || ok {
        // FIXME: merge old channel data with new data from min constructor
        continue
    }
}
// not found -> falls through to m.storage.Save(k, Value{AccessHash: ch.AccessHash})
```

When the channel is not yet stored (`Find` returns `ok == false`), execution falls through and saves the **min** access hash as if it were a full one.

A min access hash is only valid for `inputPeerPhotoFileLocation`; it must not be used for normal RPCs such as `channels.getFullChannel`. Per TDLib / Telegram-Android a min peer does not count as a "known" peer. Once stored via `Value{AccessHash}`, there is no flag distinguishing it from a full hash, so a consumer that reads it back and issues a normal RPC will fail (`CHANNEL_INVALID` / `CHANNEL_PRIVATE`).

## Inconsistency with the rest of the codebase

Every other place that records hashes already skips min entities unconditionally:

- `applyUsers` (same file): `if user.Min { continue }`
- `updates.(*internalState).saveChannelHashes`: `if c.Min { continue }`
- `updates.(*internalState).saveUserHashes`: skips min/zero, documented as *"per TDLib / Telegram-Android, such an entity does not count as a known peer"*

Only `applyChats` persists a min channel on first observation.

## Fix

Skip min channels unconditionally in `applyChats`, mirroring `applyUsers` and the `updates` feeders. The existing `FIXME`/`TODO` about fetching the full channel via getDifference is preserved as a `TODO`.

## Test

`TestManager_applyChats` previously covered only the overwrite case (channel seen full, then min — full hash preserved). Added a channel observed **only** as min and asserted it is not persisted. The new assertion fails on `main` and passes with this change.

```
--- FAIL: TestManager_applyChats   (without fix)
    apply_test.go: Should be false
--- PASS: TestManager_applyChats   (with fix)
```

`go test ./telegram/peers/... ./telegram/updates/...` passes.
