### PR TITLE
feat(dcs): MTProto-over-HTTP transport with http_wait long-polling

### DIFF
--- a/mtproto/conn.go
+++ b/mtproto/conn.go
@@ -241,6 +241,8 @@ func (c *Conn) Run(ctx context.Context, f func(ctx context.Context) error) error
 		g.Go("pingLoop", c.pingLoop)
 		g.Go("ackLoop", c.ackLoop)
 		g.Go("saltsLoop", c.saltLoop)
+		// Enable HTTP long-polling if the transport is HTTP; no-op otherwise.
+		c.startHTTPWait()
 		if c.pfs {
 			// Renewal loop requests reconnect before temp key expiry.
 			g.Go("tempKeyRenewal", c.tempKeyRenewalLoop)

--- a/mtproto/http_wait.go
+++ b/mtproto/http_wait.go
@@ -1,0 +1,72 @@
+package mtproto
+
+import (
+	"context"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/mt"
+)
+
+// httpWaiter is an optional capability of a transport.Conn that needs the
+// mtproto layer to drive HTTP long-polling.
+//
+// The MTProto HTTP transport is request/response: to receive server-pushed
+// messages while idle, the client must keep an http_wait service message in
+// flight so the server has a response to hold open. http_wait is encrypted with
+// the session key, so only the mtproto layer can produce it — the transport
+// cannot. A transport implementing this interface (see the telegram/dcs HTTP
+// resolver) is detected by Conn after the handshake and handed a factory that
+// yields freshly-encrypted http_wait frames.
+//
+// See https://core.telegram.org/mtproto/transports#http-transport.
+type httpWaiter interface {
+	// HTTPWaitParams reports the desired http_wait fields (milliseconds).
+	HTTPWaitParams() (maxDelay, waitAfter, maxWait int)
+	// StartHTTPWait starts the transport long-poll loop, using frame to build
+	// each encrypted http_wait message. It must be non-blocking.
+	StartHTTPWait(frame func(ctx context.Context) (*bin.Buffer, error))
+}
+
+// startHTTPWait enables http_wait long-polling if the transport requires it.
+// It is a no-op for transports that do not implement httpWaiter (TCP, WebSocket,
+// MTProxy), which receive server pushes over a full-duplex socket instead.
+func (c *Conn) startHTTPWait() {
+	w, ok := c.conn.(httpWaiter)
+	if !ok {
+		return
+	}
+	maxDelay, waitAfter, maxWait := w.HTTPWaitParams()
+	w.StartHTTPWait(func(ctx context.Context) (*bin.Buffer, error) {
+		return c.encodeHTTPWait(ctx, maxDelay, waitAfter, maxWait)
+	})
+}
+
+// encodeHTTPWait builds an encrypted http_wait service message into a fresh
+// buffer. It mirrors write, but does not send: the transport sends the frame as
+// a long-poll POST.
+func (c *Conn) encodeHTTPWait(ctx context.Context, maxDelay, waitAfter, maxWait int) (*bin.Buffer, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	msgID, seqNo := c.nextMsgSeq(false)
+
+	// Guard the auth key against concurrent key regeneration, like write does.
+	// During createAuthKey (exclusive Lock) this blocks, so no http_wait is sent
+	// with a stale key; any long-poll started earlier delivers at most a -404,
+	// which the exchange layer swallows (continue-on-ProtocolErr).
+	c.exchangeLock.RLock()
+	defer c.exchangeLock.RUnlock()
+
+	b := &bin.Buffer{}
+	if err := c.newEncryptedMessage(msgID, seqNo, &mt.HTTPWaitRequest{
+		MaxDelay:  maxDelay,
+		WaitAfter: waitAfter,
+		MaxWait:   maxWait,
+	}, b); err != nil {
+		return nil, errors.Wrap(err, "encode http_wait")
+	}
+	return b, nil
+}

--- a/mtproto/http_wait_test.go
+++ b/mtproto/http_wait_test.go
@@ -1,0 +1,74 @@
+package mtproto
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/crypto"
+	"github.com/gotd/td/mt"
+)
+
+// fakeHTTPWaiter is a transport.Conn that advertises the http_wait capability.
+type fakeHTTPWaiter struct {
+	maxDelay, waitAfter, maxWait int
+
+	paramsCalled bool
+	frame        func(ctx context.Context) (*bin.Buffer, error)
+}
+
+func (f *fakeHTTPWaiter) Send(context.Context, *bin.Buffer) error { return nil }
+func (f *fakeHTTPWaiter) Recv(context.Context, *bin.Buffer) error { return nil }
+func (f *fakeHTTPWaiter) Close() error                            { return nil }
+
+func (f *fakeHTTPWaiter) HTTPWaitParams() (maxDelay, waitAfter, maxWait int) {
+	f.paramsCalled = true
+	return f.maxDelay, f.waitAfter, f.maxWait
+}
+
+func (f *fakeHTTPWaiter) StartHTTPWait(frame func(ctx context.Context) (*bin.Buffer, error)) {
+	f.frame = frame
+}
+
+// plainConn is a transport.Conn without the http_wait capability.
+type plainConn struct{}
+
+func (plainConn) Send(context.Context, *bin.Buffer) error { return nil }
+func (plainConn) Recv(context.Context, *bin.Buffer) error { return nil }
+func (plainConn) Close() error                            { return nil }
+
+func TestConn_startHTTPWait(t *testing.T) {
+	a := require.New(t)
+	c := newTestClient(func(int64, int32, bin.Encoder) (bin.Encoder, error) { return nil, nil })
+
+	fake := &fakeHTTPWaiter{maxDelay: 1, waitAfter: 2, maxWait: 25000}
+	c.conn = fake
+
+	c.startHTTPWait()
+
+	a.True(fake.paramsCalled, "HTTPWaitParams must be consulted")
+	a.NotNil(fake.frame, "StartHTTPWait must receive a frame factory")
+
+	// The factory must produce a valid encrypted http_wait carrying the params.
+	buf, err := fake.frame(context.Background())
+	a.NoError(err)
+	a.NotEmpty(buf.Buf)
+
+	// Decrypt server-side and decode the inner http_wait to verify the fields.
+	msg, err := crypto.NewServerCipher(c.rand).DecryptFromBuffer(c.authKey, buf)
+	a.NoError(err)
+	var wait mt.HTTPWaitRequest
+	a.NoError(wait.Decode(&bin.Buffer{Buf: msg.Data()}))
+	a.Equal(1, wait.MaxDelay)
+	a.Equal(2, wait.WaitAfter)
+	a.Equal(25000, wait.MaxWait)
+}
+
+func TestConn_startHTTPWait_NonHTTPNoop(t *testing.T) {
+	c := newTestClient(func(int64, int32, bin.Encoder) (bin.Encoder, error) { return nil, nil })
+	c.conn = plainConn{}
+	// A non-HTTP transport must not be driven; this must not panic.
+	c.startHTTPWait()
+}

--- a/telegram/dcs/http.go
+++ b/telegram/dcs/http.go
@@ -1,0 +1,414 @@
+package dcs
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"net/http"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/go-faster/errors"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/proto/codec"
+	"github.com/gotd/td/tg"
+	"github.com/gotd/td/transport"
+)
+
+const (
+	// defaultHTTPMaxWait is the default http_wait max_wait (ms): the server holds
+	// the long-poll response open up to this long. Matches the MTProto default.
+	defaultHTTPMaxWait = 25000
+	// httpClientTimeoutMargin is added on top of max_wait for the HTTP client
+	// timeout so a full-length long-poll response is not cut off.
+	httpClientTimeoutMargin = 5 * time.Second
+	// httpWaitRetryInterval throttles the poll loop when a wait frame cannot be
+	// built (e.g. during key exchange) or a POST fails, avoiding a busy loop.
+	httpWaitRetryInterval = 500 * time.Millisecond
+	// httpInboxSize buffers response frames until Recv consumes them.
+	httpInboxSize = 32
+	// httpMaxConnsPerHost bounds concurrent connections of the default client to
+	// a single DC, so a burst of sends cannot exhaust file descriptors.
+	httpMaxConnsPerHost = 16
+)
+
+// recvResult is a decoded response delivered to Recv: either a frame or a
+// transport-level protocol error (e.g. auth_key_not_found).
+type recvResult struct {
+	data []byte
+	err  error
+}
+
+// httpConn implements transport.Conn over the MTProto HTTP transport.
+//
+// See https://core.telegram.org/mtproto/transports#http-transport.
+//
+// MTProto over HTTP is request/response: the server can only deliver messages
+// as the body of a response to a client POST. Send posts one raw MTProto frame
+// (framing is done by HTTP Content-Length, there is no codec tag) and the
+// response body — the messages the server had queued for the session — is
+// delivered to Recv through inbox. Send is non-blocking: the POST and its
+// (possibly long-polling) response are handled on a separate goroutine so a 25s
+// http_wait long-poll never stalls the mtproto write path.
+type httpConn struct {
+	client *http.Client
+	// urls holds one /api endpoint per candidate DC address. Requests use the
+	// current index; a failed POST rotates to the next candidate.
+	urls   []string
+	urlIdx atomic.Uint32
+
+	// inbox buffers responses (frames or protocol errors) until Recv consumes
+	// them.
+	inbox chan recvResult
+
+	// http_wait parameters in milliseconds, reported via HTTPWaitParams and used
+	// by the mtproto layer to build http_wait messages.
+	maxDelay  int
+	waitAfter int
+	maxWait   int
+
+	ctx       context.Context
+	cancel    context.CancelFunc
+	startOnce sync.Once
+	closeOnce sync.Once
+}
+
+func newHTTPConn(client *http.Client, urls []string, maxDelay, waitAfter, maxWait int) *httpConn {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &httpConn{
+		client:    client,
+		urls:      urls,
+		inbox:     make(chan recvResult, httpInboxSize),
+		maxDelay:  maxDelay,
+		waitAfter: waitAfter,
+		maxWait:   maxWait,
+		ctx:       ctx,
+		cancel:    cancel,
+	}
+}
+
+var _ transport.Conn = (*httpConn)(nil)
+
+// Send posts a single MTProto frame. It is non-blocking: the POST and response
+// are handled on a separate goroutine, so a long-poll response never stalls the
+// caller. Delivery reliability is provided by the mtproto rpc engine
+// (acks/retransmits) and liveness by the ping loop; a failed POST is therefore
+// dropped here and recovered upstream.
+func (c *httpConn) Send(ctx context.Context, b *bin.Buffer) error {
+	select {
+	case <-c.ctx.Done():
+		return errors.Wrap(net.ErrClosed, "send")
+	default:
+	}
+
+	// b.Buf is reused by the caller once Send returns; copy before handing it to
+	// the POST goroutine.
+	frame := make([]byte, len(b.Buf))
+	copy(frame, b.Buf)
+	// One goroutine per send: bounded in practice by the mtproto rpc engine's
+	// in-flight window and by the client's MaxConnsPerHost (which the goroutines
+	// block on). All are cancelled on Close via c.ctx.
+	go func() { _, _ = c.roundtrip(frame) }()
+	return nil
+}
+
+// Recv blocks until an incoming frame or a transport-level protocol error is
+// available.
+func (c *httpConn) Recv(ctx context.Context, b *bin.Buffer) error {
+	select {
+	case r := <-c.inbox:
+		if r.err != nil {
+			return r.err
+		}
+		b.Buf = append(b.Buf[:0], r.data...)
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-c.ctx.Done():
+		return errors.Wrap(net.ErrClosed, "recv")
+	}
+}
+
+// Close releases the connection and cancels in-flight requests.
+func (c *httpConn) Close() error {
+	c.closeOnce.Do(c.cancel)
+	return nil
+}
+
+// roundtrip posts one frame and delivers the response to inbox. It reports
+// whether anything was delivered (a frame or a protocol error) and returns an
+// error only for transport-level failures (POST error, non-200), which callers
+// use to back off.
+func (c *httpConn) roundtrip(frame []byte) (delivered bool, _ error) {
+	url := c.urls[c.urlIndex()]
+	req, err := http.NewRequestWithContext(c.ctx, http.MethodPost, url, bytes.NewReader(frame))
+	if err != nil {
+		return false, errors.Wrap(err, "build request")
+	}
+	req.Header.Set("Content-Type", "application/octet-stream")
+
+	resp, err := c.client.Do(req)
+	if err != nil {
+		c.rotateURL() // fail over to the next candidate address
+		return false, errors.Wrap(err, "do request")
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return false, errors.Errorf("unexpected status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return false, errors.Wrap(err, "read body")
+	}
+	switch {
+	case len(body) == 0:
+		// Empty body is a valid "dummy" long-poll response (max_wait elapsed with
+		// no messages); nothing to deliver.
+		return false, nil
+	case len(body) == bin.Word:
+		// A 4-byte body is a transport-level protocol error (e.g. -404 auth key
+		// not found), not an encrypted message. The TCP codecs surface it via
+		// checkProtocolError; do the same so the read loop can react (e.g.
+		// regenerate the auth key) instead of feeding garbage to the decrypter.
+		code := int32(binary.LittleEndian.Uint32(body))
+		c.deliver(recvResult{err: &codec.ProtocolErr{Code: -code}})
+		return true, nil
+	default:
+		c.deliver(recvResult{data: body})
+		return true, nil
+	}
+}
+
+// urlIndex returns the current candidate index. The modulo is taken on the
+// unsigned counter so the index stays in range even if the counter wraps.
+func (c *httpConn) urlIndex() int {
+	return int(c.urlIdx.Load() % uint32(len(c.urls)))
+}
+
+func (c *httpConn) deliver(r recvResult) {
+	select {
+	case c.inbox <- r:
+	case <-c.ctx.Done():
+	}
+}
+
+// rotateURL advances to the next candidate address after a failed POST. Failover
+// is best-effort: a burst of concurrent failures may advance the index by more
+// than one, but the poll loop's round-robin still reaches every candidate.
+func (c *httpConn) rotateURL() {
+	if len(c.urls) > 1 {
+		c.urlIdx.Add(1)
+	}
+}
+
+// HTTPWaitParams reports the http_wait fields (milliseconds) the transport wants
+// the mtproto layer to use. It is part of the mtproto HTTP long-poll capability.
+func (c *httpConn) HTTPWaitParams() (maxDelay, waitAfter, maxWait int) {
+	return c.maxDelay, c.waitAfter, c.maxWait
+}
+
+// StartHTTPWait starts the long-poll loop. frame yields a freshly-encrypted
+// http_wait service message — only the mtproto layer can encrypt it. The loop
+// keeps exactly one long-poll POST outstanding, re-issuing it as soon as the
+// previous response arrives, to minimize update latency. It is safe to call at
+// most once; further calls are no-ops.
+//
+// The loop runs in a goroutine whose lifetime is bound solely to Close: it is
+// not part of the mtproto Run errgroup, so the connection must be closed to stop
+// it (Conn.handleClose does this on teardown).
+func (c *httpConn) StartHTTPWait(frame func(ctx context.Context) (*bin.Buffer, error)) {
+	c.startOnce.Do(func() {
+		go c.pollLoop(frame)
+	})
+}
+
+func (c *httpConn) pollLoop(frame func(ctx context.Context) (*bin.Buffer, error)) {
+	// A conforming server holds an empty response until max_wait; a response that
+	// comes back much sooner than this signals a middlebox not honoring the
+	// long-poll, and must be throttled to avoid a request storm.
+	fastEmpty := time.Duration(c.maxWait) * time.Millisecond / 2
+
+	for {
+		if c.ctx.Err() != nil {
+			return
+		}
+		b, err := frame(c.ctx)
+		if err != nil {
+			// Wait frame cannot be built (e.g. key exchange in progress) or the
+			// connection is closing. Back off to avoid a hot loop.
+			if !c.sleep(httpWaitRetryInterval) {
+				return
+			}
+			continue
+		}
+		// Synchronous: blocks up to max_wait, then immediately loops to re-issue
+		// the next http_wait (low update latency, one poll outstanding).
+		start := time.Now()
+		delivered, err := c.roundtrip(b.Buf)
+		switch {
+		case err != nil:
+			// POST failed; back off instead of hammering a dead connection. The
+			// ping loop ultimately detects and tears down a dead connection.
+			if !c.sleep(httpWaitRetryInterval) {
+				return
+			}
+		case !delivered && time.Since(start) < fastEmpty:
+			// Instant empty 200 from a non-conforming middlebox: throttle.
+			if !c.sleep(httpWaitRetryInterval) {
+				return
+			}
+		}
+	}
+}
+
+// sleep waits for d, returning false if the connection was closed while waiting.
+func (c *httpConn) sleep(d time.Duration) bool {
+	select {
+	case <-c.ctx.Done():
+		return false
+	case <-time.After(d):
+		return true
+	}
+}
+
+var _ Resolver = httpResolver{}
+
+type httpResolver struct {
+	client     *http.Client
+	scheme     string
+	port       int
+	preferIPv6 bool
+	maxDelay   int
+	waitAfter  int
+	maxWait    int
+	// startIdx rotates the preferred candidate across successive Primary calls
+	// (i.e. across reconnects), so a dead first address does not trap the client.
+	startIdx *atomic.Uint32
+}
+
+func (r httpResolver) urls(candidates []tg.DCOption) []string {
+	// Rotate the starting candidate per call for cross-reconnect failover. Add(1)-1
+	// makes the first call start at index 0 (the highest-priority DC); the modulo
+	// is taken on the unsigned counter to stay in range on wrap.
+	off := int((r.startIdx.Add(1) - 1) % uint32(len(candidates)))
+	urls := make([]string, len(candidates))
+	for i := range candidates {
+		dc := candidates[(off+i)%len(candidates)]
+		addr := net.JoinHostPort(dc.IPAddress, strconv.Itoa(r.port))
+		urls[i] = r.scheme + "://" + addr + "/api"
+	}
+	return urls
+}
+
+func (r httpResolver) Primary(ctx context.Context, dc int, list List) (transport.Conn, error) {
+	candidates := FindPrimaryDCs(list.Options, dc, r.preferIPv6)
+	// The HTTP transport cannot speak to TCP-obfuscated-only DCs.
+	n := 0
+	for _, x := range candidates {
+		if !x.TCPObfuscatedOnly {
+			candidates[n] = x
+			n++
+		}
+	}
+	candidates = candidates[:n]
+	if len(candidates) == 0 {
+		return nil, errors.Errorf("no addresses for DC %d", dc)
+	}
+	return newHTTPConn(r.client, r.urls(candidates), r.maxDelay, r.waitAfter, r.maxWait), nil
+}
+
+func (r httpResolver) MediaOnly(ctx context.Context, dc int, list List) (transport.Conn, error) {
+	return nil, errors.Errorf("can't resolve %d: MediaOnly is unsupported", dc)
+}
+
+func (r httpResolver) CDN(ctx context.Context, dc int, list List) (transport.Conn, error) {
+	return nil, errors.Errorf("can't resolve %d: CDN is unsupported", dc)
+}
+
+// HTTPOptions is HTTP resolver creation options.
+type HTTPOptions struct {
+	// Client is the HTTP client used for POST requests. If nil, a client with a
+	// bounded transport and a timeout derived from MaxWait is used. A custom
+	// client's timeout must exceed MaxWait, otherwise long-poll responses are cut
+	// off. For Scheme "https" a custom client with an appropriate tls.Config
+	// (SNI/certificates for the DC) is required.
+	Client *http.Client
+	// Scheme is "http" (default) or "https".
+	//
+	// Note: https support is experimental. Connecting over https to a bare DC IP
+	// needs a custom Client whose tls.Config matches the DC certificate; the
+	// default client will fail TLS verification.
+	Scheme string
+	// Port overrides the transport port. Defaults to 80 for http and 443 for
+	// https.
+	//
+	// The HTTP transport uses this fixed port for every DC and intentionally
+	// ignores tg.DCOption.Port (which is the TCP MTProto port), per the MTProto
+	// HTTP transport specification.
+	Port int
+	// PreferIPv6 gives IPv6 DCs higher precedence.
+	// Default is to prefer IPv4 DCs over IPv6.
+	PreferIPv6 bool
+	// MaxDelay, WaitAfter and MaxWait are the http_wait fields in milliseconds.
+	// Defaults: 0, 0, 25000.
+	//
+	// See https://core.telegram.org/mtproto/service_messages.
+	MaxDelay  int
+	WaitAfter int
+	MaxWait   int
+}
+
+func (o *HTTPOptions) setDefaults() {
+	if o.Scheme == "" {
+		o.Scheme = "http"
+	}
+	if o.Port == 0 {
+		if o.Scheme == "https" {
+			o.Port = 443
+		} else {
+			o.Port = 80
+		}
+	}
+	if o.MaxWait == 0 {
+		o.MaxWait = defaultHTTPMaxWait
+	}
+	if o.Client == nil {
+		o.Client = &http.Client{
+			Timeout: time.Duration(o.MaxWait)*time.Millisecond + httpClientTimeoutMargin,
+			Transport: &http.Transport{
+				Proxy:               http.ProxyFromEnvironment,
+				MaxConnsPerHost:     httpMaxConnsPerHost,
+				MaxIdleConnsPerHost: httpMaxConnsPerHost,
+			},
+		}
+	}
+}
+
+// HTTP creates an MTProto-over-HTTP DC resolver with http_wait long-polling.
+//
+// It suits environments where a raw persistent MTProto TCP socket cannot be
+// held but HTTP POST to the DC is possible. Updates are delivered via http_wait
+// long-polling, so their latency is bounded by the round-trip rather than being
+// instantaneous. MediaOnly and CDN DCs are not supported.
+//
+// See https://core.telegram.org/mtproto/transports#http-transport.
+func HTTP(opts HTTPOptions) Resolver {
+	opts.setDefaults()
+	return httpResolver{
+		client:     opts.Client,
+		scheme:     opts.Scheme,
+		port:       opts.Port,
+		preferIPv6: opts.PreferIPv6,
+		maxDelay:   opts.MaxDelay,
+		waitAfter:  opts.WaitAfter,
+		maxWait:    opts.MaxWait,
+		startIdx:   new(atomic.Uint32),
+	}
+}

--- a/telegram/dcs/http_internal_test.go
+++ b/telegram/dcs/http_internal_test.go
@@ -1,0 +1,46 @@
+package dcs
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+)
+
+// The poll loop must fail over past a dead candidate URL to a working one.
+func TestHTTPConn_FailoverRotatesPastDeadURL(t *testing.T) {
+	a := require.New(t)
+
+	// A closed server yields a guaranteed connection-refused address.
+	deadSrv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	deadURL := deadSrv.URL + "/api"
+	deadSrv.Close()
+
+	payload := []byte("alive")
+	alive := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write(payload)
+	}))
+	defer alive.Close()
+
+	client := &http.Client{Timeout: 2 * time.Second}
+	// Dead address first: the loop must rotate to the working one.
+	conn := newHTTPConn(client, []string{deadURL, alive.URL + "/api"}, 0, 0, defaultHTTPMaxWait)
+	defer func() { _ = conn.Close() }()
+
+	conn.StartHTTPWait(func(context.Context) (*bin.Buffer, error) {
+		return &bin.Buffer{Buf: []byte("wait")}, nil
+	})
+
+	recvCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	var b bin.Buffer
+	a.NoError(conn.Recv(recvCtx, &b))
+	a.Equal(payload, b.Buf)
+}

--- a/telegram/dcs/http_test.go
+++ b/telegram/dcs/http_test.go
@@ -1,0 +1,319 @@
+package dcs_test
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/binary"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/go-faster/errors"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/proto/codec"
+	"github.com/gotd/td/telegram/dcs"
+	"github.com/gotd/td/tg"
+)
+
+// httpWaiter mirrors the optional capability the mtproto layer type-asserts on
+// the transport to drive http_wait long-polling.
+type httpWaiter interface {
+	HTTPWaitParams() (maxDelay, waitAfter, maxWait int)
+	StartHTTPWait(frame func(ctx context.Context) (*bin.Buffer, error))
+}
+
+// listFor builds a DC list with a single primary DC pointing at the given test
+// server, and returns the resolver options aimed at it.
+func listFor(t *testing.T, srv *httptest.Server) (dcs.List, dcs.HTTPOptions) {
+	t.Helper()
+	u, err := url.Parse(srv.URL)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(u.Port())
+	require.NoError(t, err)
+
+	list := dcs.List{Options: []tg.DCOption{{
+		ID:        2,
+		IPAddress: u.Hostname(),
+		Port:      port,
+	}}}
+	return list, dcs.HTTPOptions{Scheme: u.Scheme, Port: port}
+}
+
+func TestHTTP_SendRecv(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		a.Equal(http.MethodPost, r.Method)
+		a.Equal("/api", r.URL.Path)
+		body, err := io.ReadAll(r.Body)
+		a.NoError(err)
+		_, _ = w.Write(body) // echo
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	data, err := io.ReadAll(io.LimitReader(rand.Reader, 256))
+	a.NoError(err)
+	a.NoError(conn.Send(ctx, &bin.Buffer{Buf: data}))
+
+	var b bin.Buffer
+	a.NoError(conn.Recv(ctx, &b))
+	a.Equal(data, b.Buf)
+}
+
+func TestHTTP_EmptyResponseNoFrame(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK) // empty body: "dummy" long-poll response
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	a.NoError(conn.Send(ctx, &bin.Buffer{Buf: []byte{1, 2, 3}}))
+
+	recvCtx, cancel := context.WithTimeout(ctx, 200*time.Millisecond)
+	defer cancel()
+	var b bin.Buffer
+	err = conn.Recv(recvCtx, &b)
+	a.ErrorIs(err, context.DeadlineExceeded, "empty response must not produce a frame")
+}
+
+func TestHTTP_WaitParams(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	defer srv.Close()
+	list, opts := listFor(t, srv)
+
+	// Defaults.
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+	w, ok := conn.(httpWaiter)
+	a.True(ok, "http transport must expose the http_wait capability")
+	md, wa, mw := w.HTTPWaitParams()
+	a.Equal(0, md)
+	a.Equal(0, wa)
+	a.Equal(25000, mw)
+
+	// Custom.
+	opts.MaxDelay, opts.WaitAfter, opts.MaxWait = 5, 10, 15000
+	conn2, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn2.Close() }()
+	md, wa, mw = conn2.(httpWaiter).HTTPWaitParams()
+	a.Equal(5, md)
+	a.Equal(10, wa)
+	a.Equal(15000, mw)
+}
+
+func TestHTTP_StartHTTPWaitDeliversServerData(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	const waitFrame = "http-wait-frame"
+	payload := []byte("server-pushed-update")
+
+	var gotWaitFrame atomic.Bool
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		if string(body) == waitFrame {
+			gotWaitFrame.Store(true)
+		}
+		_, _ = w.Write(payload)
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	var calls atomic.Int64
+	conn.(httpWaiter).StartHTTPWait(func(context.Context) (*bin.Buffer, error) {
+		calls.Add(1)
+		return &bin.Buffer{Buf: []byte(waitFrame)}, nil
+	})
+
+	// The long-poll loop must deliver server data with no application Send.
+	recvCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+	var b bin.Buffer
+	a.NoError(conn.Recv(recvCtx, &b))
+	a.Equal(payload, b.Buf)
+	a.True(gotWaitFrame.Load(), "server must have received the http_wait frame")
+	a.Positive(calls.Load(), "frame factory must be invoked by the poll loop")
+}
+
+func TestHTTP_UnsupportedMediaCDN(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	list := dcs.List{Options: []tg.DCOption{{ID: 2, IPAddress: "127.0.0.1"}}}
+	res := dcs.HTTP(dcs.HTTPOptions{})
+
+	_, err := res.MediaOnly(ctx, 2, list)
+	a.Error(err)
+	_, err = res.CDN(ctx, 2, list)
+	a.Error(err)
+}
+
+func TestHTTP_NoAddresses(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+	_, err := dcs.HTTP(dcs.HTTPOptions{}).Primary(ctx, 2, dcs.List{})
+	a.Error(err)
+}
+
+// A 4-byte response body is a transport-level protocol error (e.g. -404 auth key
+// not found), not an encrypted message, and must surface from Recv as a
+// codec.ProtocolErr so the read loop can react.
+func TestHTTP_TransportProtocolError(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		code := int32(-codec.CodeAuthKeyNotFound) // -404
+		var buf [4]byte
+		binary.LittleEndian.PutUint32(buf[:], uint32(code))
+		_, _ = w.Write(buf[:])
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	a.NoError(conn.Send(ctx, &bin.Buffer{Buf: []byte{1, 2, 3, 4, 5}}))
+
+	var b bin.Buffer
+	err = conn.Recv(ctx, &b)
+	var pe *codec.ProtocolErr
+	a.True(errors.As(err, &pe), "4-byte body must surface as ProtocolErr, got %v", err)
+	a.Equal(int32(codec.CodeAuthKeyNotFound), pe.Code)
+}
+
+func TestHTTP_CloseDuringInflight(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	release := make(chan struct{})
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+		<-release // hold the response until the test releases it
+	}))
+	// LIFO: release first (unblock handler), then Close (waits for handlers).
+	defer srv.Close()
+	defer close(release)
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+
+	a.NoError(conn.Send(ctx, &bin.Buffer{Buf: []byte{1, 2, 3}}))
+	a.NoError(conn.Close())
+
+	// Recv after Close returns promptly with an error, not a hang.
+	recvCtx, cancel := context.WithTimeout(ctx, time.Second)
+	defer cancel()
+	var b bin.Buffer
+	a.Error(conn.Recv(recvCtx, &b))
+	// Send after Close is rejected.
+	a.Error(conn.Send(ctx, &bin.Buffer{Buf: []byte{1}}))
+}
+
+// Run with -race: many concurrent Send plus the poll loop must not corrupt the
+// inbox or race on the URL index.
+func TestHTTP_ConcurrentSendRace(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.ReadAll(r.Body)
+		_, _ = w.Write([]byte("ok"))
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	conn.(httpWaiter).StartHTTPWait(func(context.Context) (*bin.Buffer, error) {
+		return &bin.Buffer{Buf: []byte("wait")}, nil
+	})
+
+	drain := make(chan struct{})
+	go func() {
+		defer close(drain)
+		for i := 0; i < 30; i++ {
+			rctx, cancel := context.WithTimeout(ctx, 300*time.Millisecond)
+			var b bin.Buffer
+			_ = conn.Recv(rctx, &b)
+			cancel()
+		}
+	}()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_ = conn.Send(ctx, &bin.Buffer{Buf: []byte("x")})
+		}()
+	}
+	wg.Wait()
+	<-drain
+}
+
+// A middlebox returning an instant empty 200 (not honoring the long-poll) must
+// be throttled so the poll loop does not storm the DC with requests.
+func TestHTTP_ThrottlesInstantEmptyResponse(t *testing.T) {
+	a := require.New(t)
+	ctx := context.Background()
+
+	var reqs atomic.Int64
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reqs.Add(1)
+		_, _ = io.ReadAll(r.Body)
+		w.WriteHeader(http.StatusOK) // instant empty response
+	}))
+	defer srv.Close()
+
+	list, opts := listFor(t, srv)
+	conn, err := dcs.HTTP(opts).Primary(ctx, 2, list)
+	a.NoError(err)
+	defer func() { _ = conn.Close() }()
+
+	conn.(httpWaiter).StartHTTPWait(func(context.Context) (*bin.Buffer, error) {
+		return &bin.Buffer{Buf: []byte("wait")}, nil
+	})
+
+	time.Sleep(1200 * time.Millisecond)
+	n := reqs.Load()
+	// Throttled to ~one poll per httpWaitRetryInterval; without the throttle this
+	// would be thousands over the same window.
+	a.Positive(n, "poll loop should still send http_wait")
+	a.Less(n, int64(20), "instant empty responses must be throttled, got %d", n)
+}


### PR DESCRIPTION
## Summary

Implements the MTProto **HTTP transport** with `http_wait` long-polling — the one transport listed in the [MTProto transport docs](https://core.telegram.org/mtproto/transports#http-transport) that gotd does not yet provide, even though `mt.HTTPWaitRequest` is already generated.

Discussed first in #1817.

## What it adds

- **`dcs.HTTP(...)` resolver** (`telegram/dcs/http.go`) — a `transport.Conn` that carries MTProto frames as `POST /api` request bodies, framed by HTTP `Content-Length` (no codec tag, per spec). `Send` is non-blocking; responses arrive via `Recv`.
- **`http_wait` long-polling** (`mtproto/http_wait.go`) — the HTTP transport is request/response, so to receive server pushes while idle the client must keep an encrypted `http_wait` service message in flight, giving the server a response to hold open. The transport advertises this need through a small optional capability interface; `mtproto.Conn` detects it after the handshake and drives the loop. No `telegram.Options` change, and it is a no-op for full-duplex transports (TCP, WebSocket, MTProxy).

## Behavior notes

- 4-byte response bodies are surfaced from `Recv` as `codec.ProtocolErr` (e.g. `-404` auth key not found), so the existing read-loop recovery path works unchanged.
- Non-conforming middleboxes that return an instant empty `200` are throttled instead of hot-looping.
- `http_wait` frames are re-encrypted per poll and guarded by the same `exchangeLock` as `write`, so key regeneration cannot race a stale-key long-poll.
- HTTPS is supported but marked experimental; media/CDN DCs are not supported by this resolver.

## Tests

`go test -race ./telegram/dcs/... ./mtproto/...` covers send/recv, empty-response, wait-param defaults/overrides, server-push delivery, transport protocol error, close-during-inflight, concurrent-send race, URL failover, instant-empty throttle, and the mtproto `http_wait` encode path.

---

Opening as **draft** to gather maintainer feedback on the approach (per #1817) before polishing. Happy to adjust the capability-interface design, naming, or packaging.
