### PR TITLE
feat(telegram): allow overriding schema layer in initConnection

### DIFF
--- a/telegram/client.go
+++ b/telegram/client.go
@@ -84,6 +84,9 @@ type Client struct {
 	// Telegram device information.
 	device DeviceConfig // immutable
 
+	// Schema layer requested via invokeWithLayer.
+	layer int // immutable
+
 	// MTProto options.
 	opts mtproto.Options // immutable
 
@@ -196,6 +199,7 @@ func NewClient(appID int, appHash string, opt Options) *Client {
 		onConnectionState: opt.OnConnectionState,
 		clock:             opt.Clock,
 		device:            opt.Device,
+		layer:             opt.Layer,
 		migrationTimeout:  opt.MigrationTimeout,
 		noUpdatesMode:     opt.NoUpdates,
 		mw:                opt.Middlewares,

--- a/telegram/conn_builder.go
+++ b/telegram/conn_builder.go
@@ -108,6 +108,7 @@ func (c *Client) createConn(
 		opts, manager.ConnOptions{
 			DC:      s.DC,
 			Test:    c.testDC,
+			Layer:   c.layer,
 			Device:  c.device,
 			Handler: c.asHandler(),
 			Setup:   setup,

--- a/telegram/internal/manager/conn.go
+++ b/telegram/internal/manager/conn.go
@@ -50,6 +50,8 @@ type Conn struct {
 	// InitConnection parameters.
 	appID  int          // immutable
 	device DeviceConfig // immutable
+	// layer is the schema layer sent in invokeWithLayer.
+	layer int // immutable
 
 	// setup is callback which called after initConnection, but before ready signaling.
 	// This is necessary to transfer auth from previous connection to another DC.
@@ -231,7 +233,7 @@ func (c *Conn) Invoke(ctx context.Context, input bin.Encoder, output bin.Decoder
 	}
 	q := c.wrapRequest(noopDecoder{input})
 	req := c.wrapRequest(&tg.InvokeWithLayerRequest{
-		Layer: tg.Layer,
+		Layer: c.layer,
 		Query: q,
 	})
 	err := c.proto.Invoke(ctx, req, output)
@@ -273,7 +275,7 @@ func (c *Conn) invokeCDN(
 }
 func (c *Conn) invokeCDNWrapped(ctx context.Context, input bin.Encoder, output bin.Decoder) error {
 	req := &tg.InvokeWithLayerRequest{
-		Layer: tg.Layer,
+		Layer: c.layer,
 		Query: c.cdnInitRequest(noopDecoder{input}),
 	}
 	return c.proto.Invoke(ctx, req, output)
@@ -364,7 +366,7 @@ func (c *Conn) init(ctx context.Context) error {
 		Query:          c.wrapRequest(&tg.HelpGetConfigRequest{}),
 	})
 	req := c.wrapRequest(&tg.InvokeWithLayerRequest{
-		Layer: tg.Layer,
+		Layer: c.layer,
 		Query: q,
 	})
 

--- a/telegram/internal/manager/conn_cdn_test.go
+++ b/telegram/internal/manager/conn_cdn_test.go
@@ -42,6 +42,7 @@ func newTestConn(mode ConnMode, proto protoConn) *Conn {
 		dc:          203,
 		appID:       42,
 		device:      DeviceConfig{AppVersion: "test-app"},
+		layer:       tg.Layer,
 		proto:       proto,
 		clock:       clock.System,
 		log:         log.For(log.Nop),

--- a/telegram/internal/manager/conn_layer_test.go
+++ b/telegram/internal/manager/conn_layer_test.go
@@ -1,0 +1,53 @@
+package manager
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/clock"
+	"github.com/gotd/td/mtproto"
+	"github.com/gotd/td/tg"
+)
+
+func TestConnOptionsLayerDefault(t *testing.T) {
+	a := require.New(t)
+
+	opts := ConnOptions{}
+	opts.setDefaults(clock.System)
+	a.Equal(tg.Layer, opts.Layer)
+
+	opts = ConnOptions{Layer: 42}
+	opts.setDefaults(clock.System)
+	a.Equal(42, opts.Layer)
+}
+
+func TestConnInvokeUsesConfiguredLayer(t *testing.T) {
+	a := require.New(t)
+	p := &captureProto{}
+	c := newTestConn(ConnModeData, p)
+	c.layer = 42
+	c.gotConfig.Signal()
+
+	a.NoError(c.Invoke(context.Background(), &tg.HelpGetConfigRequest{}, &tg.Config{}))
+
+	outer, ok := p.lastInput.(*tg.InvokeWithoutUpdatesRequest)
+	a.True(ok)
+
+	withLayer, ok := outer.Query.(*tg.InvokeWithLayerRequest)
+	a.True(ok)
+	a.Equal(42, withLayer.Layer)
+}
+
+func TestCreateConnPropagatesLayer(t *testing.T) {
+	a := require.New(t)
+
+	conn := CreateConn(nil, ConnModeData, 42, mtproto.Options{Clock: clock.System}, ConnOptions{
+		Layer: 42,
+	})
+	a.Equal(42, conn.layer)
+
+	conn = CreateConn(nil, ConnModeData, 42, mtproto.Options{Clock: clock.System}, ConnOptions{})
+	a.Equal(tg.Layer, conn.layer)
+}

--- a/telegram/internal/manager/create.go
+++ b/telegram/internal/manager/create.go
@@ -18,8 +18,12 @@ type SetupCallback = func(ctx context.Context, invoker tg.Invoker) error
 
 // ConnOptions is a Telegram client connection options.
 type ConnOptions struct {
-	DC      int
-	Test    bool
+	DC   int
+	Test bool
+	// Layer is the schema layer sent in invokeWithLayer.
+	//
+	// If not provided, tg.Layer will be used.
+	Layer   int
 	Device  DeviceConfig
 	Handler Handler
 	Setup   SetupCallback
@@ -41,6 +45,9 @@ func defaultBackoff(c clock.Clock) func(ctx context.Context) backoff.BackOff {
 func (c *ConnOptions) setDefaults(connClock clock.Clock) {
 	if c.DC == 0 {
 		c.DC = 2
+	}
+	if c.Layer == 0 {
+		c.Layer = tg.Layer
 	}
 	// It's okay to use zero value Test.
 	c.Device.SetDefaults()
@@ -67,6 +74,7 @@ func CreateConn(
 		dc:          connOpts.DC,
 		appID:       appID,
 		device:      connOpts.Device,
+		layer:       connOpts.Layer,
 		clock:       opts.Clock,
 		handler:     connOpts.Handler,
 		sessionInit: tdsync.NewReady(),

--- a/telegram/options.go
+++ b/telegram/options.go
@@ -125,6 +125,14 @@ type Options struct {
 	// Will be sent with session creation request.
 	Device DeviceConfig
 
+	// Layer is the schema layer to request via invokeWithLayer.
+	//
+	// If not provided, tg.Layer will be used, i.e. the layer of the schema
+	// this package is generated from. Override it only if the server must be
+	// asked for an older layer; requests are still encoded using tg.Layer
+	// schema, so a mismatch may cause decoding errors.
+	Layer int
+
 	MessageID mtproto.MessageIDSource
 	Clock     clock.Clock
 
@@ -162,6 +170,9 @@ func (opt *Options) setDefaults() {
 	}
 	if opt.DCList.Zero() {
 		opt.DCList = dcs.Prod()
+	}
+	if opt.Layer == 0 {
+		opt.Layer = tg.Layer
 	}
 	// It's okay to use zero value AckBatchSize, mtproto.Options will set defaults.
 	// It's okay to use zero value AckInterval, mtproto.Options will set defaults.

--- a/telegram/options_test.go
+++ b/telegram/options_test.go
@@ -1,0 +1,26 @@
+package telegram
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/gotd/td/tg"
+)
+
+func TestOptionsLayer(t *testing.T) {
+	t.Run("Default", func(t *testing.T) {
+		opt := Options{}
+		opt.setDefaults()
+		require.Equal(t, tg.Layer, opt.Layer)
+	})
+	t.Run("Explicit", func(t *testing.T) {
+		opt := Options{Layer: 42}
+		opt.setDefaults()
+		require.Equal(t, 42, opt.Layer)
+	})
+	t.Run("Client", func(t *testing.T) {
+		require.Equal(t, 42, NewClient(1, "hash", Options{Layer: 42}).layer)
+		require.Equal(t, tg.Layer, NewClient(1, "hash", Options{}).layer)
+	})
+}

--- a/telegram/pool.go
+++ b/telegram/pool.go
@@ -147,6 +147,7 @@ func (c *Client) dc(
 			dialer, mode, c.appID,
 			options, manager.ConnOptions{
 				DC:      dcID,
+				Layer:   c.layer,
 				Device:  c.device,
 				Handler: handler,
 				Setup:   setup,


### PR DESCRIPTION
Add Options.Layer to configure the layer sent in invokeWithLayer instead of always using the tg.Layer constant.

The layer is threaded through Client and manager.ConnOptions down to Conn, covering the regular init flow, regular invokes and both CDN wrapped paths. Defaults to tg.Layer when unset, so behavior is unchanged for existing users.