### PR TITLE
feat(markup): add style functional options for keyboard buttons

### DIFF
--- a/telegram/message/markup/button.go
+++ b/telegram/message/markup/button.go
@@ -2,6 +2,51 @@ package markup
 
 import "github.com/gotd/td/tg"
 
+// StyleOption is a functional parameter that configures the tg.KeyboardButtonStyle
+// of a button, allowing a custom background color and a custom emoji label.
+//
+// See https://core.telegram.org/api/bots/buttons#button-styles.
+type StyleOption func(s *tg.KeyboardButtonStyle)
+
+// applyStyle builds a tg.KeyboardButtonStyle from the given options.
+func applyStyle(options []StyleOption) tg.KeyboardButtonStyle {
+	var style tg.KeyboardButtonStyle
+	for _, opt := range options {
+		opt(&style)
+	}
+	return style
+}
+
+// StyleBgPrimary sets a dark blue background color, recommended for main actions.
+func StyleBgPrimary() StyleOption {
+	return func(s *tg.KeyboardButtonStyle) {
+		s.BgPrimary = true
+	}
+}
+
+// StyleBgDanger sets a red background color, recommended for destructive actions.
+func StyleBgDanger() StyleOption {
+	return func(s *tg.KeyboardButtonStyle) {
+		s.BgDanger = true
+	}
+}
+
+// StyleBgSuccess sets a green background color, recommended for positive actions.
+func StyleBgSuccess() StyleOption {
+	return func(s *tg.KeyboardButtonStyle) {
+		s.BgSuccess = true
+	}
+}
+
+// StyleIcon sets the ID of a custom emoji to be displayed before the button's label.
+//
+// See https://core.telegram.org/api/custom-emoji.
+func StyleIcon(icon int64) StyleOption {
+	return func(s *tg.KeyboardButtonStyle) {
+		s.SetIcon(icon)
+	}
+}
+
 // Row creates keyboard row.
 func Row(buttons ...tg.KeyboardButtonClass) tg.KeyboardButtonRow {
 	return tg.KeyboardButtonRow{
@@ -10,39 +55,44 @@ func Row(buttons ...tg.KeyboardButtonClass) tg.KeyboardButtonRow {
 }
 
 // Button creates new plain text button.
-func Button(text string) *tg.KeyboardButton {
+func Button(text string, style ...StyleOption) *tg.KeyboardButton {
 	return &tg.KeyboardButton{
-		Text: text,
+		Text:  text,
+		Style: applyStyle(style),
 	}
 }
 
 // URL creates new URL button.
-func URL(text, url string) *tg.KeyboardButtonURL {
+func URL(text, url string, style ...StyleOption) *tg.KeyboardButtonURL {
 	return &tg.KeyboardButtonURL{
-		Text: text,
-		URL:  url,
+		Text:  text,
+		URL:   url,
+		Style: applyStyle(style),
 	}
 }
 
 // Callback creates new callback button.
-func Callback(text string, data []byte) *tg.KeyboardButtonCallback {
+func Callback(text string, data []byte, style ...StyleOption) *tg.KeyboardButtonCallback {
 	return &tg.KeyboardButtonCallback{
-		Text: text,
-		Data: data,
+		Text:  text,
+		Data:  data,
+		Style: applyStyle(style),
 	}
 }
 
 // RequestPhone creates button to request a user's phone number.
-func RequestPhone(text string) *tg.KeyboardButtonRequestPhone {
+func RequestPhone(text string, style ...StyleOption) *tg.KeyboardButtonRequestPhone {
 	return &tg.KeyboardButtonRequestPhone{
-		Text: text,
+		Text:  text,
+		Style: applyStyle(style),
 	}
 }
 
 // RequestGeoLocation creates button to request a user's geo location.
-func RequestGeoLocation(text string) *tg.KeyboardButtonRequestGeoLocation {
+func RequestGeoLocation(text string, style ...StyleOption) *tg.KeyboardButtonRequestGeoLocation {
 	return &tg.KeyboardButtonRequestGeoLocation{
-		Text: text,
+		Text:  text,
+		Style: applyStyle(style),
 	}
 }
 
@@ -52,25 +102,28 @@ func RequestGeoLocation(text string) *tg.KeyboardButtonRequestGeoLocation {
 //
 // If samePeer set, pressing the button will insert the bot‘s
 // username and the specified inline query in the current chat's input field.
-func SwitchInline(text, query string, samePeer bool) *tg.KeyboardButtonSwitchInline {
+func SwitchInline(text, query string, samePeer bool, style ...StyleOption) *tg.KeyboardButtonSwitchInline {
 	return &tg.KeyboardButtonSwitchInline{
 		SamePeer: samePeer,
 		Text:     text,
 		Query:    query,
+		Style:    applyStyle(style),
 	}
 }
 
 // Game creates button to start a game.
-func Game(text string) *tg.KeyboardButtonGame {
+func Game(text string, style ...StyleOption) *tg.KeyboardButtonGame {
 	return &tg.KeyboardButtonGame{
-		Text: text,
+		Text:  text,
+		Style: applyStyle(style),
 	}
 }
 
 // Buy creates button to buy a product.
-func Buy(text string) *tg.KeyboardButtonBuy {
+func Buy(text string, style ...StyleOption) *tg.KeyboardButtonBuy {
 	return &tg.KeyboardButtonBuy{
-		Text: text,
+		Text:  text,
+		Style: applyStyle(style),
 	}
 }
 
@@ -88,21 +141,23 @@ func InputURLAuth(requestWriteAccess bool, text, fwdText, url string, bot tg.Inp
 
 // URLAuth creates button to request a user to authorize via URL using Seamless Telegram Login.
 // Can only be sent or received as part of a reply keyboard, use InputURLAuth for inline keyboards.
-func URLAuth(text, url string, buttonID int, fwdText string) *tg.KeyboardButtonURLAuth {
+func URLAuth(text, url string, buttonID int, fwdText string, style ...StyleOption) *tg.KeyboardButtonURLAuth {
 	return &tg.KeyboardButtonURLAuth{
 		Text:     text,
 		URL:      url,
 		ButtonID: buttonID,
 		FwdText:  fwdText,
+		Style:    applyStyle(style),
 	}
 }
 
 // RequestPoll creates button that allows the user to create and send a poll when pressed.
 // Available only in private.
-func RequestPoll(text string, quiz bool) *tg.KeyboardButtonRequestPoll {
+func RequestPoll(text string, quiz bool, style ...StyleOption) *tg.KeyboardButtonRequestPoll {
 	return &tg.KeyboardButtonRequestPoll{
-		Text: text,
-		Quiz: quiz,
+		Text:  text,
+		Quiz:  quiz,
+		Style: applyStyle(style),
 	}
 }
 
@@ -117,39 +172,43 @@ func InputUserProfile(text string, user tg.InputUserClass) *tg.InputKeyboardButt
 
 // UserProfile creates button that links directly to a user profile.
 // Can only be sent or received as part of a reply keyboard, use InputUserProfile for inline keyboards.
-func UserProfile(text string, userID int64) *tg.KeyboardButtonUserProfile {
+func UserProfile(text string, userID int64, style ...StyleOption) *tg.KeyboardButtonUserProfile {
 	return &tg.KeyboardButtonUserProfile{
 		Text:   text,
 		UserID: userID,
+		Style:  applyStyle(style),
 	}
 }
 
 // WebView creates button to open a bot web app using messages.requestWebView, sending over user information after
 // user confirmation.
 // Can only be sent or received as part of an inline keyboard, use SimpleWebView for reply keyboards.
-func WebView(text, url string) *tg.KeyboardButtonWebView {
+func WebView(text, url string, style ...StyleOption) *tg.KeyboardButtonWebView {
 	return &tg.KeyboardButtonWebView{
-		Text: text,
-		URL:  url,
+		Text:  text,
+		URL:   url,
+		Style: applyStyle(style),
 	}
 }
 
 // SimpleWebView creates button to open a bot web app using messages.requestSimpleWebView, without sending user
 // information to the web app.
 // Can only be sent or received as part of a reply keyboard, use WebView for inline keyboards.
-func SimpleWebView(text, url string) *tg.KeyboardButtonSimpleWebView {
+func SimpleWebView(text, url string, style ...StyleOption) *tg.KeyboardButtonSimpleWebView {
 	return &tg.KeyboardButtonSimpleWebView{
-		Text: text,
-		URL:  url,
+		Text:  text,
+		URL:   url,
+		Style: applyStyle(style),
 	}
 }
 
 // RequestPeer creates button that prompts the user to select and share a peer with the bot using
 // messages.sendBotRequestedPeer.
-func RequestPeer(text string, buttonID int, peerType tg.RequestPeerTypeClass) *tg.KeyboardButtonRequestPeer {
+func RequestPeer(text string, buttonID int, peerType tg.RequestPeerTypeClass, style ...StyleOption) *tg.KeyboardButtonRequestPeer {
 	return &tg.KeyboardButtonRequestPeer{
 		Text:     text,
 		ButtonID: buttonID,
 		PeerType: peerType,
+		Style:    applyStyle(style),
 	}
 }

--- a/telegram/message/markup/button_test.go
+++ b/telegram/message/markup/button_test.go
@@ -1,0 +1,106 @@
+package markup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestStyleOptions(t *testing.T) {
+	t.Run("None", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle(nil)
+		a.True(style.Zero())
+		a.False(style.BgPrimary)
+		a.False(style.BgDanger)
+		a.False(style.BgSuccess)
+		_, ok := style.GetIcon()
+		a.False(ok)
+	})
+	t.Run("BgPrimary", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle([]StyleOption{StyleBgPrimary()})
+		a.True(style.BgPrimary)
+		a.False(style.BgDanger)
+		a.False(style.BgSuccess)
+	})
+	t.Run("BgDanger", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle([]StyleOption{StyleBgDanger()})
+		a.False(style.BgPrimary)
+		a.True(style.BgDanger)
+		a.False(style.BgSuccess)
+	})
+	t.Run("BgSuccess", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle([]StyleOption{StyleBgSuccess()})
+		a.False(style.BgPrimary)
+		a.False(style.BgDanger)
+		a.True(style.BgSuccess)
+	})
+	t.Run("Icon", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle([]StyleOption{StyleIcon(123456)})
+		icon, ok := style.GetIcon()
+		a.True(ok)
+		a.Equal(int64(123456), icon)
+	})
+	t.Run("Combined", func(t *testing.T) {
+		a := require.New(t)
+
+		style := applyStyle([]StyleOption{
+			StyleBgPrimary(),
+			StyleBgDanger(),
+			StyleBgSuccess(),
+			StyleIcon(42),
+		})
+		a.True(style.BgPrimary)
+		a.True(style.BgDanger)
+		a.True(style.BgSuccess)
+		icon, ok := style.GetIcon()
+		a.True(ok)
+		a.Equal(int64(42), icon)
+	})
+}
+
+func TestButtonStyle(t *testing.T) {
+	a := require.New(t)
+
+	want := tg.KeyboardButtonStyle{BgDanger: true}
+	want.SetIcon(777)
+
+	options := []StyleOption{StyleBgDanger(), StyleIcon(777)}
+
+	a.Equal(want, Button("text", options...).Style)
+	a.Equal(want, URL("text", "url", options...).Style)
+	a.Equal(want, Callback("text", []byte("data"), options...).Style)
+	a.Equal(want, RequestPhone("text", options...).Style)
+	a.Equal(want, RequestGeoLocation("text", options...).Style)
+	a.Equal(want, SwitchInline("text", "query", true, options...).Style)
+	a.Equal(want, Game("text", options...).Style)
+	a.Equal(want, Buy("text", options...).Style)
+	a.Equal(want, URLAuth("text", "url", 1, "fwd", options...).Style)
+	a.Equal(want, RequestPoll("text", true, options...).Style)
+	a.Equal(want, UserProfile("text", 1, options...).Style)
+	a.Equal(want, WebView("text", "url", options...).Style)
+	a.Equal(want, SimpleWebView("text", "url", options...).Style)
+	a.Equal(want, RequestPeer("text", 0, &tg.RequestPeerTypeUser{}, options...).Style)
+}
+
+func TestButtonNoStyle(t *testing.T) {
+	a := require.New(t)
+
+	// Without options, the style must stay zero so SetFlags does not set the
+	// optional Style flag during encoding.
+	a.True(Button("text").Style.Zero())
+	a.True(URL("text", "url").Style.Zero())
+	a.True(Callback("text", []byte("data")).Style.Zero())
+	a.True(RequestPeer("text", 0, &tg.RequestPeerTypeUser{}).Style.Zero())
+}


### PR DESCRIPTION
## Summary

Adds `StyleOption` functional parameters to the `telegram/message/markup` button constructors, allowing callers to configure `tg.KeyboardButtonStyle` (custom background color and custom emoji label) inline.

New options:
- `StyleBgPrimary()` — dark blue background (main actions)
- `StyleBgDanger()` — red background (destructive actions)
- `StyleBgSuccess()` — green background (positive actions)
- `StyleIcon(icon int64)` — custom emoji shown before the label

Each button constructor whose `tg` type carries a `Style` field gained a trailing `style ...StyleOption` parameter: `Button`, `URL`, `Callback`, `RequestPhone`, `RequestGeoLocation`, `SwitchInline`, `Game`, `Buy`, `URLAuth`, `RequestPoll`, `UserProfile`, `WebView`, `SimpleWebView`, and `RequestPeer`. The `Input*` variants are untouched since their types have no `Style` field.

```go
markup.URL("Delete", "https://example.com/del", markup.StyleBgDanger(), markup.StyleIcon(123456))
```

## Notes

- **Backward compatible**: the new parameter is variadic, so existing call sites compile unchanged. With no options the style stays zero, which the generated `SetFlags()` leaves unflagged on encode — matching prior behavior.
- `StyleIcon` uses the generated `SetIcon` setter so the optional flag bit is set correctly.

## Tests

Added `button_test.go` covering each option in isolation, the combined/empty cases, the resulting `.Style` across all style-aware constructors, and the no-options zero-style invariant. Passes under `-race`.

Refs #1798