### PR TITLE
fix(updates): backfill min channel/user access hashes in delivered entities

### DIFF
--- a/telegram/updates/min_backfill.go
+++ b/telegram/updates/min_backfill.go
@@ -1,0 +1,106 @@
+package updates
+
+import (
+	"context"
+
+	"github.com/gotd/log"
+
+	"github.com/gotd/td/tg"
+)
+
+// Updates carry the raw entities from the server, which may be "min"
+// constructors (Channel.Min / User.Min). A min entity's access hash is valid
+// only for a narrow set of operations (e.g. inputPeerPhotoFileLocation) and
+// fails normal RPCs such as messages.sendMessage with CHANNEL_INVALID. Since the
+// manager already records full hashes from non-min observations
+// (saveChannelHashes / saveUserHashes), we can swap a min hash for the known
+// full one without any network round-trip, so user code that builds an
+// InputPeer straight from update entities (e.g. e.Channels[id].AsInputPeer())
+// works in every chat.
+//
+// The Min flag itself is left set: a min entity may still carry incomplete
+// fields, and downstream consumers (e.g. peers.Manager.applyChats) rely on it to
+// decide whether to persist the peer. Only the access hash is corrected, and
+// only on a copy, so the original entity shared with other code is untouched.
+//
+// See https://github.com/gotd/td/issues/1553.
+
+// dispatch hands an updates batch to the user handler after backfilling any min
+// channel or user entities with the full access hash from the access-hash store.
+func (s *internalState) dispatch(ctx context.Context, u *tg.Updates) error {
+	u.Chats = backfillMinChats(ctx, s.log, s.hasher, s.selfID, u.Chats)
+	u.Users = backfillMinUsers(ctx, s.log, s.userHasher, s.selfID, u.Users)
+	return s.handler.Handle(ctx, u)
+}
+
+// dispatch mirrors internalState.dispatch for the per-channel worker, which owns
+// delivery of channel message updates — the exact path in issue #1553.
+func (s *channelState) dispatch(ctx context.Context, u *tg.Updates) error {
+	u.Chats = backfillMinChats(ctx, s.log, s.hasher, s.selfID, u.Chats)
+	u.Users = backfillMinUsers(ctx, s.log, s.userHasher, s.selfID, u.Users)
+	return s.handler.Handle(ctx, u)
+}
+
+// backfillMinChats returns chats with the access hash of every min channel
+// replaced by the full hash from the access-hash store, when one is known.
+// Channels left unknown keep their min hash unchanged (no regression).
+//
+// The input slice and its entities are never mutated: the same slice may be
+// shared with another goroutine (e.g. channelState.getDifference also hands
+// diff.Chats to sendOut). Only when a replacement is needed is a fresh slice
+// allocated and the affected entities copied; otherwise the original slice is
+// returned as-is, keeping the common path allocation-free.
+func backfillMinChats(ctx context.Context, lg log.Helper, hasher ChannelAccessHasher, selfID int64, chats []tg.ChatClass) []tg.ChatClass {
+	out := chats
+	for i, c := range chats {
+		ch, ok := c.(*tg.Channel)
+		if !ok || !ch.Min {
+			continue
+		}
+		hash, found, err := hasher.GetChannelAccessHash(ctx, selfID, ch.ID)
+		if err != nil {
+			lg.Error(ctx, "GetChannelAccessHash error",
+				log.Error(err), log.Int64("channel_id", ch.ID))
+			continue
+		}
+		if !found {
+			continue
+		}
+		if &out[0] == &chats[0] {
+			out = make([]tg.ChatClass, len(chats))
+			copy(out, chats)
+		}
+		cp := *ch
+		cp.SetAccessHash(hash)
+		out[i] = &cp
+	}
+	return out
+}
+
+// backfillMinUsers mirrors backfillMinChats for min users.
+func backfillMinUsers(ctx context.Context, lg log.Helper, hasher UserAccessHasher, selfID int64, users []tg.UserClass) []tg.UserClass {
+	out := users
+	for i, u := range users {
+		usr, ok := u.(*tg.User)
+		if !ok || !usr.Min {
+			continue
+		}
+		hash, found, err := hasher.GetUserAccessHash(ctx, selfID, usr.ID)
+		if err != nil {
+			lg.Error(ctx, "GetUserAccessHash error",
+				log.Error(err), log.Int64("user_id", usr.ID))
+			continue
+		}
+		if !found {
+			continue
+		}
+		if &out[0] == &users[0] {
+			out = make([]tg.UserClass, len(users))
+			copy(out, users)
+		}
+		cp := *usr
+		cp.SetAccessHash(hash)
+		out[i] = &cp
+	}
+	return out
+}

--- a/telegram/updates/min_backfill_test.go
+++ b/telegram/updates/min_backfill_test.go
@@ -1,0 +1,101 @@
+package updates
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// TestDispatchBackfillsMinAccessHash is the regression test for
+// https://github.com/gotd/td/issues/1553: entities delivered to user handlers
+// must carry a usable (full) access hash for min channels/users whose full hash
+// the manager already knows, so e.Channels[id].AsInputPeer() works in any chat.
+func TestDispatchBackfillsMinAccessHash(t *testing.T) {
+	ctx := context.Background()
+
+	const (
+		minChannelID  = int64(100) // seen as min, full hash known
+		fullChannelID = int64(200) // known full hash
+		minHash       = int64(11)  // min access hash carried by the update
+		realHash      = int64(99)  // full access hash from the store
+		unknownChanID = int64(300) // min, but no stored hash
+
+		minUserID  = int64(400)
+		userMin    = int64(44)
+		userReal   = int64(88)
+		unknownUID = int64(500)
+	)
+
+	var got *tg.Updates
+	handler := telegram.UpdateHandlerFunc(func(ctx context.Context, u tg.UpdatesClass) error {
+		got = u.(*tg.Updates)
+		return nil
+	})
+	s := newShortTestState(t, &countDiffAPI{}, handler)
+
+	// Pre-seed full hashes, as a prior non-min observation would.
+	require.NoError(t, s.hasher.SetChannelAccessHash(ctx, s.selfID, minChannelID, realHash))
+	require.NoError(t, s.userHasher.SetUserAccessHash(ctx, s.selfID, minUserID, userReal))
+
+	minChannel := &tg.Channel{ID: minChannelID}
+	minChannel.SetAccessHash(minHash)
+	minChannel.SetMin(true)
+
+	fullChannel := &tg.Channel{ID: fullChannelID}
+	fullChannel.SetAccessHash(realHash) // already full, not min
+
+	unknownMin := &tg.Channel{ID: unknownChanID}
+	unknownMin.SetAccessHash(minHash)
+	unknownMin.SetMin(true)
+
+	minUser := &tg.User{ID: minUserID, Min: true, AccessHash: userMin}
+	unknownUser := &tg.User{ID: unknownUID, Min: true, AccessHash: userMin}
+
+	require.NoError(t, s.dispatch(ctx, &tg.Updates{
+		Chats: []tg.ChatClass{minChannel, fullChannel, unknownMin},
+		Users: []tg.UserClass{minUser, unknownUser},
+	}))
+	require.NotNil(t, got)
+
+	channelByID := func(id int64) *tg.Channel {
+		for _, c := range got.Chats {
+			if ch, ok := c.(*tg.Channel); ok && ch.ID == id {
+				return ch
+			}
+		}
+		t.Fatalf("channel %d not delivered", id)
+		return nil
+	}
+	userByID := func(id int64) *tg.User {
+		for _, u := range got.Users {
+			if usr, ok := u.(*tg.User); ok && usr.ID == id {
+				return usr
+			}
+		}
+		t.Fatalf("user %d not delivered", id)
+		return nil
+	}
+
+	// Min channel with a known full hash: hash backfilled, Min flag retained.
+	delivered := channelByID(minChannelID)
+	require.Equal(t, realHash, delivered.AccessHash, "min channel hash must be backfilled")
+	require.True(t, delivered.Min, "Min flag must be retained")
+
+	// Full channel: untouched.
+	require.Equal(t, realHash, channelByID(fullChannelID).AccessHash)
+
+	// Min channel with no stored hash: left unchanged, no regression.
+	require.Equal(t, minHash, channelByID(unknownChanID).AccessHash)
+
+	// Min user with a known full hash: backfilled. Unknown: unchanged.
+	require.Equal(t, userReal, userByID(minUserID).AccessHash)
+	require.Equal(t, userMin, userByID(unknownUID).AccessHash)
+
+	// The original entity must not be mutated (copy-on-write).
+	require.Equal(t, minHash, minChannel.AccessHash, "original min channel must be untouched")
+	require.Equal(t, userMin, minUser.AccessHash, "original min user must be untouched")
+}

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -419,7 +419,7 @@ func (s *internalState) handleQts(ctx context.Context, qts int, u tg.UpdateClass
 	// and loops forever re-dispatching them. Such updates carry no position to
 	// order by, so dispatch them directly without touching the qts state.
 	if qts == 0 {
-		if err := s.handler.Handle(ctx, &tg.Updates{
+		if err := s.dispatch(ctx, &tg.Updates{
 			Updates: []tg.UpdateClass{u},
 			Users:   ents.Users,
 			Chats:   ents.Chats,
@@ -503,6 +503,8 @@ func (s *internalState) newChannelState(channelID, accessHash int64, initialPts 
 		Storage:               s.storage,
 		DiffLimit:             s.diffLim,
 		RawClient:             s.client,
+		Hasher:                s.hasher,
+		UserHasher:            s.userHasher,
 		Handler:               s.handler,
 		OnChannelTooLong:      s.onTooLong,
 		OnChannelInaccessible: s.onChannelInaccessible,
@@ -569,7 +571,7 @@ func (s *internalState) getDifference(ctx context.Context, reason string) error 
 		}
 
 		if len(diff.NewMessages) > 0 || len(diff.NewEncryptedMessages) > 0 {
-			if err := s.handler.Handle(ctx, &tg.Updates{
+			if err := s.dispatch(ctx, &tg.Updates{
 				Updates: append(
 					msgsToUpdates(diff.NewMessages, false),
 					encryptedMsgsToUpdates(diff.NewEncryptedMessages)...,
@@ -613,7 +615,7 @@ func (s *internalState) getDifference(ctx context.Context, reason string) error 
 		}
 
 		if len(diff.NewMessages) > 0 || len(diff.NewEncryptedMessages) > 0 {
-			if err := s.handler.Handle(ctx, &tg.Updates{
+			if err := s.dispatch(ctx, &tg.Updates{
 				Updates: append(
 					msgsToUpdates(diff.NewMessages, false),
 					encryptedMsgsToUpdates(diff.NewEncryptedMessages)...,

--- a/telegram/updates/state_apply.go
+++ b/telegram/updates/state_apply.go
@@ -103,7 +103,7 @@ func (s *internalState) applyCombined(ctx context.Context, comb *tg.UpdatesCombi
 	}
 
 	if len(others) > 0 {
-		if err := s.handler.Handle(ctx, &tg.Updates{
+		if err := s.dispatch(ctx, &tg.Updates{
 			Updates: others,
 			Users:   ents.Users,
 			Chats:   ents.Chats,
@@ -156,7 +156,7 @@ func (s *internalState) applyPts(ctx context.Context, state int, updates []updat
 	}
 
 	if len(converted) > 0 {
-		if err := s.handler.Handle(ctx, &tg.Updates{
+		if err := s.dispatch(ctx, &tg.Updates{
 			Updates: converted,
 			Users:   ents.Users,
 			Chats:   ents.Chats,
@@ -186,7 +186,7 @@ func (s *internalState) applyQts(ctx context.Context, state int, updates []updat
 		ents.Merge(update.Entities)
 	}
 
-	if err := s.handler.Handle(ctx, &tg.Updates{
+	if err := s.dispatch(ctx, &tg.Updates{
 		Updates: converted,
 		Users:   ents.Users,
 		Chats:   ents.Chats,

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -53,6 +53,8 @@ type channelState struct {
 	diffLim        int
 	client         API
 	storage        StateStorage
+	hasher         ChannelAccessHasher
+	userHasher     UserAccessHasher
 	log            log.Helper
 	tracer         trace.Tracer
 	handler        telegram.UpdateHandler
@@ -71,6 +73,8 @@ type channelStateConfig struct {
 	DiffLimit             int
 	RawClient             API
 	Storage               StateStorage
+	Hasher                ChannelAccessHasher
+	UserHasher            UserAccessHasher
 	Handler               telegram.UpdateHandler
 	OnChannelTooLong      func(channelID int64)
 	OnChannelInaccessible func(channelID int64)
@@ -93,6 +97,8 @@ func newChannelState(cfg channelStateConfig) *channelState {
 		diffLim:        cfg.DiffLimit,
 		client:         cfg.RawClient,
 		storage:        cfg.Storage,
+		hasher:         cfg.Hasher,
+		userHasher:     cfg.UserHasher,
 		log:            log.For(cfg.Logger),
 		handler:        cfg.Handler,
 		onTooLong:      cfg.OnChannelTooLong,
@@ -263,7 +269,7 @@ func (s *channelState) applyPts(ctx context.Context, state int, updates []update
 	}
 
 	if len(converted) > 0 {
-		if err := s.handler.Handle(ctx, &tg.Updates{
+		if err := s.dispatch(ctx, &tg.Updates{
 			Updates: converted,
 			Users:   ents.Users,
 			Chats:   ents.Chats,
@@ -350,7 +356,7 @@ func (s *channelState) getDifference(ctx context.Context, reason string) error {
 		}
 
 		if len(diff.NewMessages) > 0 {
-			if err := s.handler.Handle(ctx, &tg.Updates{
+			if err := s.dispatch(ctx, &tg.Updates{
 				Updates: msgsToUpdates(diff.NewMessages, true),
 				Users:   diff.Users,
 				Chats:   diff.Chats,


### PR DESCRIPTION
## Summary

Fixes #1553 — replying to a channel message with code like

```go
channel := e.Channels[peer.ChannelID]
sender.To(channel.AsInputPeer()).Reply(m.ID).Text(ctx, "Test")
```

fails with `sendMessage: RPCError: 400: CHANNEL_INVALID` in *some* channels.

## Root cause

Entities handed to update handlers (`tg.Updates{Chats, Users}`) were the **raw** constructors from the server, which may be **min** (`Channel.Min` / `User.Min`). A min access hash is valid only for a narrow set of operations (e.g. `inputPeerPhotoFileLocation`) and is rejected for normal RPCs such as `messages.sendMessage`. `AsInputPeer()` copies whatever hash the entity has, so building an input peer directly from a min entity produced an unusable peer — hence "works in some channels, not others".

## Fix

The updates manager already records full (non-min) access hashes from prior observations (`saveChannelHashes` / `saveUserHashes`), so the full hash can be restored with a **read-only store lookup — no network round-trip** (which is what the existing min discipline in `messageUpdatesPeersKnown` requires for channel-message peers).

- New `dispatch()` on `internalState` and `channelState` wraps every `handler.Handle` call and swaps a min entity's access hash for the known full one before delivery. All 8 dispatch sites are routed through it.
- The `Min` flag is **left set** — `peers.Manager.applyChats` still relies on it to refuse persisting the peer; only the access hash is corrected.
- Backfill is **copy-on-write at the slice level**: the input slice and its entities are never mutated (`channelState.getDifference` shares `diff.Chats` with `sendOut` on another goroutine), and a fresh slice is allocated only when a replacement is actually made — the common path stays allocation-free.
- Unknown hashes are left unchanged → no regression.
- `channelState` gains `Hasher`/`UserHasher` (it owns the `UpdateNewChannelMessage` path — the exact case in the issue), wired from `internalState`.

## Tests

- `telegram/updates/min_backfill_test.go`: covers backfill of min channel/user, the unknown-hash no-op, the non-min untouched case, and copy-on-write (originals not mutated).
- `go test -race ./telegram/updates/... ./telegram/peers/...` and the multi-DC e2e suite pass; gofmt/vet clean.

## Note

This resolves the issue for users on the updates manager (the standard path). Code that builds input peers from entities obtained entirely outside the manager still needs a resolved hash, but that is not the reported scenario.