### PR TITLE
fix(crypto): derive temp AES keys from fixed-length nonces

### DIFF
--- a/crypto/temp_keys.go
+++ b/crypto/temp_keys.go
@@ -5,11 +5,11 @@ import (
 	"math/big"
 )
 
-// sha1BigInt returns SHA1(a + b).
-func sha1BigInt(a, b *big.Int) []byte {
-	var buf []byte
-	buf = append(buf, a.Bytes()...)
-	buf = append(buf, b.Bytes()...)
+// sha1Bytes returns SHA1(a + b).
+func sha1Bytes(a, b []byte) []byte {
+	buf := make([]byte, 0, len(a)+len(b))
+	buf = append(buf, a...)
+	buf = append(buf, b...)
 
 	h := sha1.Sum(buf) // #nosec
 	return h[:]
@@ -17,20 +17,31 @@ func sha1BigInt(a, b *big.Int) []byte {
 
 // TempAESKeys returns tmp_aes_key and tmp_aes_iv based on new_nonce and
 // server_nonce as defined in "Creating an Authorization Key".
+//
+// new_nonce (int256) and server_nonce (int128) are fixed-length byte strings
+// of 32 and 16 bytes. They must be hashed at their full length: see
+// https://core.telegram.org/mtproto/auth_key#presenting-proof-of-work-server-authentication
+//
+// They are passed here as *big.Int, so they are first serialized back to their
+// canonical fixed length with FillBytes. Using big.Int.Bytes() instead would
+// strip leading zero bytes, and whenever new_nonce or server_nonce starts with
+// 0x00 (about 1/256 of the time each) the SHA1 input would be a byte short and
+// the derived tmp_aes_key/tmp_aes_iv would be wrong, making the server_DH_params
+// answer impossible to decrypt for a spec-compliant peer.
 func TempAESKeys(newNonce, serverNonce *big.Int) (key, iv []byte) {
-	// See https://core.telegram.org/mtproto/auth_key#presenting-proof-of-work-server-authentication
-	// 5. Server responds in one of two ways: [...]
+	nn := make([]byte, 32)
+	newNonce.FillBytes(nn)
+	sn := make([]byte, 16)
+	serverNonce.FillBytes(sn)
 
-	// tmp_aes_key := SHA1(new_nonce + server_nonce) + substr (SHA1(server_nonce + new_nonce), 0, 12);
-	// SHA1(new_nonce + server_nonce)
-	key = append(key, sha1BigInt(newNonce, serverNonce)...)
-	// substr (SHA1(server_nonce + new_nonce), 0, 12);
-	key = append(key, sha1BigInt(serverNonce, newNonce)[:12]...)
+	// tmp_aes_key := SHA1(new_nonce + server_nonce) + substr(SHA1(server_nonce + new_nonce), 0, 12)
+	key = append(key, sha1Bytes(nn, sn)...)
+	key = append(key, sha1Bytes(sn, nn)[:12]...)
 
-	// tmp_aes_iv := substr (SHA1(server_nonce + new_nonce), 12, 8) + SHA1(new_nonce + new_nonce) + substr (new_nonce, 0, 4);
-	iv = append(iv, sha1BigInt(serverNonce, newNonce)[12:12+8]...)
-	iv = append(iv, sha1BigInt(newNonce, newNonce)...)
-	iv = append(iv, newNonce.Bytes()[:4]...)
+	// tmp_aes_iv := substr(SHA1(server_nonce + new_nonce), 12, 8) + SHA1(new_nonce + new_nonce) + substr(new_nonce, 0, 4)
+	iv = append(iv, sha1Bytes(sn, nn)[12:12+8]...)
+	iv = append(iv, sha1Bytes(nn, nn)...)
+	iv = append(iv, nn[:4]...)
 
 	return key, iv
 }

--- a/crypto/temp_keys_test.go
+++ b/crypto/temp_keys_test.go
@@ -3,8 +3,11 @@ package crypto
 import (
 	"bytes"
 	"crypto/aes"
+	"encoding/hex"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/gotd/ige"
 )
@@ -75,4 +78,49 @@ func TestTempAESKeys(t *testing.T) {
 	if !bytes.Equal(answer, expectedAnswer) {
 		t.Fatal("mismatch")
 	}
+}
+
+// TestTempAESKeysLeadingZeroNonce is a regression test for nonces whose first
+// byte is 0x00.
+//
+// new_nonce (int256) and server_nonce (int128) are fixed-length byte strings of
+// 32 and 16 bytes. Deriving the temp keys via big.Int.Bytes() strips leading
+// zero bytes, so whenever a nonce starts with 0x00 the SHA1 input is a byte
+// short and the resulting tmp_aes_key/tmp_aes_iv are wrong. That happens for
+// about 1/256 of new_nonce values and 1/256 of server_nonce values, breaking
+// the handshake with a spec-compliant peer.
+//
+// The vectors below were derived independently from the fixed-length nonces and
+// differ from what the stripped derivation would produce.
+func TestTempAESKeysLeadingZeroNonce(t *testing.T) {
+	var (
+		newNonceBytes    [32]byte
+		serverNonceBytes [16]byte
+	)
+	for i := range newNonceBytes {
+		newNonceBytes[i] = byte(i) // 0x00, 0x01, ... 0x1f
+	}
+	for i := range serverNonceBytes {
+		serverNonceBytes[i] = byte(0x20 + i)
+	}
+	serverNonceBytes[0] = 0x00 // 0x00, 0x21, ... 0x2f
+
+	newNonce := new(big.Int).SetBytes(newNonceBytes[:])
+	serverNonce := new(big.Int).SetBytes(serverNonceBytes[:])
+
+	key, iv := TempAESKeys(newNonce, serverNonce)
+
+	require.Equal(t,
+		"0a2d0f607499a866848e41798a34315e4922c39fe55c6caf5bc322c4b8c08c6a",
+		hex.EncodeToString(key),
+	)
+	require.Equal(t,
+		"9cb702d4fd6e5d25e864070e166e6218f6783e8511471a5ab7802cf200010203",
+		hex.EncodeToString(iv),
+	)
+
+	// tmp_aes_iv ends with substr(new_nonce, 0, 4): the first four bytes of the
+	// fixed-length nonce, including the leading zero. With the stripped
+	// derivation this would be newNonceBytes[1:5] instead.
+	require.Equal(t, newNonceBytes[:4], iv[len(iv)-4:])
 }


### PR DESCRIPTION
## Summary

`crypto.TempAESKeys` derives `tmp_aes_key` / `tmp_aes_iv` from `new_nonce` and `server_nonce` by passing them through `(*big.Int).Bytes()`, which returns the **minimal** big-endian encoding and therefore drops leading zero bytes. Per the MTProto spec ([Creating an Authorization Key](https://core.telegram.org/mtproto/auth_key#presenting-proof-of-work-server-authentication)), `new_nonce` (int256) and `server_nonce` (int128) are **fixed-length** byte strings of 32 and 16 bytes and must be hashed at their full length.

When either nonce begins with `0x00` (~1/256 of the time per nonce, ~0.8% combined), the SHA1 input is a byte short, so the derived key/IV are wrong and the `server_DH_params` answer cannot be decrypted by a spec-compliant peer.

## Root cause

```go
// before
buf = append(buf, a.Bytes()...)           // strips leading zero bytes
...
iv = append(iv, newNonce.Bytes()[:4]...)  // wrong 4 bytes when new_nonce[0] == 0x00
```

`Int256.BigInt()` / `Int128.BigInt()` are `SetBytes` over the canonical 32 / 16-byte arrays, so a leading `0x00` is real input that then gets dropped.

Both exchange flows derive the temp keys through this function, so the issue is symmetric:

- `exchange/client_flow.go` — `crypto.TempAESKeys(newNonce.BigInt(), serverNonce.BigInt())`
- `exchange/server_flow.go` — `crypto.TempAESKeys(innerData.NewNonce.BigInt(), serverNonce.BigInt())`

Because gotd's client and server share this derivation, `gotd <-> gotd` always agrees, and the existing `TestTempAESKeys` vector happens to use nonces that both start with a non-zero byte — so the path was never exercised. It surfaces only when gotd interoperates with a different, spec-correct MTProto implementation (found while running gotd as a server against a third-party spec-compliant client).

## Fix

Serialize each nonce back to its canonical fixed length with `FillBytes` (32 / 16 bytes) before hashing — the same fixed-length pattern already used elsewhere in this package (`crypto.FillBytes`, `crypto/srp/hash.go`). No public API change.

## Testing

- New `TestTempAESKeysLeadingZeroNonce` exercises leading-zero `new_nonce` and `server_nonce`; the expected key/IV were derived independently from the fixed-length nonces. It **fails on `main`** and passes with this change.
- The existing `TestTempAESKeys` (official sample vector) still passes.
- `go test ./crypto/... ./exchange/...` is green.

## Notes

I kept the `*big.Int` signature to make the change minimal and non-breaking. If you'd prefer, `TempAESKeys` could instead take the fixed-length `bin.Int256` / `bin.Int128` directly so the invariant is enforced by the type — happy to follow up in a separate PR.
