### PR TITLE
feat(calls): expose the selected ICE candidate pair

### DIFF
--- a/telegram/calls/connection.go
+++ b/telegram/calls/connection.go
@@ -86,6 +86,28 @@ func (c *Conn) VideoSSRC() uint32 { return c.videoSSRC }
 // OnTrack registers a callback invoked for each remote media track.
 func (c *Conn) OnTrack(fn func(*webrtc.TrackRemote, *webrtc.RTPReceiver)) { c.onTrack = fn }
 
+// SelectedCandidatePair reports the ICE candidate pair currently carrying
+// this call's media, or nil before ICE has settled.
+//
+// Exposed because the pair is the only place that answers a question a
+// caller cannot answer otherwise: is this call going peer-to-peer, or
+// through a relay? Telegram hands its reflectors to us as ordinary TURN
+// servers (see iceServers), so a relayed call shows a local candidate of
+// type relay and a direct one does not. Without this the transport is
+// unreachable from outside the package and the distinction is invisible.
+//
+// Read-only: the returned candidates are pion's own values and must not be
+// mutated.
+func (c *Conn) SelectedCandidatePair() (*webrtc.ICECandidatePair, error) {
+	c.mu.Lock()
+	ice := c.ice
+	c.mu.Unlock()
+	if ice == nil {
+		return nil, nil
+	}
+	return ice.GetSelectedCandidatePair()
+}
+
 // OnConnected registers a callback invoked once the call's media transport is
 // connected. If the connection is already up, fn is called immediately.
 func (c *Conn) OnConnected(fn func()) {


### PR DESCRIPTION
`Conn` keeps its `*webrtc.ICETransport` unexported, so a caller cannot
tell whether a call went peer-to-peer or through a relay. There is no
other way to find out: nothing else on the connection carries it.

That distinction is worth having. Telegram hands its reflectors over as
ordinary TURN servers (see `iceServers`), so a relayed call shows a local
candidate of type `relay` and a direct one does not. A rising share of
relayed calls is the first sign that direct paths are being blocked
somewhere — a network, a NAT, a provider — and in production it surfaces
as "quality got worse lately" long before anyone can name why.

Read-only accessor over the existing transport. Returns `nil` before ICE
has settled, which callers can treat as unknown. It takes the connection
mutex to read the transport and releases it before calling into pion —
the same shape `Close` already uses for the same fields.

Six lines of behaviour; no new state, no new dependency.

---

Based directly on current `main`. `go test ./telegram/calls/...`, `go vet`
and `gofmt` clean.

Separate from #1839 on purpose: that one is three bug fixes for silent
inbound audio, this is a small API addition, and mixing them would make
both harder to judge.