### PR TITLE
feat(mtproto): add debug tracing for stalled request diagnosis

### DIFF
--- a/mtproto/ack.go
+++ b/mtproto/ack.go
@@ -16,12 +16,18 @@ func (c *Conn) ackLoop(ctx context.Context) error {
 	send := func() {
 		defer func() { buf = buf[:0] }()
 
+		start := c.clock.Now()
 		if err := c.writeServiceMessage(ctx, &mt.MsgsAck{MsgIDs: buf}); err != nil {
-			c.log.Error(ctx, "Failed to ACK", log.Error(err))
+			// A failing ack write is a strong signal that the outgoing half of
+			// the connection is broken while the read loop still works.
+			c.log.Error(ctx, "Failed to ACK", log.Error(err), log.Any("msg_ids", buf))
 			return
 		}
 
-		logger.Debug(ctx, "Ack", log.Any("msg_ids", buf))
+		logger.Debug(ctx, "Ack",
+			log.Any("msg_ids", buf),
+			log.Duration("elapsed", c.clock.Now().Sub(start)),
+		)
 	}
 
 	ticker := c.clock.Ticker(c.ackInterval)

--- a/mtproto/ping.go
+++ b/mtproto/ping.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/go-faster/errors"
+	"github.com/gotd/log"
 
 	"github.com/gotd/td/bin"
 	"github.com/gotd/td/crypto"
@@ -98,6 +99,7 @@ func (c *Conn) pingLoop(ctx context.Context) error {
 	// for example, it may set disconnect_delay equal to 75 seconds.
 	delay := c.pingInterval + c.pingTimeout
 
+	logger := c.log.Named("ping")
 	ticker := c.clock.Ticker(c.pingInterval)
 	defer ticker.Stop()
 
@@ -106,14 +108,24 @@ func (c *Conn) pingLoop(ctx context.Context) error {
 		case <-ctx.Done():
 			return errors.Wrap(ctx.Err(), "ping loop")
 		case <-ticker.C():
+			start := c.clock.Now()
+			logger.Debug(ctx, "Sending ping", log.Duration("timeout", c.pingTimeout))
 			if err := func() error {
 				ctx, cancel := context.WithTimeout(ctx, c.pingTimeout)
 				defer cancel()
 
 				return c.pingDelayDisconnect(ctx, int(delay.Seconds()))
 			}(); err != nil {
+				// A missed pong means the connection is half-open: the server
+				// is not answering our pings even though the read loop may
+				// still be delivering updates. This should trigger a reconnect.
+				logger.Warn(ctx, "Ping failed, connection considered dead",
+					log.Error(err),
+					log.Duration("elapsed", c.clock.Now().Sub(start)),
+				)
 				return errors.Wrap(err, "disconnect (pong missed)")
 			}
+			logger.Debug(ctx, "Ping acknowledged", log.Duration("elapsed", c.clock.Now().Sub(start)))
 		}
 	}
 }

--- a/mtproto/read.go
+++ b/mtproto/read.go
@@ -90,10 +90,20 @@ func (c *Conn) consumeMessage(ctx context.Context, buf *bin.Buffer) error {
 
 	needAck := (msg.SeqNo & 0x01) != 0
 	if needAck {
+		// Enqueue message id for acknowledge. This can block if the ack loop
+		// is stuck (e.g. writing acks over a half-open connection), which would
+		// stall message consumption. Trace slow enqueues to surface it.
+		start := c.clock.Now()
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
 		case c.ackSendChan <- msg.MessageID:
+			if waited := c.clock.Now().Sub(start); waited > slowWriteThreshold {
+				c.log.Warn(ctx, "Slow ack enqueue (ack loop may be stalled)",
+					log.Int64("msg_id", msg.MessageID),
+					log.Duration("waited", waited),
+				)
+			}
 		}
 	}
 

--- a/mtproto/write.go
+++ b/mtproto/write.go
@@ -2,6 +2,9 @@ package mtproto
 
 import (
 	"context"
+	"time"
+
+	"github.com/gotd/log"
 
 	"github.com/gotd/td/bin"
 )
@@ -17,11 +20,34 @@ func (c *Conn) writeServiceMessage(ctx context.Context, message bin.Encoder) err
 
 var bufPool = bin.NewPool(0)
 
+// slowWriteThreshold is the duration after which a single write (lock
+// acquisition + encrypt + transport send) is considered suspiciously slow and
+// logged at warning level. A blocked or slow write is the primary signature of
+// a half-open connection where updates are still received but requests can no
+// longer be issued.
+const slowWriteThreshold = 3 * time.Second
+
 func (c *Conn) write(ctx context.Context, msgID int64, seqNo int32, message bin.Encoder) error {
+	start := c.clock.Now()
+
 	// Grab shared lock for writing.
 	// It prevents message sending during key regeneration if server forgot current auth key.
+	//
+	// Note: if key exchange holds the write lock (see createAuthKey), every
+	// send — including pings, acks and content requests — blocks here. Tracing
+	// the lock acquisition separately lets us distinguish "stuck on exchange
+	// lock" from "stuck on transport send".
 	c.exchangeLock.RLock()
 	defer c.exchangeLock.RUnlock()
+
+	locked := c.clock.Now()
+	if waited := locked.Sub(start); waited > slowWriteThreshold {
+		c.logWithTypeID(peekID(message)).Warn(ctx, "Slow write: waited for exchange lock",
+			log.Int64("msg_id", msgID),
+			log.Int32("seq_no", seqNo),
+			log.Duration("waited", waited),
+		)
+	}
 
 	b := bufPool.Get()
 	defer bufPool.Put(b)
@@ -30,11 +56,32 @@ func (c *Conn) write(ctx context.Context, msgID int64, seqNo int32, message bin.
 		return err
 	}
 
+	logger := c.logWithTypeID(peekID(message)).With(
+		log.Int64("msg_id", msgID),
+		log.Int32("seq_no", seqNo),
+		log.Int("size_bytes", b.Len()),
+	)
+	logger.Debug(ctx, "Sending message")
+
 	if err := c.conn.Send(ctx, b); err != nil {
+		logger.Debug(ctx, "Send failed", log.Error(err), log.Duration("elapsed", c.clock.Now().Sub(locked)))
 		return err
 	}
 
+	if elapsed := c.clock.Now().Sub(locked); elapsed > slowWriteThreshold {
+		logger.Warn(ctx, "Slow write: transport send took too long", log.Duration("elapsed", elapsed))
+	}
+
 	return nil
+}
+
+// peekID returns the type id of an encodable message for logging, or 0 if it
+// cannot be determined without encoding.
+func peekID(message bin.Encoder) uint32 {
+	if t, ok := message.(interface{ TypeID() uint32 }); ok {
+		return t.TypeID()
+	}
+	return 0
 }
 
 func (c *Conn) nextMsgSeq(content bool) (msgID int64, seqNo int32) {

--- a/rpc/engine.go
+++ b/rpc/engine.go
@@ -149,8 +149,11 @@ func (e *Engine) Do(ctx context.Context, req Request) error {
 		return errors.Wrap(err, "retryUntilAck")
 	}
 
+	logger.Debug(ctx, "Acknowledged, waiting for result", log.Bool("sent", sent))
+
 	select {
 	case <-ctx.Done():
+		logger.Debug(ctx, "Context done before result", log.Bool("sent", sent), log.Error(ctx.Err()))
 		if !sent {
 			return ctx.Err()
 		}
@@ -183,8 +186,10 @@ func (e *Engine) Do(ctx context.Context, req Request) error {
 		// received before close: the server may have already processed it,
 		// so resending is not safe. Report plain context error, callers
 		// should not retry transparently.
+		logger.Debug(ctx, "Engine closed while waiting for result")
 		return errors.Wrap(e.reqCtx.Err(), "engine forcibly closed")
 	case <-done:
+		logger.Debug(ctx, "Result received", log.Error(resultErr))
 		return resultErr
 	}
 }
@@ -264,9 +269,15 @@ func (e *Engine) retryUntilAck(ctx context.Context, req Request) (sent bool, err
 func (e *Engine) NotifyResult(msgID int64, b *bin.Buffer) error {
 	e.mux.Lock()
 	fn, ok := e.rpc[msgID]
+	pending := len(e.rpc)
 	e.mux.Unlock()
 	if !ok {
-		e.log.Warn(context.Background(), "rpc callback not set", log.Int64("msg_id", msgID))
+		// Result arrived but no caller is waiting for it: the request likely
+		// already timed out, was dropped, or the connection was replaced.
+		e.log.Warn(context.Background(), "rpc callback not set (result for unknown/expired request)",
+			log.Int64("msg_id", msgID),
+			log.Int("pending", pending),
+		)
 		return nil
 	}
 

--- a/telegram/connect.go
+++ b/telegram/connect.go
@@ -114,6 +114,7 @@ func (c *Client) reconnectUntilClosed(ctx context.Context) error {
 	return backoff.RetryNotify(func() error {
 		if err := c.runUntilRestart(ctx); err != nil {
 			if c.isPermanentError(err) {
+				c.log.Warn(ctx, "Permanent connection error, will not reconnect", log.Error(err))
 				return backoff.Permanent(err)
 			}
 			return err
@@ -129,6 +130,7 @@ func (c *Client) reconnectUntilClosed(ctx context.Context) error {
 		c.handlePrimaryConnDead(err)
 		c.replaceConn(c.createPrimaryConn(nil))
 		c.connMux.Unlock()
+		c.log.Debug(context.Background(), "Primary connection replaced after restart")
 	})
 }
 

--- a/telegram/internal/manager/conn.go
+++ b/telegram/internal/manager/conn.go
@@ -61,7 +61,7 @@ type Conn struct {
 	// Wrappers for external world, like logs or PRNG.
 	// Should be immutable.
 	clock clock.Clock // immutable
-	log   log.Helper // immutable
+	log   log.Helper  // immutable
 
 	// Handler passed by client.
 	handler Handler // immutable
@@ -179,13 +179,32 @@ func (c *Conn) Run(ctx context.Context) (err error) {
 }
 
 func (c *Conn) waitSession(ctx context.Context) error {
+	// Fast path: config already available, do not log.
+	select {
+	case <-c.gotConfig.Ready():
+		return nil
+	default:
+	}
+
+	// Connection not ready yet. A request blocked here while updates keep
+	// flowing means the connection's read loop is alive but init
+	// (initConnection/help.getConfig) has not completed — the exact shape of
+	// "can receive updates but cannot issue requests".
+	start := c.clock.Now()
+	c.log.Debug(ctx, "Invoke waiting for connection to become ready")
 	select {
 	// Connection is considered ready only after mode-specific init succeeded.
 	case <-c.gotConfig.Ready():
+		c.log.Debug(ctx, "Connection became ready", log.Duration("waited", c.clock.Now().Sub(start)))
 		return nil
 	case <-c.dead.Ready():
+		c.log.Debug(ctx, "Connection died while waiting for readiness", log.Duration("waited", c.clock.Now().Sub(start)))
 		return pool.ErrConnDead
 	case <-ctx.Done():
+		c.log.Debug(ctx, "Context done while waiting for connection readiness",
+			log.Duration("waited", c.clock.Now().Sub(start)),
+			log.Error(ctx.Err()),
+		)
 		return ctx.Err()
 	}
 }
@@ -383,6 +402,7 @@ func (c *Conn) init(ctx context.Context) error {
 	c.cfg = cfg
 	c.mux.Unlock()
 
+	c.log.Debug(ctx, "Connection initialized, ready to invoke", log.Int("this_dc", cfg.ThisDC))
 	c.gotConfig.Signal()
 	err := c.flushPendingSession()
 	return err

--- a/telegram/internal/manager/conn_pfs_test.go
+++ b/telegram/internal/manager/conn_pfs_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/gotd/log"
 	"github.com/gotd/td/bin"
+	"github.com/gotd/td/clock"
 	"github.com/gotd/td/mtproto"
 	"github.com/gotd/td/tdsync"
 	"github.com/gotd/td/tg"
@@ -116,6 +117,8 @@ func TestConnOnSessionDeferredQueue(t *testing.T) {
 func TestConnWaitSessionRequiresConfig(t *testing.T) {
 	a := require.New(t)
 	c := &Conn{
+		clock:       clock.System,
+		log:         log.For(log.Nop),
 		sessionInit: tdsync.NewReady(),
 		gotConfig:   tdsync.NewReady(),
 		dead:        tdsync.NewReady(),

--- a/telegram/invoke.go
+++ b/telegram/invoke.go
@@ -90,6 +90,7 @@ func (c *Client) invokeDirect(ctx context.Context, input bin.Encoder, output bin
 // invokeConn waits until the reconnection loop replaces the connection and
 // retries the request on it, see https://github.com/gotd/td/issues/1030.
 func (c *Client) invokeConn(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
+	attempt := 0
 	for {
 		c.connMux.Lock()
 		conn := c.conn
@@ -105,8 +106,10 @@ func (c *Client) invokeConn(ctx context.Context, input bin.Encoder, output bin.D
 		if c.ctx != nil {
 			clientDone = c.ctx.Done()
 		}
+		attempt++
 		c.log.Debug(ctx, "Primary connection is dead, waiting for new connection to retry",
 			log.Error(err),
+			log.Int("attempt", attempt),
 		)
 		select {
 		case <-ctx.Done():
@@ -115,6 +118,7 @@ func (c *Client) invokeConn(ctx context.Context, input bin.Encoder, output bin.D
 			// Client is closed, no reconnection will happen.
 			return errors.Wrap(c.ctx.Err(), "client closed")
 		case <-connChanged:
+			c.log.Debug(ctx, "Primary connection replaced, retrying request", log.Int("attempt", attempt))
 		}
 	}
 }


### PR DESCRIPTION
## Problem

After some time — probably after a reconnect (uncertain) — the client ends up in a state where it can **only receive updates** and can **no longer issue requests**. The read path stays alive (updates keep arriving) while the request path stalls indefinitely.

This is hard to diagnose because a request and an update travel completely different routes through the layers, so the stall can hide in any one of a handful of choke points. This PR adds targeted logging at each of them so the next occurrence pinpoints the layer.

## Where a request can silently stall

- **`mtproto.write` (send side)** — every send takes `exchangeLock.RLock()` then `conn.Send`. If key regeneration holds the exchange lock as a writer, or the TCP write side is a black hole, all sends (pings/acks/content) block here while the read loop keeps delivering updates.
- **`manager.Conn.waitSession`** — after a reconnect a fresh `manager.Conn` is built; `Invoke` blocks until `gotConfig` signals (init/`help.getConfig`). If the new conn's read loop is alive but init never completes, every `Invoke` blocks here — the exact shape of the bug.
- **`rpc.Engine.Do`** — acked-but-never-answered, or retry-limit; the terminal branch identifies which.
- **ack loop / read-loop ack enqueue** — `consumeMessage` dispatches the update *then* blocks on `ackSendChan`; a stuck ack loop stalls consumption while dispatched updates look fine.
- **ping loop** — the health-check that should catch a half-open connection and force a reconnect.

## Changes (logging only, no behavior change)

- **`mtproto/write.go`** — trace each send (msg_id, seq_no, type, size); warn when exchange-lock wait or transport send exceeds `slowWriteThreshold` (3s).
- **`mtproto/ping.go`** — log ping sent/acknowledged with elapsed; warn on ping failure.
- **`mtproto/read.go`** — warn on slow `ackSendChan` enqueue.
- **`mtproto/ack.go`** — msg_ids on ack failure, elapsed on success.
- **`rpc/engine.go`** — log which terminal branch resolves each `Do`; enrich "rpc callback not set" with pending count.
- **`telegram/internal/manager/conn.go`** — log when `Invoke` blocks on session readiness and how it resolves, plus init completion.
- **`telegram/invoke.go` / `telegram/connect.go`** — log reconnect-retry attempts, connection replacement, and permanent-error decisions.

All new logs are `Debug` (`Warn` for anomalies), so they are quiet in production and light up under a debug logger.

## What to watch for when reproducing

Run with a debug-level logger and look for:
- `Slow write…` / `Ping failed, connection considered dead`
- `Invoke waiting for connection to become ready` **without** a following `Connection became ready`
- repeated `rpc callback not set (result for unknown/expired request)`

## Testing

- `go build ./...` ✅
- `go test -race ./mtproto/... ./rpc/... ./telegram/internal/manager/...` ✅
- `go test ./telegram/` ✅