### PR TITLE
accept negative DC IDs for temporary media auth keys

### DIFF
--- a/exchange/flow_test.go
+++ b/exchange/flow_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gotd/log/logzap"
 	"github.com/gotd/td/bin"
 	"github.com/gotd/td/crypto"
+	"github.com/gotd/td/proto/codec"
 	"github.com/gotd/td/tdsync"
 	"github.com/gotd/td/testutil"
 	"github.com/gotd/td/transport"
@@ -75,6 +76,100 @@ func testExchange(tempMode bool) func(t *testing.T) {
 func TestExchange(t *testing.T) {
 	t.Run("PQInnerData", testExchange(false))
 	t.Run("PQInnerDataDC", testExchange(true))
+}
+
+func TestExchangeNegativeTemporaryMediaDC(t *testing.T) {
+	a := require.New(t)
+	log := zaptest.NewLogger(t)
+
+	reader := rand.New(rand.NewSource(1))
+	key, err := rsa.GenerateKey(reader, crypto.RSAKeyBits)
+	a.NoError(err)
+	privateKey := PrivateKey{
+		RSA: key,
+	}
+
+	i := transport.Intermediate
+	client, server := i.Pipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var clientResult ClientExchangeResult
+	var serverResult ServerExchangeResult
+	g := tdsync.NewCancellableGroup(ctx)
+	g.Go(func(ctx context.Context) error {
+		r, err := NewExchanger(client, -2).
+			WithLogger(logzap.New(log.Named("client"))).
+			WithRand(reader).
+			WithTempMode(60).
+			Client([]PublicKey{privateKey.Public()}).
+			Run(ctx)
+		clientResult = r
+		return err
+	})
+
+	g.Go(func(ctx context.Context) error {
+		r, err := NewExchanger(server, 2).
+			WithLogger(logzap.New(log.Named("server"))).
+			WithRand(reader).
+			Server(privateKey).
+			Run(ctx)
+		serverResult = r
+		return err
+	})
+
+	a.NoError(g.Wait())
+	a.NotZero(clientResult.ExpiresAt)
+	a.Equal(clientResult.AuthKey, serverResult.Key)
+	a.Equal(clientResult.ServerSalt, serverResult.ServerSalt)
+}
+
+func TestExchangeRejectsWrongNegativeTemporaryMediaDC(t *testing.T) {
+	a := require.New(t)
+	log := zaptest.NewLogger(t)
+
+	reader := rand.New(rand.NewSource(1))
+	key, err := rsa.GenerateKey(reader, crypto.RSAKeyBits)
+	a.NoError(err)
+	privateKey := PrivateKey{
+		RSA: key,
+	}
+
+	i := transport.Intermediate
+	client, server := i.Pipe()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+
+	var serverErr error
+	g := tdsync.NewCancellableGroup(ctx)
+	g.Go(func(ctx context.Context) error {
+		_, _ = NewExchanger(client, -3).
+			WithLogger(logzap.New(log.Named("client"))).
+			WithRand(reader).
+			WithTempMode(60).
+			Client([]PublicKey{privateKey.Public()}).
+			Run(ctx)
+		return nil
+	})
+
+	g.Go(func(ctx context.Context) error {
+		_, serverErr = NewExchanger(server, 2).
+			WithLogger(logzap.New(log.Named("server"))).
+			WithRand(reader).
+			Server(privateKey).
+			Run(ctx)
+		_ = client.Close()
+		_ = server.Close()
+		cancel()
+		return nil
+	})
+
+	a.NoError(g.Wait())
+	var exchangeErr *ServerExchangeError
+	a.ErrorAs(serverErr, &exchangeErr)
+	a.Equal(int32(codec.CodeWrongDC), exchangeErr.Code)
 }
 
 // TestServerUnexpectedEncrypted verifies that the server flow surfaces a frame

--- a/exchange/server_flow.go
+++ b/exchange/server_flow.go
@@ -203,7 +203,8 @@ SendResPQ:
 			}
 		case *mt.PQInnerDataTempDC:
 			// PFS flow: same DC validation, plus ExpiresIn is consumed by TG side.
-			if innerDataDC.DC != s.dc {
+			// Telegram clients can use negative dc_id for temporary media auth keys.
+			if !sameOrTemporaryMediaDC(innerDataDC.DC, s.dc) {
 				err := errors.Errorf(
 					"wrong DC ID, want %d, got %d",
 					s.dc, innerDataDC.DC,
@@ -306,4 +307,8 @@ SendResPQ:
 		Key:        authKey.WithID(),
 		ServerSalt: serverSalt,
 	}, nil
+}
+
+func sameOrTemporaryMediaDC(got, want int) bool {
+	return got == want || got == -want
 }


### PR DESCRIPTION
## Summary

- allow server-side temporary auth-key exchange to accept a negative `dc_id` when its absolute value matches the server DC
- keep permanent auth-key DC validation strict
- keep mismatched temporary DCs rejected with `CodeWrongDC`

## Why

Telegram clients can use negative DC IDs for media-only temporary auth keys during MTProto auth-key generation. Before this change, a server running as DC 2 rejected `p_q_inner_data_temp_dc{dc:-2}` as `wrong DC ID, want 2, got -2` even though it targets the same DC for temporary media authorization.

See Telegram MTProto auth key docs: https://core.telegram.org/mtproto/auth_key#dh-exchange-initiation

## Tests

- `go test ./exchange -run "TestExchangeNegativeTemporaryMediaDC|TestExchangeRejectsWrongNegativeTemporaryMediaDC" -count=1 -timeout 60s -v`
- `go test ./exchange -count=1`
- `git diff --check`