### PR TITLE
feat(updates): optional concurrency limit for getChannelDifference

### DIFF
--- a/telegram/updates/channel_diff_concurrency_test.go
+++ b/telegram/updates/channel_diff_concurrency_test.go
@@ -1,0 +1,277 @@
+package updates
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/trace/noop"
+	"go.uber.org/zap/zaptest"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/gotd/log/logzap"
+
+	"github.com/gotd/td/telegram"
+	"github.com/gotd/td/tg"
+)
+
+// gateChannelDiffAPI is an API stub whose UpdatesGetChannelDifference blocks on
+// release while tracking how many calls are in flight at once, so a test can
+// observe the peak concurrency the updates manager allows.
+type gateChannelDiffAPI struct {
+	entered chan struct{} // one token per call that reached the RPC body
+	release chan struct{} // calls block here until the test closes it
+
+	mu      sync.Mutex
+	current int
+	peak    int
+	total   int
+}
+
+func (a *gateChannelDiffAPI) UpdatesGetState(ctx context.Context) (*tg.UpdatesState, error) {
+	return &tg.UpdatesState{}, nil
+}
+
+func (a *gateChannelDiffAPI) UpdatesGetDifference(
+	ctx context.Context, request *tg.UpdatesGetDifferenceRequest,
+) (tg.UpdatesDifferenceClass, error) {
+	return &tg.UpdatesDifferenceEmpty{}, nil
+}
+
+func (a *gateChannelDiffAPI) UpdatesGetChannelDifference(
+	ctx context.Context, request *tg.UpdatesGetChannelDifferenceRequest,
+) (tg.UpdatesChannelDifferenceClass, error) {
+	a.mu.Lock()
+	a.total++
+	a.current++
+	if a.current > a.peak {
+		a.peak = a.current
+	}
+	a.mu.Unlock()
+
+	a.entered <- struct{}{}
+	<-a.release
+
+	a.mu.Lock()
+	a.current--
+	a.mu.Unlock()
+	return &tg.UpdatesChannelDifferenceEmpty{}, nil
+}
+
+func (a *gateChannelDiffAPI) snapshot() (current, peak, total int) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+	return a.current, a.peak, a.total
+}
+
+// newGatedChannelState builds a channelState wired to the gate API and the
+// given semaphore. Each channelState.Run issues exactly one getChannelDifference
+// at startup (the gate API returns an empty, final difference).
+func newGatedChannelState(t *testing.T, id int64, api API, sem chDiffSem) *channelState {
+	t.Helper()
+	return newChannelState(channelStateConfig{
+		Out:        make(chan tracedUpdate, 10),
+		ChannelID:  id,
+		AccessHash: 1,
+		RawClient:  api,
+		Storage:    newMemStorage(),
+		Handler: telegram.UpdateHandlerFunc(func(context.Context, tg.UpdatesClass) error {
+			return nil
+		}),
+		OnChannelTooLong:      func(int64) {},
+		OnChannelInaccessible: func(int64) {},
+		RemoveChannel:         make(chan int64, 1),
+		Logger:                logzap.New(zaptest.NewLogger(t)),
+		Tracer:                noop.NewTracerProvider().Tracer(""),
+		ChannelDiffSem:        sem,
+	})
+}
+
+// TestNewThreadsChannelDiffConcurrency verifies Config.MaxChannelDifferenceConcurrency
+// builds the manager's shared semaphore (and leaves it nil when unset).
+func TestNewThreadsChannelDiffConcurrency(t *testing.T) {
+	handler := telegram.UpdateHandlerFunc(func(context.Context, tg.UpdatesClass) error { return nil })
+
+	m := New(Config{Handler: handler, MaxChannelDifferenceConcurrency: 3})
+	require.NotNil(t, m.chDiffSem, "positive limit must build a semaphore")
+	require.Equal(t, 3, cap(m.chDiffSem), "semaphore capacity must equal the limit")
+
+	def := New(Config{Handler: handler})
+	require.Nil(t, def.chDiffSem, "default (0) must leave the manager unlimited")
+}
+
+// TestNewChannelStateInheritsConcurrencyLimit verifies a channel tracked by a
+// running manager at runtime (internalState.newChannelState, the path taken when
+// an update arrives for a not-yet-tracked channel) shares the manager's
+// getChannelDifference semaphore, so runtime joins are bounded by the same limit
+// as the channels loaded at start.
+func TestNewChannelStateInheritsConcurrencyLimit(t *testing.T) {
+	ctx := context.Background()
+
+	const selfID = 123
+	storage := newMemStorage()
+	require.NoError(t, storage.SetState(ctx, selfID, State{}))
+
+	sem := newChDiffSem(4)
+	s := newState(ctx, stateConfig{
+		RawClient: &gateChannelDiffAPI{},
+		Logger:    logzap.New(zaptest.NewLogger(t)),
+		Tracer:    noop.NewTracerProvider().Tracer(""),
+		Handler: telegram.UpdateHandlerFunc(func(context.Context, tg.UpdatesClass) error {
+			return nil
+		}),
+		OnChannelTooLong: func(int64) {},
+		Storage:          storage,
+		Hasher:           newMemAccessHasher(),
+		SelfID:           selfID,
+		DiffLimit:        diffLimitUser,
+		WorkGroup:        &errgroup.Group{},
+		ChannelDiffSem:   sem,
+	})
+
+	ch := s.newChannelState(4242, 1, 0)
+	require.Equal(t, sem, ch.chDiffSem,
+		"a runtime-added channel must share the manager's getChannelDifference semaphore")
+}
+
+// TestChannelDifferenceConcurrencyLimited verifies the shared semaphore caps the
+// number of concurrent getChannelDifference calls across channels.
+func TestChannelDifferenceConcurrencyLimited(t *testing.T) {
+	const (
+		limit    = 2
+		channels = 6
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	api := &gateChannelDiffAPI{
+		entered: make(chan struct{}, channels),
+		release: make(chan struct{}),
+	}
+	sem := newChDiffSem(limit)
+
+	var wg sync.WaitGroup
+	for i := range channels {
+		st := newGatedChannelState(t, int64(1000+i), api, sem)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = st.Run(ctx)
+		}()
+	}
+
+	// Exactly `limit` calls may reach the RPC; collect them.
+	for range limit {
+		<-api.entered
+	}
+	// No further call may start while the slots are held.
+	select {
+	case <-api.entered:
+		t.Fatal("getChannelDifference exceeded the concurrency limit")
+	case <-time.After(100 * time.Millisecond):
+	}
+	current, _, _ := api.snapshot()
+	require.Equal(t, limit, current, "exactly `limit` calls must be in flight")
+
+	// Release the held calls; the remaining channels then proceed, still capped.
+	close(api.release)
+	for range channels - limit {
+		<-api.entered
+	}
+
+	cancel()
+	wg.Wait()
+
+	_, peak, total := api.snapshot()
+	require.LessOrEqual(t, peak, limit, "peak concurrency must never exceed the limit")
+	require.Equal(t, channels, total, "every channel must eventually fetch its difference")
+}
+
+// TestChannelDifferenceUnlimitedByDefault verifies a zero limit (nil semaphore)
+// keeps today's behavior: every channel recovers concurrently, uncapped.
+func TestChannelDifferenceUnlimitedByDefault(t *testing.T) {
+	const channels = 6
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	api := &gateChannelDiffAPI{
+		entered: make(chan struct{}, channels),
+		release: make(chan struct{}),
+	}
+	sem := newChDiffSem(0) // unlimited
+
+	var wg sync.WaitGroup
+	for i := range channels {
+		st := newGatedChannelState(t, int64(2000+i), api, sem)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = st.Run(ctx)
+		}()
+	}
+
+	// All channels must be able to enter the RPC at once; if a cap were wrongly
+	// applied this would block and the test would time out.
+	for range channels {
+		<-api.entered
+	}
+	current, _, _ := api.snapshot()
+	require.Equal(t, channels, current, "all channels must run concurrently when unlimited")
+
+	close(api.release)
+	cancel()
+	wg.Wait()
+
+	_, peak, _ := api.snapshot()
+	require.Equal(t, channels, peak, "peak concurrency must reach all channels when unlimited")
+}
+
+// TestChannelDifferenceAcquireRespectsContext verifies acquire aborts on context
+// cancellation without issuing the RPC.
+func TestChannelDifferenceAcquireRespectsContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	api := &gateChannelDiffAPI{
+		entered: make(chan struct{}, 2),
+		release: make(chan struct{}),
+	}
+	sem := newChDiffSem(1)
+
+	var wg sync.WaitGroup
+
+	// Channel A grabs the only slot and blocks inside the RPC.
+	stA := newGatedChannelState(t, 3001, api, sem)
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_ = stA.Run(ctx)
+	}()
+	<-api.entered // A is in flight, holding the slot.
+
+	// Channel B blocks on acquire and must never reach the RPC.
+	stB := newGatedChannelState(t, 3002, api, sem)
+	bDone := make(chan struct{})
+	go func() {
+		_ = stB.Run(ctx)
+		close(bDone)
+	}()
+	select {
+	case <-api.entered:
+		t.Fatal("B entered the RPC despite a full semaphore")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	cancel() // B's acquire must return ctx.Err and B.Run must finish.
+	<-bDone
+
+	_, _, total := api.snapshot()
+	require.Equal(t, 1, total, "B must not call getChannelDifference after ctx cancel")
+
+	close(api.release) // let A unwind.
+	wg.Wait()
+}

--- a/telegram/updates/channel_diff_semaphore.go
+++ b/telegram/updates/channel_diff_semaphore.go
@@ -1,0 +1,44 @@
+package updates
+
+import "context"
+
+// chDiffSem bounds how many updates.getChannelDifference requests may be in
+// flight at once across all channel workers of a single manager. It is a
+// counting semaphore backed by a buffered channel.
+//
+// A nil chDiffSem imposes no limit, so the manager's default behaviour (every
+// channel recovers its gap independently) is preserved with zero overhead.
+type chDiffSem chan struct{}
+
+// newChDiffSem returns a semaphore admitting at most n concurrent holders, or
+// nil (unlimited) when n is not positive.
+func newChDiffSem(n int) chDiffSem {
+	if n <= 0 {
+		return nil
+	}
+	return make(chDiffSem, n)
+}
+
+// acquire takes a slot, blocking until one is free or ctx is done. It returns
+// ctx.Err() if the context is cancelled before a slot is obtained. A nil
+// semaphore acquires instantly.
+func (s chDiffSem) acquire(ctx context.Context) error {
+	if s == nil {
+		return nil
+	}
+	select {
+	case s <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release returns a previously acquired slot. It is a no-op on a nil semaphore
+// and must be called exactly once per successful acquire.
+func (s chDiffSem) release() {
+	if s == nil {
+		return
+	}
+	<-s
+}

--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -60,6 +60,12 @@ type Config struct {
 	Logger log.Logger
 	// TracerProvider (optional).
 	TracerProvider trace.TracerProvider
+	// MaxChannelDifferenceConcurrency limits how many updates.getChannelDifference
+	// requests may be in flight at once across all tracked channels. 0 (the
+	// default) means unlimited: every channel recovers its gap independently, as
+	// before. A positive value bounds the burst so an account in many active
+	// channels does not exceed Telegram's per-account method rate limit.
+	MaxChannelDifferenceConcurrency int
 }
 
 func (cfg *Config) setDefaults() {

--- a/telegram/updates/config.go
+++ b/telegram/updates/config.go
@@ -61,8 +61,8 @@ type Config struct {
 	// TracerProvider (optional).
 	TracerProvider trace.TracerProvider
 	// MaxChannelDifferenceConcurrency limits how many updates.getChannelDifference
-	// requests may be in flight at once across all tracked channels. 0 (the
-	// default) means unlimited: every channel recovers its gap independently, as
+	// requests may be in flight at once across all tracked channels. Non-positive
+	// values (<= 0, default 0) mean unlimited: every channel recovers its gap as
 	// before. A positive value bounds the burst so an account in many active
 	// channels does not exceed Telegram's per-account method rate limit.
 	MaxChannelDifferenceConcurrency int

--- a/telegram/updates/manager.go
+++ b/telegram/updates/manager.go
@@ -31,18 +31,20 @@ type Manager struct {
 
 	// immutable:
 
-	cfg    Config
-	lg     log.Helper
-	tracer trace.Tracer
+	cfg       Config
+	lg        log.Helper
+	tracer    trace.Tracer
+	chDiffSem chDiffSem
 }
 
 // New creates new manager.
 func New(cfg Config) *Manager {
 	cfg.setDefaults()
 	return &Manager{
-		cfg:    cfg,
-		lg:     log.For(cfg.Logger),
-		tracer: cfg.TracerProvider.Tracer(""),
+		cfg:       cfg,
+		lg:        log.For(cfg.Logger),
+		tracer:    cfg.TracerProvider.Tracer(""),
+		chDiffSem: newChDiffSem(cfg.MaxChannelDifferenceConcurrency),
 	}
 }
 
@@ -160,6 +162,7 @@ func (m *Manager) Run(ctx context.Context, api API, userID int64, opt AuthOption
 			SelfID:                userID,
 			DiffLimit:             diffLim,
 			WorkGroup:             wg,
+			ChannelDiffSem:        m.chDiffSem,
 		})
 
 		return nil

--- a/telegram/updates/state.go
+++ b/telegram/updates/state.go
@@ -79,6 +79,7 @@ type internalState struct {
 	diffLim               int
 	wg                    *errgroup.Group
 	tracer                trace.Tracer
+	chDiffSem             chDiffSem
 }
 
 type stateConfig struct {
@@ -100,6 +101,7 @@ type stateConfig struct {
 	SelfID                int64
 	DiffLimit             int
 	WorkGroup             *errgroup.Group
+	ChannelDiffSem        chDiffSem
 }
 
 func newState(ctx context.Context, cfg stateConfig) *internalState {
@@ -127,6 +129,7 @@ func newState(ctx context.Context, cfg stateConfig) *internalState {
 		diffLim:               cfg.DiffLimit,
 		wg:                    cfg.WorkGroup,
 		tracer:                cfg.Tracer,
+		chDiffSem:             cfg.ChannelDiffSem,
 	}
 	s.pts = newSequenceBox(sequenceConfig{
 		InitialState: cfg.State.Pts,
@@ -511,6 +514,7 @@ func (s *internalState) newChannelState(channelID, accessHash int64, initialPts 
 		RemoveChannel:         s.removeChannel,
 		Logger:                s.log.Named("channel").With(log.Int64("channel_id", channelID)).Logger(),
 		Tracer:                s.tracer,
+		ChannelDiffSem:        s.chDiffSem,
 	})
 }
 

--- a/telegram/updates/state_channel.go
+++ b/telegram/updates/state_channel.go
@@ -62,6 +62,9 @@ type channelState struct {
 	onInaccessible func(channelID int64)
 	// removeChannel signals *internalState to drop this channel from tracking.
 	removeChannel chan<- int64
+	// chDiffSem bounds concurrent getChannelDifference calls across all channels
+	// of the manager. nil means unlimited.
+	chDiffSem chDiffSem
 }
 
 type channelStateConfig struct {
@@ -81,6 +84,7 @@ type channelStateConfig struct {
 	RemoveChannel         chan<- int64
 	Logger                log.Logger
 	Tracer                trace.Tracer
+	ChannelDiffSem        chDiffSem
 }
 
 func newChannelState(cfg channelStateConfig) *channelState {
@@ -105,6 +109,7 @@ func newChannelState(cfg channelStateConfig) *channelState {
 		onInaccessible: cfg.OnChannelInaccessible,
 		removeChannel:  cfg.RemoveChannel,
 		tracer:         cfg.Tracer,
+		chDiffSem:      cfg.ChannelDiffSem,
 	}
 
 	state.pts = newSequenceBox(sequenceConfig{
@@ -324,6 +329,14 @@ func (s *channelState) getDifference(ctx context.Context, reason string) error {
 		}
 	}
 
+	// Bound concurrent getChannelDifference across channels: a member of many
+	// active channels would otherwise burst past the per-account method limit.
+	// The slot wraps only the RPC — released before processing and the !Final
+	// recursion so a busy channel's catch-up does not monopolise it (and so a
+	// limit of 1 cannot self-deadlock on the nested call).
+	if err := s.chDiffSem.acquire(ctx); err != nil {
+		return err
+	}
 	diff, err := s.client.UpdatesGetChannelDifference(ctx, &tg.UpdatesGetChannelDifferenceRequest{
 		Channel: &tg.InputChannel{
 			ChannelID:  s.channelID,
@@ -333,6 +346,7 @@ func (s *channelState) getDifference(ctx context.Context, reason string) error {
 		Pts:    s.pts.State(),
 		Limit:  s.diffLim,
 	})
+	s.chDiffSem.release()
 	if err != nil {
 		if tgerr.Is(err, "CHANNEL_PRIVATE") {
 			return s.handleInaccessible(ctx)


### PR DESCRIPTION
## Motivation

The updates manager runs one worker per tracked channel, and each worker
issues `updates.getChannelDifference` independently on its own gap/idle
timers. There is no global throttle across channels.

For an account that is a member of many active channels this is a problem.
On connect (and on every reconnect) the manager loads every channel with a
stored pts and the workers fire `getChannelDifference` in a large
simultaneous burst. For accounts subscribed to 500+ active channels this
burst routinely exceeds Telegram's per-account method rate limit: in
production we have observed sustained `FLOOD_WAIT` on **up to ~50% of all
`getChannelDifference` calls**, which in turn slows gap recovery and delays
update delivery for the channels that actually matter.

Telegram's official clients bound this. TDLib, for example, caps in-flight
channel-difference requests via `MAX_CONCURRENT_GET_CHANNEL_DIFFERENCES`.
gotd currently has no equivalent knob.

## Change

Add an opt-in `Config.MaxChannelDifferenceConcurrency` that bounds how many
`getChannelDifference` requests may be in flight at once across all channel
workers of a single manager.

- A shared counting semaphore (a buffered channel — no new dependency)
  gates the call.
- The slot wraps **only the RPC**; it is released before diff processing
  and before the `!Final` recursion. So a channel with a long backlog does
  not hold a slot while it catches up, and a limit of `1` cannot
  self-deadlock on the nested call.
- The default (`0`) is **unlimited**: the semaphore is `nil`,
  `acquire`/`release` are no-ops, and behaviour is byte-for-byte unchanged
  for existing users. The limit is purely opt-in.

```go
m := updates.New(updates.Config{
    Handler: h,
    // ... cap concurrent getChannelDifference across all channels:
    MaxChannelDifferenceConcurrency: 10,
})
```

## Testing

`telegram/updates/channel_diff_concurrency_test.go` covers:
- the config value is threaded through `New` to the channel workers;
- concurrency never exceeds the configured limit under contention;
- the default remains unlimited (no semaphore);
- `acquire` respects context cancellation;
- a channel added to a running manager at runtime inherits the same limit.

All `telegram/updates` tests pass with `-race`.

## Compatibility

Fully backward compatible. No API removed or changed; one optional `Config`
field added. Zero behavioural change unless a positive limit is set.
