### PR TITLE
fix(exchange): apply ExchangeTimeout to key exchange steps 5 and 7

### DIFF
--- a/exchange/client_flow.go
+++ b/exchange/client_flow.go
@@ -143,7 +143,10 @@ Loop:
 	}
 
 	// 5. Server responds with Server_DH_Params.
-	if err := c.conn.Recv(ctx, b); err != nil {
+	// tryRead applies the exchange timeout; a bare conn.Recv inherits the
+	// caller's context, which carries no deadline in PFS mode because connect
+	// scopes DialTimeout to the dial, leaving this read unbounded.
+	if err := c.tryRead(ctx, b); err != nil {
 		return ClientExchangeResult{}, errors.Wrap(err, "read ServerDHParams message")
 	}
 	c.log.Debug(ctx, "Received server ServerDHParams")
@@ -238,7 +241,8 @@ Loop:
 		authKey := big.NewInt(0).Exp(gA, bParam, dhPrime)
 
 		b.Reset()
-		if err := c.conn.Recv(ctx, b); err != nil {
+		// See the note at step 5: tryRead applies the exchange timeout.
+		if err := c.tryRead(ctx, b); err != nil {
 			return ClientExchangeResult{}, errors.Wrap(err, "read DhGen message")
 		}
 		c.log.Debug(ctx, "Received server DhGen")

--- a/exchange/client_flow_timeout_test.go
+++ b/exchange/client_flow_timeout_test.go
@@ -1,0 +1,149 @@
+package exchange
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zaptest"
+
+	"github.com/gotd/log/logzap"
+	"github.com/gotd/td/bin"
+	"github.com/gotd/td/testutil"
+	"github.com/gotd/td/transport"
+)
+
+// blackholeAfterNRecv wraps a transport.Conn so that Send behaves normally
+// but every Recv beyond the first allowed calls blocks until ctx is done
+// instead of returning data.
+//
+// This reproduces a server that answers the first key exchange steps and
+// then goes silent: it "accepts our writes" (Send always succeeds, exactly
+// like a real peer that received the client's data) yet never replies to
+// the next request, leaving a bare conn.Recv with no way to unblock other
+// than its context.
+type blackholeAfterNRecv struct {
+	transport.Conn
+	allowed int32
+	count   atomic.Int32
+}
+
+func (c *blackholeAfterNRecv) Recv(ctx context.Context, b *bin.Buffer) error {
+	if c.count.Add(1) <= c.allowed {
+		return c.Conn.Recv(ctx, b)
+	}
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+// TestClientExchangeRespectsTimeout pins ExchangeTimeout to the raw reads at
+// key exchange steps 5 and 7.
+//
+// Exchanger.WithTimeout documents itself as setting the deadline of "every
+// exchange request", and the server flow applies it to all three of its
+// reads. The client flow applies it to every write and to the step 2 read,
+// then reads steps 5 and 7 through a bare conn.Recv. transport.connection.Recv
+// derives its socket deadline solely from ctx.Deadline(), so those two reads
+// are unbounded whenever the caller's context carries no deadline -- which in
+// PFS mode is always, because mtproto.Conn.connect scopes DialTimeout to the
+// dial and hands the raw context to the exchange.
+//
+// The caller context here is deliberately context.Background(): the point is
+// that a context with no deadline of its own must still be bounded by the
+// configured ExchangeTimeout.
+//
+// Both sites are covered independently: allowing 1 reply through blackholes
+// the step 5 read (ServerDHParams), allowing 2 blackholes the step 7 read
+// (DhGen). A regression that reintroduces a bare conn.Recv at either site
+// fails its corresponding case.
+func TestClientExchangeRespectsTimeout(t *testing.T) {
+	tests := []struct {
+		name          string
+		allowed       int32
+		wantErrSubstr string
+	}{
+		{
+			name:          "step5 ServerDHParams read",
+			allowed:       1,
+			wantErrSubstr: "read ServerDHParams message",
+		},
+		{
+			name:          "step7 DhGen read",
+			allowed:       2,
+			wantErrSubstr: "read DhGen message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const dc = 2
+
+			log := zaptest.NewLogger(t)
+			privateKey := PrivateKey{RSA: testutil.RSAPrivateKey()}
+
+			i := transport.Intermediate
+			rawClient, server := i.Pipe()
+
+			// Real server side flow drives the replies allowed through. Once
+			// the client below stops draining the pipe, the server's own next
+			// Send blocks until t.Cleanup closes the connections; done is
+			// closed on return so cleanup can wait for the goroutine to
+			// actually exit instead of just unblocking it.
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				_, _ = NewExchanger(server, dc).
+					WithLogger(logzap.New(log.Named("server"))).
+					WithRand(testutil.Rand([]byte("exchange-timeout-test-server"))).
+					Server(privateKey).
+					Run(context.Background())
+			}()
+
+			t.Cleanup(func() {
+				_ = rawClient.Close()
+				_ = server.Close()
+				select {
+				case <-done:
+				case <-time.After(10 * time.Second):
+					t.Error("server goroutine did not exit after connections were closed")
+				}
+			})
+
+			client := &blackholeAfterNRecv{Conn: rawClient, allowed: tt.allowed}
+
+			// The timeout under test bounds the blackholed raw read; it must
+			// also comfortably cover the real RSA/DH driven reads that precede
+			// it, which are slow under -race on a throttled CI runner. The
+			// outer guard must in turn dwarf the real key exchange crypto that
+			// runs before the step 7 read (RSA pad/decrypt, PQ factorization
+			// and two 2048-bit DH modexps): that CPU bound work, not the read,
+			// is what a tight guard trips over under the race detector.
+			const (
+				exchangeTimeout = 1 * time.Second
+				hangGuard       = 30 * time.Second
+			)
+
+			e := NewExchanger(client, dc).
+				WithLogger(logzap.New(log.Named("client"))).
+				WithRand(testutil.Rand([]byte("exchange-timeout-test-client"))).
+				WithTimeout(exchangeTimeout).
+				Client([]PublicKey{privateKey.Public()})
+
+			result := make(chan error, 1)
+			go func() {
+				_, err := e.Run(context.Background())
+				result <- err
+			}()
+
+			select {
+			case err := <-result:
+				require.ErrorIs(t, err, context.DeadlineExceeded)
+				require.ErrorContains(t, err, tt.wantErrSubstr)
+			case <-time.After(hangGuard):
+				t.Fatal("exchange hung despite configured timeout")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What happens

A peer that completes the TCP handshake, answers key exchange steps 1-4, and then stops responding parks the client **forever**. No timeout fires, and cancelling the context has no effect.

Production goroutine dump (v0.159.0, PFS enabled), two goroutines parked 27 and 21 minutes:

```
internal/poll.runtime_pollWait
  net.(*conn).Read
    mtproxy/obfuscated2.(*Obfuscated2).Read
      proto/codec.readAbridged
        transport.(*connection).Recv
          exchange.ClientExchange.Run
```

There is no `unencryptedWriter` frame between `ClientExchange.Run` and `connection.Recv`, which localizes both to a direct `conn.Recv` call — steps 5 or 7 — and rules out step 2, which carries the `ExchangeTimeout` bound. One goroutine was the primary connection (`telegram.Client.Run`'s errgroup), the other a sub-DC pool connection (`pool` → `tdsync.Supervisor`). Both block their owners indefinitely: `telegram.Client.Run` never returns, and `pool.DC.Close` is `cancel()` + `grp.Wait()` with no timeout, so the deferred sub-connection teardown cannot finish either. The connection is never recreated.

The caller cancelled its run context every 55 seconds — thousands of times — with no effect, because cancellation cannot interrupt a parked read on a deadline-less socket.

## Why

`Exchanger.WithTimeout` documents itself as setting the deadline of "every exchange request" (`exchange/flow.go:62`), and `mtproto.Options.ExchangeTimeout` as the timeout of "every key exchange request" (`mtproto/options.go:50-51`). That bound is applied by `unencryptedWriter.tryRead` (`exchange/proto.go:44`).

The **server** flow uses it for all three of its reads (`server_flow.go:130`, `:166`, `:267`). The **client** flow uses it for every write and for the step 2 read (`client_flow.go:34`), then reads steps 5 and 7 through a bare `conn.Recv` (`client_flow.go:146`, `:241`). Those are the only two non-test `conn.Recv` calls in the module outside `tryRead` itself and the steady-state read loop in `mtproto/read.go`.

Below the exchange, `transport.(*connection).Recv` derives its socket deadline solely from `ctx.Deadline()` (`transport/connection.go:63`) and clears any previous one at `:60`. With no deadline it sets none, and `codec.Read` parks.

Nothing else can rescue the socket during this window: `handleClose` — the mechanism that closes the connection on context cancellation — is started at `mtproto/conn.go:227`, *after* `connect()` returns at `:221`. So during the key exchange there is neither a deadline nor a closer.

Likely cause of the original slip: `readUnencrypted` decodes into a `bin.Decoder`, while steps 5 and 7 need the raw buffer — so `conn.Recv` was reached for when `tryRead`, which reads raw *and* applies the timeout, was the right one of the two.

## Why PFS makes it fatal

`mtproto.Conn.connect` chooses its timeout policy by mode:

- **non-PFS**: `connectCtx` carries `DialTimeout` across dial *and* exchange (`connect.go:17-22`), so the bare reads inherit a deadline by accident and cannot park forever.
- **PFS**: `DialTimeout` is scoped to the dial alone and `connectPFS(ctx)` receives the caller's raw context (`connect.go:26-34`, `:47-48`).

Two conditions compose; remove either and the wedge disappears. The PFS reasoning is sound — temporary plus permanent key generation legitimately takes longer than a dial — so **this PR does not touch it**. It makes the documented per-read bound actually apply, after which both modes are bounded by the same mechanism and the PFS policy is harmless.

`EnablePFS` is opt-in and off by default, which is why this has gone unnoticed.

## The change

Two lines: `c.conn.Recv` → `c.tryRead` at both sites, using the package's existing unexported helper.

- No exported API change (verified: `go doc -all ./exchange` is identical before and after, 36 declarations).
- No new mechanism, option, goroutine or error value.
- Cannot break an `errors.Is` check: in the affected configuration no error was previously observable — the call hung.
- Non-PFS users are unaffected in practice; their reads already carried `DialTimeout`.
- Nothing is closed, only a deadline is set. If it fires, `connect`'s existing `multierr.AppendInto(&rErr, conn.Close())` discards the socket, so there is no risk of reusing a connection with a half-consumed frame.

## Test

`exchange/client_flow_timeout_test.go` drives the real server flow over `transport.Intermediate.Pipe()` with a wrapper whose `Send` succeeds normally and whose `Recv` goes silent after N replies — reproducing a peer that accepts our writes and then stops answering. Allowing 1 reply pins the step 5 read, allowing 2 pins step 7, so a regression at either site fails its own case.

On `main` both subtests hang to their 30s guard; with this change both pass in about a second. The two commits are ordered so this is visible in the PR's own history: the test lands first and fails, the fix follows.

The caller context is deliberately `context.Background()` — the point is that a context with no deadline of its own must still be bounded by the configured `ExchangeTimeout`.

Note on the error shape: the test's fake conn returns `ctx.Err()`, so the assertion is `context.DeadlineExceeded`. Over a real socket the deadline surfaces as a `*net.OpError` wrapping `os.ErrDeadlineExceeded` instead. Either way `telegram.Client.isPermanentError` does not match it, so the reconnect loop retries — the desired behaviour.

## Not in this PR

Deliberately excluded, each a separate concern: a cancellation watcher for the connect phase, an idle watchdog for connections whose peer goes silent in steady state, context-aware transport locks, and rpc acknowledgement semantics.

This supersedes #1830, which bundled all of the above and which I am closing. Its blast radius — +2840/-105 across 29 files, six independent changes, rewriting `transport/connection.go` and `mtproto/conn.go` — made it unreviewable as a unit, with no partial-accept path. That was my mistake in packaging. The exchange timeout is the only part required to stop the permanent wedge, so it goes first and alone.
