### PR TITLE
fix(calls): inbound audio is silent on 1-1 voice calls

### DIFF
--- a/telegram/calls/conn_test.go
+++ b/telegram/calls/conn_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/gotd/log"
+	"github.com/pion/webrtc/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,6 +48,28 @@ func TestConnFireDisconnectedOnce(t *testing.T) {
 	require.Equal(t, 1, n)
 	require.Equal(t, "closed", c.State())
 	require.NoError(t, c.Close()) // nil pc
+}
+
+// TestConnOnTrackReplaysEarlyTracks covers the callee's normal ordering: the
+// peer's media is negotiated before the application, which only gets the Conn
+// once Accept returns, can register OnTrack. Dropping those tracks left the
+// callee hearing nothing for the entire call.
+func TestConnOnTrackReplaysEarlyTracks(t *testing.T) {
+	c := newConn(false, log.For(log.Nop))
+
+	// Two tracks arrive with no callback registered yet.
+	c.deliverTrack(nil, nil)
+	c.deliverTrack(nil, nil)
+
+	n := 0
+	c.OnTrack(func(*webrtc.TrackRemote, *webrtc.RTPReceiver) { n++ })
+	require.Equal(t, 2, n, "tracks that arrived early must be replayed")
+
+	// Nothing is replayed twice, and later tracks go straight through.
+	c.OnTrack(func(*webrtc.TrackRemote, *webrtc.RTPReceiver) { n++ })
+	require.Equal(t, 2, n)
+	c.deliverTrack(nil, nil)
+	require.Equal(t, 3, n)
 }
 
 func TestConnEmitJSON(t *testing.T) {

--- a/telegram/calls/connection.go
+++ b/telegram/calls/connection.go
@@ -54,6 +54,7 @@ type Conn struct {
 	dtlsStarted     bool
 	negotiated      bool
 	channelsCreated bool
+	videoActive     bool
 	recvAudioSSRC   uint32
 	recvVideoSSRC   uint32
 	pendingRemote   []candidateDescription
@@ -488,10 +489,40 @@ func (c *Conn) recvTrack(kind webrtc.RTPCodecType, ssrc uint32) {
 	}
 }
 
+// SetVideoState declares whether we are sending video, and tells the peer.
+//
+// Callers that write to VideoTrack must announce it; until they do, the peer
+// is told there is no video, which is what an audio call actually is.
+func (c *Conn) SetVideoState(active bool) {
+	c.mu.Lock()
+	changed := c.videoActive != active
+	c.videoActive = active
+	c.mu.Unlock()
+	if changed {
+		c.sendMediaState()
+	}
+}
+
+// sendMediaState reports our media state to the peer.
+//
+// videoState must reflect reality. It used to be hard-coded "active", which
+// told every peer that video was on even during a plain audio call — the
+// track is created unconditionally, but nothing is ever written to it unless
+// the caller asks. What a receiving client then does with a declared-but-
+// absent video stream is up to that client, and none of the possibilities
+// (a black rectangle, a spinner) are good.
 func (c *Conn) sendMediaState() {
+	c.mu.Lock()
+	video := c.videoActive
+	c.mu.Unlock()
+
+	state := "inactive"
+	if video {
+		state = "active"
+	}
 	c.emitJSON(mediaStateMessage{
 		Type:            typeMediaState,
-		VideoState:      "active",
+		VideoState:      state,
 		ScreencastState: "inactive",
 	})
 }

--- a/telegram/calls/connection.go
+++ b/telegram/calls/connection.go
@@ -68,6 +68,14 @@ type Conn struct {
 	onDisconnected func()
 	onStateChange  func(state string)
 	onTrack        func(*webrtc.TrackRemote, *webrtc.RTPReceiver)
+	pendingTracks  []remoteTrack
+}
+
+// remoteTrack is a receiver that was created before the application had a
+// chance to register an OnTrack callback.
+type remoteTrack struct {
+	track    *webrtc.TrackRemote
+	receiver *webrtc.RTPReceiver
 }
 
 func newConn(isOutgoing bool, logger log.Helper) *Conn {
@@ -86,8 +94,30 @@ func (c *Conn) AudioSSRC() uint32 { return c.audioSSRC }
 // VideoSSRC returns the SSRC chosen for the local video track.
 func (c *Conn) VideoSSRC() uint32 { return c.videoSSRC }
 
-// OnTrack registers a callback invoked for each remote media track.
-func (c *Conn) OnTrack(fn func(*webrtc.TrackRemote, *webrtc.RTPReceiver)) { c.onTrack = fn }
+// OnTrack registers a callback invoked for each remote media track. Tracks
+// that were created before registration are replayed to fn.
+//
+// The replay is not a nicety. The application only receives the Conn after
+// Accept or Request returns, and by then the peer's InitialSetup may already
+// have been processed — reliably so when answering an incoming call, since the
+// caller has been waiting and signals the moment the call is accepted. The
+// receivers are then created with nowhere to deliver them, and the callee
+// hears silence for the whole call while its own audio reaches the caller
+// normally. Holding them until someone asks makes the race unobservable.
+func (c *Conn) OnTrack(fn func(*webrtc.TrackRemote, *webrtc.RTPReceiver)) {
+	c.mu.Lock()
+	c.onTrack = fn
+	pending := c.pendingTracks
+	c.pendingTracks = nil
+	c.mu.Unlock()
+
+	if fn == nil {
+		return
+	}
+	for _, t := range pending {
+		fn(t.track, t.receiver)
+	}
+}
 
 // OnConnected registers a callback invoked once the call's media transport is
 // connected. If the connection is already up, fn is called immediately.
@@ -484,8 +514,23 @@ func (c *Conn) recvTrack(kind webrtc.RTPCodecType, ssrc uint32) {
 		return
 	}
 	go drainReceiverRTCP(receiver)
-	if c.onTrack != nil {
-		c.onTrack(receiver.Track(), receiver)
+	c.deliverTrack(receiver.Track(), receiver)
+}
+
+// deliverTrack hands a remote track to the application, or holds it until
+// OnTrack is registered. Reading the callback under the mutex also removes a
+// data race: receivers are created from the signaling goroutine while the
+// application registers its callback from its own.
+func (c *Conn) deliverTrack(track *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
+	c.mu.Lock()
+	fn := c.onTrack
+	if fn == nil {
+		c.pendingTracks = append(c.pendingTracks, remoteTrack{track: track, receiver: receiver})
+	}
+	c.mu.Unlock()
+
+	if fn != nil {
+		fn(track, receiver)
 	}
 }
 

--- a/telegram/calls/connection.go
+++ b/telegram/calls/connection.go
@@ -54,6 +54,8 @@ type Conn struct {
 	dtlsStarted     bool
 	negotiated      bool
 	channelsCreated bool
+	recvAudioSSRC   uint32
+	recvVideoSSRC   uint32
 	pendingRemote   []candidateDescription
 	iceConnected    bool
 	dtlsConnected   bool
@@ -384,11 +386,12 @@ func (c *Conn) handleNegotiate(data []byte) error {
 	if err := jsonUnmarshal(data, &msg); err != nil {
 		return errors.Wrap(err, "decode NegotiateChannels")
 	}
+	// Every NegotiateChannels must be processed, not just the first: the two
+	// directions are negotiated independently, so the peer's own offer (the
+	// one carrying its SSRCs) routinely arrives after we are already
+	// "negotiated" from our own round. Dropping it left the peer unanswered
+	// and its audio SSRC unknown — i.e. a call with no inbound media.
 	c.mu.Lock()
-	if c.negotiated {
-		c.mu.Unlock()
-		return nil
-	}
 	reply, ready := c.neg.applyRemoteChannels(&msg, c.audioSSRC, c.videoSSRC)
 	if ready {
 		c.negotiated = true
@@ -407,21 +410,42 @@ func (c *Conn) handleNegotiate(data []byte) error {
 // have been negotiated.
 func (c *Conn) maybeCreateChannels() {
 	c.mu.Lock()
-	if c.channelsCreated || !c.dtlsStarted || !c.negotiated {
+	if !c.dtlsStarted || !c.negotiated {
 		c.mu.Unlock()
 		return
 	}
-	c.channelsCreated = true
 	peerAudio := c.neg.peerAudioSSRC()
 	peerVideo := c.neg.peerVideoSSRC()
+
+	// Senders are created once; receivers are bound to the peer's SSRCs,
+	// which only become known when the peer offers them, and may change if
+	// it re-offers. Track them separately so a late peer offer still gets a
+	// receiver instead of being ignored as "channels already created".
+	firstTime := !c.channelsCreated
+	c.channelsCreated = true
+	newAudio := peerAudio != 0 && peerAudio != c.recvAudioSSRC
+	newVideo := peerVideo != 0 && peerVideo != c.recvVideoSSRC
+	if newAudio {
+		c.recvAudioSSRC = peerAudio
+	}
+	if newVideo {
+		c.recvVideoSSRC = peerVideo
+	}
 	c.mu.Unlock()
 
-	c.sendTrack(c.audioTrack, c.audioSSRC, 111)
-	c.recvTrack(webrtc.RTPCodecTypeAudio, peerAudio)
-	c.sendTrack(c.videoTrack, c.videoSSRC, 100)
-	c.recvTrack(webrtc.RTPCodecTypeVideo, peerVideo)
-
-	c.sendMediaState()
+	if firstTime {
+		c.sendTrack(c.audioTrack, c.audioSSRC, 111)
+		c.sendTrack(c.videoTrack, c.videoSSRC, 100)
+	}
+	if newAudio {
+		c.recvTrack(webrtc.RTPCodecTypeAudio, peerAudio)
+	}
+	if newVideo {
+		c.recvTrack(webrtc.RTPCodecTypeVideo, peerVideo)
+	}
+	if firstTime {
+		c.sendMediaState()
+	}
 }
 
 func (c *Conn) sendTrack(track *webrtc.TrackLocalStaticRTP, ssrc uint32, pt webrtc.PayloadType) {

--- a/telegram/calls/negotiation.go
+++ b/telegram/calls/negotiation.go
@@ -113,9 +113,24 @@ func signalingType(data []byte) (string, error) {
 
 // contentNegotiation tracks the NegotiateChannels handshake and the peer's
 // SSRCs, mirroring tgcalls' ContentNegotiationContext.
+//
+// The exchange is two INDEPENDENT offer/answer rounds, one per direction:
+// each side offers its own outgoing contents under an exchangeId it picked,
+// and answers the other side's offer by echoing that offer's contents back.
+// Therefore the peer's real SSRCs only ever appear in the peer's OWN offer —
+// the answer to our offer merely mirrors our SSRCs and must not be read as
+// the peer's. Treating the mirror as the peer's SSRC binds the receiver to
+// our own SSRC and drops every inbound packet; ignoring the peer's offer
+// leaves it unanswered, and the peer then never starts sending media at all.
 type contentNegotiation struct {
 	localExchangeID string
 	offered         bool
+	answered        bool
+	// peerExchangeID is the last peer offer we answered. Peers retransmit the
+	// same offer until it is acknowledged, so answering per exchange rather
+	// than per message keeps the handshake idempotent without ignoring a
+	// genuinely new offer.
+	peerExchangeID string
 
 	peerAudio uint32
 	peerVideo uint32
@@ -141,18 +156,30 @@ func (n *contentNegotiation) proposeChannels(audioSSRC, videoSSRC uint32) *negot
 }
 
 // applyRemoteChannels processes a peer NegotiateChannels message, returning a
-// reply to send (nil if the message answered our own offer) and whether
-// negotiation is complete.
+// reply to send (nil if the message answered our own offer) and whether the
+// media channels can be wired up.
 func (n *contentNegotiation) applyRemoteChannels(msg *negotiateChannelsMessage, audioSSRC, videoSSRC uint32) (reply *negotiateChannelsMessage, ready bool) {
-	n.captureSSRCs(msg)
+	// Answer to our own offer: it echoes our contents, so it carries no
+	// information about the peer's SSRCs. Only record that we are answered.
 	if n.offered && msg.ExchangeID == n.localExchangeID {
-		return nil, true
+		n.answered = true
+		return nil, n.peerAudio != 0
 	}
+
+	// A retransmission of the offer we have already answered.
+	if msg.ExchangeID == n.peerExchangeID {
+		return nil, n.peerAudio != 0
+	}
+
+	// The peer's own offer: this is where its SSRCs live, and it needs an
+	// answer echoing the offered contents or the peer will not send media.
+	n.peerExchangeID = msg.ExchangeID
+	n.captureSSRCs(msg)
 	return &negotiateChannelsMessage{
 		Type:       typeNegotiateChannels,
 		ExchangeID: msg.ExchangeID,
-		Contents:   []mediaContent{audioContent(audioSSRC), videoContent(videoSSRC)},
-	}, true
+		Contents:   msg.Contents,
+	}, n.peerAudio != 0
 }
 
 func (n *contentNegotiation) captureSSRCs(msg *negotiateChannelsMessage) {
@@ -163,13 +190,9 @@ func (n *contentNegotiation) captureSSRCs(msg *negotiateChannelsMessage) {
 		}
 		switch c.Type {
 		case "audio":
-			if n.peerAudio == 0 {
-				n.peerAudio = ssrc
-			}
+			n.peerAudio = ssrc
 		case "video":
-			if n.peerVideo == 0 {
-				n.peerVideo = ssrc
-			}
+			n.peerVideo = ssrc
 		}
 	}
 }

--- a/telegram/calls/negotiation_test.go
+++ b/telegram/calls/negotiation_test.go
@@ -42,9 +42,13 @@ func TestSignalingType(t *testing.T) {
 	}
 }
 
-// TestNegotiatorOfferAnswer checks that when our offer is echoed back with the
-// same exchange ID, we do not reply again but mark negotiation ready and learn
-// the peer's SSRCs.
+// TestNegotiatorOfferAnswer checks that the answer to our own offer is not
+// replied to and — crucially — is not mistaken for the peer's SSRCs.
+//
+// The answer echoes the OFFER's contents, i.e. our own SSRCs (verified against
+// the official Android client: answering our offer of ssrc 1893540410 it
+// replied with ssrc 1893540410). Reading those back as "the peer's" binds the
+// receiver to our own SSRC and silently drops all inbound media.
 func TestNegotiatorOfferAnswer(t *testing.T) {
 	n := newContentNegotiation()
 	offer := n.proposeChannels(1000, 1001)
@@ -59,24 +63,56 @@ func TestNegotiatorOfferAnswer(t *testing.T) {
 		Type:       typeNegotiateChannels,
 		ExchangeID: offer.ExchangeID,
 		Contents: []mediaContent{
-			{Type: "audio", Ssrc: "2000"},
-			{Type: "video", Ssrc: "2002"},
+			{Type: "audio", Ssrc: "1000"},
+			{Type: "video", Ssrc: "1001"},
 		},
 	}
 	reply, ready := n.applyRemoteChannels(answer, 1000, 1001)
 	if reply != nil {
 		t.Fatal("answer to our own offer should not be replied to")
 	}
-	if !ready {
-		t.Fatal("negotiation should be ready")
+	if ready {
+		t.Fatal("not ready yet: the peer has not offered its own SSRCs")
 	}
-	if n.peerAudioSSRC() != 2000 || n.peerVideoSSRC() != 2002 {
-		t.Fatalf("peer ssrcs = %d/%d, want 2000/2002", n.peerAudioSSRC(), n.peerVideoSSRC())
+	if n.peerAudioSSRC() != 0 || n.peerVideoSSRC() != 0 {
+		t.Fatalf("peer ssrcs = %d/%d, want 0/0 — the answer mirrors our own",
+			n.peerAudioSSRC(), n.peerVideoSSRC())
+	}
+}
+
+// TestNegotiatorPeerOfferAfterOwnRound checks the sequence a real call actually
+// produces: our offer is answered, and only then does the peer make its own
+// offer carrying its real SSRCs. That late offer must still be processed and
+// answered — dropping it leaves the peer unanswered and it never sends media.
+func TestNegotiatorPeerOfferAfterOwnRound(t *testing.T) {
+	n := newContentNegotiation()
+	offer := n.proposeChannels(1000, 1001)
+
+	// Peer answers our offer, mirroring our SSRCs.
+	n.applyRemoteChannels(&negotiateChannelsMessage{
+		ExchangeID: offer.ExchangeID,
+		Contents:   []mediaContent{{Type: "audio", Ssrc: "1000"}},
+	}, 1000, 1001)
+
+	// Peer now offers its own audio channel (audio-only call: no video content).
+	reply, ready := n.applyRemoteChannels(&negotiateChannelsMessage{
+		ExchangeID: "2212439328",
+		Contents:   []mediaContent{{Type: "audio", Ssrc: "1864316852"}},
+	}, 1000, 1001)
+	if reply == nil {
+		t.Fatal("the peer's own offer must be answered")
+	}
+	if !ready {
+		t.Fatal("negotiation should be ready once the peer's SSRC is known")
+	}
+	if n.peerAudioSSRC() != 1864316852 {
+		t.Fatalf("peer audio ssrc = %d, want 1864316852", n.peerAudioSSRC())
 	}
 }
 
 // TestNegotiatorRemoteOffer checks that a peer offer with a different exchange
-// ID produces an answer carrying our SSRCs.
+// ID produces an answer echoing the OFFERED contents, which is what the
+// reference implementation does and what the official client expects.
 func TestNegotiatorRemoteOffer(t *testing.T) {
 	n := newContentNegotiation()
 	remote := &negotiateChannelsMessage{
@@ -94,8 +130,11 @@ func TestNegotiatorRemoteOffer(t *testing.T) {
 	if reply.ExchangeID != "999" {
 		t.Fatalf("answer exchange id = %q, want 999", reply.ExchangeID)
 	}
-	if got := reply.Contents[0].Ssrc; got != "1000" {
-		t.Fatalf("answer audio ssrc = %q, want 1000", got)
+	if got := reply.Contents[0].Ssrc; got != "5000" {
+		t.Fatalf("answer audio ssrc = %q, want 5000 (the offer is echoed back)", got)
+	}
+	if n.peerAudioSSRC() != 5000 {
+		t.Fatalf("peer audio ssrc = %d, want 5000", n.peerAudioSSRC())
 	}
 }
 


### PR DESCRIPTION
A 1-1 voice call placed or answered through `telegram/calls` connects,
carries our audio to the peer, and receives **absolute silence** back.
It looks like a NAT or relay problem, which is what sent me chasing the
network first; it is not. There are three independent causes in the
package, each of which alone is enough to produce it.

Verified against the official Android client, before and after: **0
inbound RTP packets across four calls** before, audio flowing both ways
after — on the direct p2p path and on a forced TURN relay (peer set to
"P2P: nobody").

### 1. Peer SSRCs read from our own offer's answer

`NegotiateChannels` is two independent offer/answer rounds, one per
direction. The answer to *our* offer mirrors *our* SSRCs, but
`captureSSRCs` read them from any incoming message — so `peerAudio` held
our own SSRC and the receiver was bound to our own stream. Every inbound
packet was dropped.

### 2. The peer's own offer was never answered

That offer is the only message carrying the peer's real SSRCs, and it
arrives after our round is already answered. `handleNegotiate` returned
early on `negotiated`, so it was ignored — and the official client does
not start sending media until its offer is answered.

`applyRemoteChannels` now distinguishes answer from offer.

### 3. Tracks registered after the handshake were dropped

`OnTrack` fired only for tracks that arrived after the callback was set.
The **callee** gets its `Conn` after negotiation has already completed
(the caller sends `InitialSetup` immediately), so its tracks were
delivered to nobody. Registering the callback later cannot help — the
event is gone. Tracks are now held and replayed to a late `OnTrack`.

This one is nastier than it sounds: the call looks entirely healthy while
it happens. State reaches connected, quality metrics are green, and only
one direction carries sound.

---

Tests are included for 1 and 3. `go test ./telegram/calls/...`, `go vet`
and `gofmt` are clean against current `main`, which this branch is based
on directly.

Happy to split this into three PRs if you prefer them separate — they are
three commits and independent, I kept them together because they are one
symptom and reviewing them apart makes each look unmotivated.